### PR TITLE
Updated OPLS Naphthalene atom type to be for all fused aromatics

### DIFF
--- a/src/data/ff/oplsaa2005/aromatics.cpp
+++ b/src/data/ff/oplsaa2005/aromatics.cpp
@@ -38,8 +38,8 @@ Forcefield_OPLSAA2005_Aromatics::Forcefield_OPLSAA2005_Aromatics()
 	// -- Benzene
 	copyAtomType(oplsAtomTypeById(145), "CA", "ring(size=6),-C(n=2),-H(n=1)");
 	copyAtomType(oplsAtomTypeById(146), "HA", "-&145");
-	// -- Napthalene
-	copyAtomType(oplsAtomTypeById(147), "CNap", "ring(size=6,n=2),nbonds=3,-C(n=3)", "CA");
+	// -- Napthalene (or larger aromatics)
+	copyAtomType(oplsAtomTypeById(147), "CNap", "ring(size=6,n>=2),nbonds=3,-C(n=3)", "CA");
 	// -- Toluene
 	copyAtomType(oplsAtomTypeById(148), "CT", "nh=3, -C(ring=6)");
 	// -- Ethylbenzene


### PR DESCRIPTION
Tiny change to oplsaa2005/aromatics.cpp to allow larger aromatics, treating all "fused" aromatic carbons the same as for naphthalene.