### PR TITLE
PointerArray based on std::vector

### DIFF
--- a/src/templates/pointerarray.h
+++ b/src/templates/pointerarray.h
@@ -41,6 +41,7 @@ template <class T> class PointerArray : std::vector<T*>
 	public:
 	using std::vector<T*>::begin;
 	using std::vector<T*>::clear;
+	using std::vector<T*>::data;
 	using std::vector<T*>::end;
 	using std::vector<T*>::erase;
 	using std::vector<T*>::operator[];
@@ -73,6 +74,11 @@ template <class T> class PointerArray : std::vector<T*>
 	{
 		return operator[](index);
 	}
+	T** items()
+	{
+		return data();
+	}
+
 
 	/*
 	 * Item Management

--- a/src/templates/pointerarray.h
+++ b/src/templates/pointerarray.h
@@ -74,6 +74,7 @@ template <class T> class PointerArray : std::vector<T*>
 	{
 		return operator[](index);
 	}
+	// Return pointer array
 	T** items()
 	{
 		return data();

--- a/src/templates/pointerarray.h
+++ b/src/templates/pointerarray.h
@@ -24,7 +24,8 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <set>
+#include <algorithm>
+#include <vector>
 #include "base/messenger.h"
 
 // Forward Declarations
@@ -35,34 +36,23 @@
  * A contiguous pointer array class designed to be as lightweight as possible.
  * Order of items must not be important, as the arrangement of pointers is subject to change.
  */
-template <class T> class PointerArray : std::set<T*>
+template <class T> class PointerArray : std::vector<T*>
 {
 	public:
-	using std::set<T*>::begin;
-	using std::set<T*>::clear;
-	using std::set<T*>::count;
-	using std::set<T*>::end;
-	using std::set<T*>::erase;
-	using std::set<T*>::insert;
-	using std::set<T*>::size;
-	// Element access operator
-	T* operator[](int index)
-	{
-		return at(index);
-	}
+	using std::vector<T*>::begin;
+	using std::vector<T*>::clear;
+	using std::vector<T*>::end;
+	using std::vector<T*>::erase;
+	using std::vector<T*>::operator[];
+	using std::vector<T*>::push_back;
+	using std::vector<T*>::rbegin;
+	using std::vector<T*>::rend;
+	using std::vector<T*>::reserve;
+	using std::vector<T*>::size;
 	// Const access operator
 	T* at(int index) const
 	{
-#ifdef CHECKS
-		if ((index < 0) || (index >= nItems_))
-		{
-			Messenger::error("PointerArray<T>::at(%i) - Array index out of bounds (%i items in array).\n", index, nItems_);
-			return NULL;
-		}
-#endif
-		auto it = begin();
-		for (int i=0; i<index; ++i) ++it;
-		return *it;
+		return operator[](index);
 	}
 
 
@@ -71,8 +61,7 @@ template <class T> class PointerArray : std::set<T*>
 	void initialise(int size)
 	{
 		clear();
-		//This is currently a NOP because there's no real way to set
-		//the size of a set
+		reserve(size);
 	}
 	// Returns the number of items in the list
 	int nItems() const
@@ -82,7 +71,7 @@ template <class T> class PointerArray : std::set<T*>
 	// Const-value access
 	T* value(int index) const
 	{
-		return at(index);
+		return operator[](index);
 	}
 
 	/*
@@ -92,17 +81,17 @@ template <class T> class PointerArray : std::set<T*>
 	// Append an item to the list
 	void append(T* ptr)
 	{
-		insert(ptr);
+		push_back(ptr);
 	}
 	// Remove an item from the array, leaving the remaining items contiguous in memory
 	void remove(T* ptr)
 	{
-		erase(ptr);
+		erase(find(begin(), end(), ptr));
 	}
 	// Remove indexed item from the array, leaving the remaining items contiguous in memory
 	void remove(int index)
 	{
-		erase(at(index));
+		erase(begin()+index);
 	}
 	// Remove last item from the array
 	void removeLast()
@@ -127,23 +116,19 @@ template <class T> class PointerArray : std::set<T*>
 	// Return array index of specified pointer
 	int indexOf(const T* ptr) const
 	{
-		int n = 0;
-		for (auto it = begin(); it != end(); ++it) {
-			if (*it == ptr) return n;
-			++n;
-		}
-
-		return -1;
+		auto it = find(begin(), end(), ptr);
+		if (it == end()) return -1;
+		return it - begin();
 	}
 	// Return whether the array contains the specified pointer
 	bool contains(T* ptr) const
 	{
-		return count(ptr);
+		return find(begin(), end(), ptr) != end();
 	}
 	// Return whether the array contains the specified pointer, searching from the last item backwards
 	bool sniatnoc(T* ptr) const
 	{
-		return count(ptr);
+		return find(rbegin(), rend(), ptr) != rend();
 	}
 };
 

--- a/src/templates/pointerarray.h
+++ b/src/templates/pointerarray.h
@@ -121,12 +121,12 @@ template <class T> class PointerArray : std::vector<T*>
 		return it - begin();
 	}
 	// Return whether the array contains the specified pointer
-	bool contains(T* ptr) const
+	bool contains(const T* ptr) const
 	{
 		return find(begin(), end(), ptr) != end();
 	}
 	// Return whether the array contains the specified pointer, searching from the last item backwards
-	bool sniatnoc(T* ptr) const
+	bool sniatnoc(const T* ptr) const
 	{
 		return find(rbegin(), rend(), ptr) != rend();
 	}

--- a/src/templates/pointerarray.h
+++ b/src/templates/pointerarray.h
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <set>
 #include "base/messenger.h"
 
 // Forward Declarations
@@ -34,52 +35,20 @@
  * A contiguous pointer array class designed to be as lightweight as possible.
  * Order of items must not be important, as the arrangement of pointers is subject to change.
  */
-template <class T> class PointerArray
+template <class T> class PointerArray : std::set<T*>
 {
 	public:
-	// Constructor
-	PointerArray<T>()
-	{
-		nItems_ = 0;
-		arraySize_ = 0;
-		items_ = NULL;
-	}
-	// Destructor
-	~PointerArray()
-	{
-		clear();
-	}
-	// Copy Constructor
-	PointerArray<T>(const PointerArray<T>& source)
-	{
-		nItems_ = 0;
-		arraySize_ = 0;
-		items_ = NULL;
-		(*this) = source;
-	}
-	// Assignment operator
-	PointerArray<T>& operator=(const PointerArray<T>& source)
-	{
-		// Clear any current data in the list...
-		clear();
-
-		initialise(source.nItems());
-
-		for (int n=0; n<source.nItems(); ++n) append(source.value(n));
-
-		return *this;
-	}
+	using std::set<T*>::begin;
+	using std::set<T*>::clear;
+	using std::set<T*>::count;
+	using std::set<T*>::end;
+	using std::set<T*>::erase;
+	using std::set<T*>::insert;
+	using std::set<T*>::size;
 	// Element access operator
 	T* operator[](int index)
 	{
-#ifdef CHECKS
-		if ((index < 0) || (index >= nItems_))
-		{
-			Messenger::error("PointerArray<T>::operator[](%i) - Array index out of bounds (%i items in array).\n", index, nItems_);
-			return NULL;
-		}
-#endif
-		return items_[index];
+		return at(index);
 	}
 	// Const access operator
 	T* at(int index) const
@@ -91,66 +60,30 @@ template <class T> class PointerArray
 			return NULL;
 		}
 #endif
-		return items_[index];
+		auto it = begin();
+		for (int i=0; i<index; ++i) ++it;
+		return *it;
 	}
 
-
-	/*
-	 * Basic Data
-	 */
-	protected:
-	// Array of items
-	T** items_;
-	// Size of items array
-	int arraySize_;
-	// Number of items in array
-	int nItems_;
 
 	public:
-	// Clear the list
-	void clear()
-	{
-		if (items_) delete[] items_;
-		items_ = NULL;
-		nItems_ = 0;
-		arraySize_ = 0;
-	}
 	// Create empty list of specified size
 	void initialise(int size)
 	{
 		clear();
-
-		arraySize_ = size;
-
-		if (size == 0) items_ = NULL;
-		else items_ = new T*[arraySize_];
-
-		for (int n=0; n<arraySize_; ++n) items_[n] = NULL;
+		//This is currently a NOP because there's no real way to set
+		//the size of a set
 	}
 	// Returns the number of items in the list
 	int nItems() const
 	{
-		return nItems_;
+		return size();
 	}
 	// Const-value access
 	T* value(int index) const
 	{
-#ifdef CHECKS
-		if ((index < 0) || (index >= nItems_))
-		{
-			Messenger::error("PointerArray<T>::index(%i) - Array index out of bounds (%i items in array).\n", index, nItems_);
-			return NULL;
-		}
-#endif
-
-		return items_[index];
+		return at(index);
 	}
-	// Return pointer array
-	T** items()
-	{
-		return items_;
-	}
-
 
 	/*
 	 * Item Management
@@ -159,75 +92,22 @@ template <class T> class PointerArray
 	// Append an item to the list
 	void append(T* ptr)
 	{
-		// If there is no space for the new item we must resize the array
-		if (nItems_ == arraySize_)
-		{
-			// Create a new array with some more item space
-			// TODO This is memory efficient, but v slow for multiple additions.  Add chunkSize?
-			T** newArray = new T*[arraySize_+2];
-
-			// Copy the existing pointers over
-			for (int n=0; n<arraySize_; ++n) newArray[n] = items_[n];
-
-			// Delete the old array
-			delete[] items_;
-
-			// Set the new array
-			items_ = newArray;
-			arraySize_ += 2;
-		}
-
-		items_[nItems_] = ptr;
-		++nItems_;
+		insert(ptr);
 	}
 	// Remove an item from the array, leaving the remaining items contiguous in memory
 	void remove(T* ptr)
 	{
-		// Step through the items until we find the specified pointer
-		for (int n=0; n<nItems_; ++n)
-		{
-			if (items_[n] == ptr)
-			{
-				// Found it. If it is at the end of the list, just decrease nItems_.
-				// If not, switch the current last item into this slot, and then decrease nItems_.
-				if (n < (nItems_-1))
-				{
-					items_[n] = items_[nItems_-1];
-					items_[nItems_-1] = NULL;
-				}
-				--nItems_;
-				return;
-			}
-		}
-		Messenger::print("PointerArray<T>::remove(%p) - Couldn't find pointer in array.\n", ptr);
+		erase(ptr);
 	}
 	// Remove indexed item from the array, leaving the remaining items contiguous in memory
 	void remove(int index)
 	{
-#ifdef CHECKS
-		if ((index < 0) || (index >= nItems_))
-		{
-			Messenger::error("Can't remove index '%i' from PointerArray<T>, since it is out of range (nItems = %i).\n", index, nItems_);
-			return;
-		}
-#endif
-		// If it is at the end of the list, just decrease nItems_.
-		// If not, switch the current last item into this slot, and then decrease nItems_.
-		if (index < (nItems_-1))
-		{
-			items_[index] = items_[nItems_-1];
-			items_[nItems_-1] = NULL;
-		}
-		--nItems_;
+		erase(at(index));
 	}
 	// Remove last item from the array
 	void removeLast()
 	{
-		if (nItems_ == 0) return;
-
-		--nItems_;
-
-		items_[nItems_] = NULL;
+		remove(size()-1);
 	}
 	// Remove item from array and return it
 	T* take(int index)
@@ -239,7 +119,7 @@ template <class T> class PointerArray
 			return NULL;
 		}
 #endif
-		T* item = items_[index];
+		T* item = at(index);
 		remove(index);
 
 		return item;
@@ -247,23 +127,23 @@ template <class T> class PointerArray
 	// Return array index of specified pointer
 	int indexOf(const T* ptr) const
 	{
-		for (int n=0; n<nItems_; ++n) if (items_[n] == ptr) return n;
+		int n = 0;
+		for (auto it = begin(); it != end(); ++it) {
+			if (*it == ptr) return n;
+			++n;
+		}
 
 		return -1;
 	}
 	// Return whether the array contains the specified pointer
-	bool contains(const T* ptr) const
+	bool contains(T* ptr) const
 	{
-		for (int n=0; n<nItems_; ++n) if (items_[n] == ptr) return true;
-
-		return false;
+		return count(ptr);
 	}
 	// Return whether the array contains the specified pointer, searching from the last item backwards
-	bool sniatnoc(const T* ptr) const
+	bool sniatnoc(T* ptr) const
 	{
-		for (int n=nItems_-1; n>=0; --n) if (items_[n] == ptr) return true;
-
-		return false;
+		return count(ptr);
 	}
 };
 


### PR DESCRIPTION
A much smaller proof of concept of moving the template classes onto standard containers.  It only touches a single file, since PointerArray is left as a facade around std::vector.

To keep things simple, no changes were made to the class interface, though the following improvements could be made:

* items() is unused and could be removed
* at(), value(), and operator[]() are all identical and two of those could be removed.