### PR TITLE
Use enumerations for IO formats

### DIFF
--- a/src/base/enumoption.cpp
+++ b/src/base/enumoption.cpp
@@ -27,10 +27,28 @@
 // Static Singleton
 UnrecognisedEnumOption EnumOptionsBase::unrecognisedOption_;
 
+// Constructors
+EnumOption::EnumOption()
+{
+	enumeration_ = 0;
+	keyword_ = "";
+	description_ = "";
+	minArgs_ = 0;
+	maxArgs_ = 0;
+}
 EnumOption::EnumOption(const int enumeration, const char* keyword, int minArgs, int maxArgs)
 {
 	enumeration_ = enumeration;
 	keyword_ = keyword;
+	description_ = "";
+	minArgs_ = minArgs;
+	maxArgs_ = (maxArgs == 0 ? minArgs : maxArgs);
+}
+EnumOption::EnumOption(const int enumeration, const char* keyword, const char* description, int minArgs, int maxArgs)
+{
+	enumeration_ = enumeration;
+	keyword_ = keyword;
+	description_ = description;
 	minArgs_ = minArgs;
 	maxArgs_ = (maxArgs == 0 ? minArgs : maxArgs);
 }
@@ -51,6 +69,12 @@ int EnumOption::enumeration() const
 const char* EnumOption::keyword() const
 {
 	return keyword_;
+}
+
+// Return option description
+const char* EnumOption::description() const
+{
+	return description_;
 }
 
 // Return whether the option has any associated arguments

--- a/src/base/enumoption.h
+++ b/src/base/enumoption.h
@@ -29,7 +29,9 @@ class EnumOption
 {
 	public:
 	// Constructors
-	EnumOption(const int enumeration = 0, const char* keyword = NULL, int minArgs = 0, int maxArgs = 0);
+	EnumOption();
+	EnumOption(const int enumeration, const char* keyword, int minArgs = 0, int maxArgs = 0);
+	EnumOption(const int enumeration, const char* keyword, const char* description, int minArgs = 0, int maxArgs = 0);
 
 
 	/*
@@ -44,6 +46,8 @@ class EnumOption
 	int enumeration_;
 	// Option keyword
 	const char* keyword_;
+	// Option description / long text
+	const char* description_;
 	// Whether the option has any associated arguments
 	bool hasArguments_;
 	// Minimum number of arguments the option takes
@@ -58,6 +62,8 @@ class EnumOption
 	int enumeration() const;
 	// Return option keyword
 	const char* keyword() const;
+	// Return option description
+	const char* description() const;
 	// Return whether the option has any associated arguments
 	bool hasArguments() const;
 	// Return minimum number of arguments the option takes

--- a/src/base/enumoptionsbase.cpp
+++ b/src/base/enumoptionsbase.cpp
@@ -77,6 +77,18 @@ const char* EnumOptionsBase::keywordByIndex(int index) const
 	return options_.constAt(index).keyword();
 }
 
+// Return description for the nth keyword in the list
+const char* EnumOptionsBase::descriptionByIndex(int index) const
+{
+	if ((index < 0) || (index >= options_.nItems()))
+	{
+		Messenger::error("Keyword index %i out of range for EnumOptions '%s'.\n", index, name_);
+		return unrecognisedOption_.keyword();
+	}
+
+	return options_.constAt(index).description();
+}
+
 // Return option by keyword
 const EnumOption& EnumOptionsBase::option(const char* keyword) const
 {

--- a/src/base/enumoptionsbase.h
+++ b/src/base/enumoptionsbase.h
@@ -64,6 +64,8 @@ class EnumOptionsBase
 	int nOptions() const;
 	// Return nth keyword in the list
 	const char* keywordByIndex(int index) const;
+	// Return description for the nth keyword in the list
+	const char* descriptionByIndex(int index) const;
 	// Return option by keyword
 	const EnumOption& option(const char* keyword) const;
 	// Return current option keyword

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -46,7 +46,7 @@ ConfigurationTab::ConfigurationTab(DissolveWindow* dissolveWindow, Dissolve& dis
 	configuration_ = cfg;
 
 	// Populate coordinates file format combo
-	ComboPopulator(ui_.CoordinatesFileFormatCombo, cfg->inputCoordinates().nFormats(), cfg->inputCoordinates().niceFormats());
+	for (int n=0; n < cfg->inputCoordinates().nFormats(); ++n) ui_.CoordinatesFileFormatCombo->addItem(cfg->inputCoordinates().formatKeyword(n));
 
 	// Populate density units combo
 	ComboEnumOptionsPopulator(ui_.DensityUnitsCombo, Units::densityUnits());

--- a/src/gui/keywordwidgets/fileandformat_funcs.cpp
+++ b/src/gui/keywordwidgets/fileandformat_funcs.cpp
@@ -49,7 +49,7 @@ FileAndFormatKeywordWidget::FileAndFormatKeywordWidget(QWidget* parent, KeywordB
 
 	// Populate combo with the file formats available
 	ui_.FormatCombo->clear();
-	for (int n=0; n < keyword_->data().nFormats(); ++n) ui_.FormatCombo->addItem(keyword_->data().format(n));
+	for (int n=0; n < keyword_->data().nFormats(); ++n) ui_.FormatCombo->addItem(keyword_->data().formatKeyword(n));
 
 	// If the FileAndFormat has keyword options, enable the options button.
 	ui_.OptionsButton->setEnabled(keyword_->hasOptions());

--- a/src/io/export/coordinates.cpp
+++ b/src/io/export/coordinates.cpp
@@ -28,9 +28,26 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-// Coordinate Type Keywords
-const char* CoordinateExportFormatKeywords[] = { "xyz", "dlpoly" };
-const char* NiceCoordinateExportFormatKeywords[] = { "XYZ Coordinates", "DL_POLY CONFIG File" };
+// Constructor
+CoordinateExportFileFormat::CoordinateExportFileFormat(const char* filename, CoordinateExportFormat format) : FileAndFormat(filename, format)
+{
+}
+
+/*
+ * Format Access
+ */
+
+// Return enum options for CoordinateExportFormat
+EnumOptions<CoordinateExportFileFormat::CoordinateExportFormat> CoordinateExportFileFormat::coordinateExportFormats()
+{
+	static EnumOptionsList CoordinateExportFormats = EnumOptionsList() <<
+		EnumOption(CoordinateExportFileFormat::XYZCoordinates, 		"xyz",	"Simple XYZ Coordinates") <<
+		EnumOption(CoordinateExportFileFormat::DLPOLYCoordinates, 	"dlpoly",	"DL_POLY CONFIG File");
+
+	static EnumOptions<CoordinateExportFileFormat::CoordinateExportFormat> options("CoordinateExportFileFormat", CoordinateExportFormats);
+
+	return options;
+}
 
 // Return number of available formats
 int CoordinateExportFileFormat::nFormats() const
@@ -38,27 +55,22 @@ int CoordinateExportFileFormat::nFormats() const
 	return CoordinateExportFileFormat::nCoordinateExportFormats;
 }
 
-// Return formats array
-const char** CoordinateExportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* CoordinateExportFileFormat::formatKeyword(int id) const
 {
-	return CoordinateExportFormatKeywords;
+	return coordinateExportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** CoordinateExportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* CoordinateExportFileFormat::formatDescription(int id) const
 {
-	return NiceCoordinateExportFormatKeywords;
+	return coordinateExportFormats().descriptionByIndex(id);
 }
 
 // Return current format as CoordinateExportFormat
 CoordinateExportFileFormat::CoordinateExportFormat CoordinateExportFileFormat::coordinateFormat() const
 {
 	return (CoordinateExportFileFormat::CoordinateExportFormat) format_;
-}
-
-// Constructor
-CoordinateExportFileFormat::CoordinateExportFileFormat(const char* filename, CoordinateExportFormat format) : FileAndFormat(filename, format)
-{
 }
 
 /*
@@ -137,7 +149,11 @@ bool CoordinateExportFileFormat::exportData(Configuration* cfg)
 	bool result = false;
 	if (coordinateFormat() == CoordinateExportFileFormat::XYZCoordinates) result = exportXYZ(parser, cfg);
 	else if (coordinateFormat() == CoordinateExportFileFormat::DLPOLYCoordinates) result = exportDLPOLY(parser, cfg);
-	else Messenger::error("Unrecognised coordinate format.\nKnown formats are: %s.\n", CoordinateExportFileFormat().formats());
+	else
+	{
+		Messenger::error("Unrecognised coordinate format.\nKnown formats are:\n");
+		printAvailableFormats();
+	}
 
 	return result;
 }

--- a/src/io/export/coordinates.h
+++ b/src/io/export/coordinates.h
@@ -33,16 +33,24 @@ class CoordinateExportFileFormat : public FileAndFormat
 	public:
 	// Available coordinate formats
 	enum CoordinateExportFormat { XYZCoordinates, DLPOLYCoordinates, nCoordinateExportFormats };
-	// Return number of available formats
-	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
-	// Return current format as CoordinateExportFormat
-	CoordinateExportFormat coordinateFormat() const;
 	// Constructor
 	CoordinateExportFileFormat(const char* filename = NULL, CoordinateExportFormat format = XYZCoordinates);
+
+
+	/*
+	 * Format Access
+	 */
+	public:
+	// Return enum options for CoordinateExportFormat
+	static EnumOptions<CoordinateExportFileFormat::CoordinateExportFormat> coordinateExportFormats();
+	// Return number of available formats
+	int nFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
+	// Return current format as CoordinateExportFormat
+	CoordinateExportFormat coordinateFormat() const;
 
 
 	/*

--- a/src/io/export/data1d.cpp
+++ b/src/io/export/data1d.cpp
@@ -24,9 +24,25 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-// Data1D Export Keywords
-const char* Data1DExportFormatKeywords[] = { "xy" };
-const char* NiceData1DExportFormatKeywords[] = { "XY Data" };
+// Constructor
+Data1DExportFileFormat::Data1DExportFileFormat(const char* filename, Data1DExportFormat format) : FileAndFormat(filename, format)
+{
+}
+
+/*
+ * Format Access
+ */
+
+// Return enum options for Data1DExportFormat
+EnumOptions<Data1DExportFileFormat::Data1DExportFormat> Data1DExportFileFormat::data1DExportFormats()
+{
+	static EnumOptionsList Data1DExportFormats = EnumOptionsList() <<
+		EnumOption(Data1DExportFileFormat::XYData1D, 		"xy",		"Simple XY data (x = bin centres)");
+
+	static EnumOptions<Data1DExportFileFormat::Data1DExportFormat> options("Data1DExportFileFormat", Data1DExportFormats);
+
+	return options;
+}
 
 // Return number of available formats
 int Data1DExportFileFormat::nFormats() const
@@ -34,27 +50,22 @@ int Data1DExportFileFormat::nFormats() const
 	return Data1DExportFileFormat::nData1DExportFormats;
 }
 
-// Return formats array
-const char** Data1DExportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* Data1DExportFileFormat::formatKeyword(int id) const
 {
-	return Data1DExportFormatKeywords;
+	return data1DExportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** Data1DExportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* Data1DExportFileFormat::formatDescription(int id) const
 {
-	return NiceData1DExportFormatKeywords;
+	return data1DExportFormats().descriptionByIndex(id);
 }
 
 // Return current format as CoordinateExportFormat
 Data1DExportFileFormat::Data1DExportFormat Data1DExportFileFormat::data1DFormat() const
 {
 	return (Data1DExportFileFormat::Data1DExportFormat) format_;
-}
-
-// Constructor
-Data1DExportFileFormat::Data1DExportFileFormat(const char* filename, Data1DExportFormat format) : FileAndFormat(filename, format)
-{
 }
 
 /*
@@ -89,8 +100,12 @@ bool Data1DExportFileFormat::exportData(const Data1D& data)
 
 	// Write data
 	bool result = false;
-	if (data1DFormat() == Data1DExportFileFormat::XYData) result = exportXY(parser, data);
-	else Messenger::error("Unrecognised data format.\nKnown formats are: %s.\n", Data1DExportFileFormat().formats());
+	if (data1DFormat() == Data1DExportFileFormat::XYData1D) result = exportXY(parser, data);
+	else
+	{
+		Messenger::error("Unrecognised Data1D format.\nKnown formats are:\n");
+		printAvailableFormats();
+	}
 
 	return result;
 }

--- a/src/io/export/data1d.h
+++ b/src/io/export/data1d.h
@@ -1,6 +1,6 @@
 /*
 	*** Export - Data1D
-	*** src/io/export/data2d.h
+	*** src/io/export/data1d.h
 	Copyright T. Youngs 2012-2020
 
 	This file is part of Dissolve.
@@ -32,17 +32,25 @@ class Data1DExportFileFormat : public FileAndFormat
 {
 	public:
 	// Available data formats
-	enum Data1DExportFormat { XYData, nData1DExportFormats };
+	enum Data1DExportFormat { XYData1D, nData1DExportFormats };
+	// Constructor
+	Data1DExportFileFormat(const char* filename = NULL, Data1DExportFormat format = Data1DExportFileFormat::XYData1D);
+
+
+	/*
+	 * Format Access
+	 */
+	public:
+	// Return enum options for Data1DExportFormat
+	static EnumOptions<Data1DExportFileFormat::Data1DExportFormat> data1DExportFormats();
 	// Return number of available formats
 	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
 	// Return current format as Data1DExportFormat
 	Data1DExportFormat data1DFormat() const;
-	// Constructor
-	Data1DExportFileFormat(const char* filename = NULL, Data1DExportFormat format = Data1DExportFileFormat::XYData);
 
 
 	/*

--- a/src/io/export/data2d.cpp
+++ b/src/io/export/data2d.cpp
@@ -24,9 +24,26 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-// Data2D Export Keywords
-const char* Data2DExportFormatKeywords[] = { "block", "cartesian" };
-const char* NiceData2DExportFormatKeywords[] = { "Block Data", "Cartesian (x,y,value) Data" };
+// Constructor
+Data2DExportFileFormat::Data2DExportFileFormat(const char* filename, Data2DExportFormat format) : FileAndFormat(filename, format)
+{
+}
+
+/*
+ * Format Access
+ */
+
+// Return enum options for Data2DExportFormat
+EnumOptions<Data2DExportFileFormat::Data2DExportFormat> Data2DExportFileFormat::data2DExportFormats()
+{
+	static EnumOptionsList Data2DExportFormats = EnumOptionsList() <<
+		EnumOption(Data2DExportFileFormat::BlockData2D, 	"block",	"Block Data") <<
+		EnumOption(Data2DExportFileFormat::CartesianData2D, 	"cartesian",	"Cartesian (x,y,value) Data");
+
+	static EnumOptions<Data2DExportFileFormat::Data2DExportFormat> options("Data2DExportFileFormat", Data2DExportFormats);
+
+	return options;
+}
 
 // Return number of available formats
 int Data2DExportFileFormat::nFormats() const
@@ -34,27 +51,22 @@ int Data2DExportFileFormat::nFormats() const
 	return Data2DExportFileFormat::nData2DExportFormats;
 }
 
-// Return formats array
-const char** Data2DExportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* Data2DExportFileFormat::formatKeyword(int id) const
 {
-	return Data2DExportFormatKeywords;
+	return data2DExportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** Data2DExportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* Data2DExportFileFormat::formatDescription(int id) const
 {
-	return NiceData2DExportFormatKeywords;
+	return data2DExportFormats().descriptionByIndex(id);
 }
 
 // Return current format as CoordinateExportFormat
 Data2DExportFileFormat::Data2DExportFormat Data2DExportFileFormat::data2DFormat() const
 {
 	return (Data2DExportFileFormat::Data2DExportFormat) format_;
-}
-
-// Constructor
-Data2DExportFileFormat::Data2DExportFileFormat(const char* filename, Data2DExportFormat format) : FileAndFormat(filename, format)
-{
 }
 
 /*
@@ -107,9 +119,13 @@ bool Data2DExportFileFormat::exportData(const Data2D& data)
 
 	// Write data
 	bool result = false;
-	if (data2DFormat() == Data2DExportFileFormat::BlockData) result = exportBlock(parser, data);
-	else if (data2DFormat() == Data2DExportFileFormat::CartesianData) result = exportCartesian(parser, data);
-	else Messenger::error("Unrecognised data format.\nKnown formats are: %s.\n", Data2DExportFileFormat().formats());
+	if (data2DFormat() == Data2DExportFileFormat::BlockData2D) result = exportBlock(parser, data);
+// 	else if (data2DFormat() == Data2DExportFileFormat::CartesianData2D) result = exportCartesian(parser, data);
+	else
+	{
+		Messenger::error("Unrecognised Data2D format.\nKnown formats are:\n");
+		printAvailableFormats();
+	}
 
 	return result;
 }

--- a/src/io/export/data2d.h
+++ b/src/io/export/data2d.h
@@ -32,17 +32,25 @@ class Data2DExportFileFormat : public FileAndFormat
 {
 	public:
 	// Available data formats
-	enum Data2DExportFormat { BlockData, CartesianData, nData2DExportFormats };
+	enum Data2DExportFormat { BlockData2D, CartesianData2D, nData2DExportFormats };
+	// Constructor
+	Data2DExportFileFormat(const char* filename = NULL, Data2DExportFormat format = Data2DExportFileFormat::BlockData2D);
+
+
+	/*
+	 * Format Access
+	 */
+	public:
+	// Return enum options for Data2DExportFormat
+	static EnumOptions<Data2DExportFileFormat::Data2DExportFormat> data2DExportFormats();
 	// Return number of available formats
 	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
 	// Return current format as Data2DExportFormat
 	Data2DExportFormat data2DFormat() const;
-	// Constructor
-	Data2DExportFileFormat(const char* filename = NULL, Data2DExportFormat format = Data2DExportFileFormat::BlockData);
 
 
 	/*

--- a/src/io/export/data3d.cpp
+++ b/src/io/export/data3d.cpp
@@ -24,9 +24,27 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-// Data3D Export Keywords
-const char* Data3DExportFormatKeywords[] = { "block", "cartesian", "pdens" };
-const char* NiceData3DExportFormatKeywords[] = { "Block Data", "Cartesian (x,y,z,value) Data", "PDens Data" };
+// Constructor
+Data3DExportFileFormat::Data3DExportFileFormat(const char* filename, Data3DExportFormat format) : FileAndFormat(filename, format)
+{
+}
+
+/*
+ * Format Access
+ */
+
+// Return enum options for Data3DExportFormat
+EnumOptions<Data3DExportFileFormat::Data3DExportFormat> Data3DExportFileFormat::data3DExportFormats()
+{
+	static EnumOptionsList Data3DExportFormats = EnumOptionsList() <<
+		EnumOption(Data3DExportFileFormat::BlockData3D, 	"block",	"Block Data") <<
+		EnumOption(Data3DExportFileFormat::CartesianData3D, 	"cartesian",	"Cartesian (x,y,value) Data") <<
+		EnumOption(Data3DExportFileFormat::CartesianData3D, 	"pdens",	"DLPutils PDens Data");
+
+	static EnumOptions<Data3DExportFileFormat::Data3DExportFormat> options("Data3DExportFileFormat", Data3DExportFormats);
+
+	return options;
+}
 
 // Return number of available formats
 int Data3DExportFileFormat::nFormats() const
@@ -34,27 +52,22 @@ int Data3DExportFileFormat::nFormats() const
 	return Data3DExportFileFormat::nData3DExportFormats;
 }
 
-// Return formats array
-const char** Data3DExportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* Data3DExportFileFormat::formatKeyword(int id) const
 {
-	return Data3DExportFormatKeywords;
+	return data3DExportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** Data3DExportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* Data3DExportFileFormat::formatDescription(int id) const
 {
-	return NiceData3DExportFormatKeywords;
+	return data3DExportFormats().descriptionByIndex(id);
 }
 
 // Return current format as CoordinateExportFormat
 Data3DExportFileFormat::Data3DExportFormat Data3DExportFileFormat::data3DFormat() const
 {
 	return (Data3DExportFileFormat::Data3DExportFormat) format_;
-}
-
-// Constructor
-Data3DExportFileFormat::Data3DExportFileFormat(const char* filename, Data3DExportFormat format) : FileAndFormat(filename, format)
-{
 }
 
 /*
@@ -153,10 +166,14 @@ bool Data3DExportFileFormat::exportData(const Data3D& data)
 
 	// Write data
 	bool result = false;
-	if (data3DFormat() == Data3DExportFileFormat::BlockData) result = exportBlock(parser, data);
-	else if (data3DFormat() == Data3DExportFileFormat::CartesianData) result = exportCartesian(parser, data);
-	else if (data3DFormat() == Data3DExportFileFormat::PDensData) result = exportPDens(parser, data);
-	else Messenger::error("Unrecognised data format.\nKnown formats are: %s.\n", Data3DExportFileFormat().formats());
+	if (data3DFormat() == Data3DExportFileFormat::BlockData3D) result = exportBlock(parser, data);
+	else if (data3DFormat() == Data3DExportFileFormat::CartesianData3D) result = exportCartesian(parser, data);
+	else if (data3DFormat() == Data3DExportFileFormat::PDensData3D) result = exportPDens(parser, data);
+	else
+	{
+		Messenger::error("Unrecognised Data3D format.\nKnown formats are:\n");
+		printAvailableFormats();
+	}
 
 	return result;
 }

--- a/src/io/export/data3d.h
+++ b/src/io/export/data3d.h
@@ -32,17 +32,25 @@ class Data3DExportFileFormat : public FileAndFormat
 {
 	public:
 	// Available data formats
-	enum Data3DExportFormat { BlockData, CartesianData, PDensData, nData3DExportFormats };
+	enum Data3DExportFormat { BlockData3D, CartesianData3D, PDensData3D, nData3DExportFormats };
+	// Constructor
+	Data3DExportFileFormat(const char* filename = NULL, Data3DExportFormat format = Data3DExportFileFormat::BlockData3D);
+
+
+	/*
+	 * Format Access
+	 */
+	public:
+	// Return enum options for Data3DExportFormat
+	static EnumOptions<Data3DExportFileFormat::Data3DExportFormat> data3DExportFormats();
 	// Return number of available formats
 	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
 	// Return current format as Data3DExportFormat
 	Data3DExportFormat data3DFormat() const;
-	// Constructor
-	Data3DExportFileFormat(const char* filename = NULL, Data3DExportFormat format = Data3DExportFileFormat::BlockData);
 
 
 	/*

--- a/src/io/export/pairpotential.cpp
+++ b/src/io/export/pairpotential.cpp
@@ -25,9 +25,26 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-// PairPotential Export Keywords
-const char* PairPotentialExportFormatKeywords[] = { "block", "TABLE" };
-const char* NicePairPotentialExportFormatKeywords[] = { "Block Data", "DL_POLY TABLE file" };
+// Constructor
+PairPotentialExportFileFormat::PairPotentialExportFileFormat(const char* filename, PairPotentialExportFormat format) : FileAndFormat(filename, format)
+{
+}
+
+/*
+ * Format Access
+ */
+
+// Return enum options for PairPotentialExportFormat
+EnumOptions<PairPotentialExportFileFormat::PairPotentialExportFormat> PairPotentialExportFileFormat::pairPotentialExportFormats()
+{
+	static EnumOptionsList PairPotentialExportFormats = EnumOptionsList() <<
+		EnumOption(PairPotentialExportFileFormat::BlockPairPotential, 		"block",	"Block Data") <<
+		EnumOption(PairPotentialExportFileFormat::DLPOLYTABLEPairPotential, 	"table",	"DL_POLY TABLE File");
+
+	static EnumOptions<PairPotentialExportFileFormat::PairPotentialExportFormat> options("PairPotentialExportFileFormat", PairPotentialExportFormats);
+
+	return options;
+}
 
 // Return number of available formats
 int PairPotentialExportFileFormat::nFormats() const
@@ -35,27 +52,22 @@ int PairPotentialExportFileFormat::nFormats() const
 	return PairPotentialExportFileFormat::nPairPotentialExportFormats;
 }
 
-// Return formats array
-const char** PairPotentialExportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* PairPotentialExportFileFormat::formatKeyword(int id) const
 {
-	return PairPotentialExportFormatKeywords;
+	return pairPotentialExportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** PairPotentialExportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* PairPotentialExportFileFormat::formatDescription(int id) const
 {
-	return NicePairPotentialExportFormatKeywords;
+	return pairPotentialExportFormats().descriptionByIndex(id);
 }
 
 // Return current format as PairPotentialExportFormat
 PairPotentialExportFileFormat::PairPotentialExportFormat PairPotentialExportFileFormat::pairPotentialFormat() const
 {
 	return (PairPotentialExportFileFormat::PairPotentialExportFormat) format_;
-}
-
-// Constructor
-PairPotentialExportFileFormat::PairPotentialExportFileFormat(const char* filename, PairPotentialExportFormat format) : FileAndFormat(filename, format)
-{
 }
 
 /*
@@ -136,7 +148,10 @@ bool PairPotentialExportFileFormat::exportData(PairPotential* pp)
 	bool result = false;
 	if (pairPotentialFormat() == PairPotentialExportFileFormat::BlockPairPotential) result = exportBlock(parser, pp);
 	else if (pairPotentialFormat() == PairPotentialExportFileFormat::DLPOLYTABLEPairPotential) result = exportDLPOLY(parser, pp);
-	else Messenger::error("Unrecognised pair potential format.\nKnown formats are: %s.\n", PairPotentialExportFileFormat().formats());
-
+	else
+	{
+		Messenger::error("Unrecognised pair potential format.\nKnown formats are:\n");
+		printAvailableFormats();
+	}
 	return result;
 }

--- a/src/io/export/pairpotential.h
+++ b/src/io/export/pairpotential.h
@@ -33,16 +33,24 @@ class PairPotentialExportFileFormat : public FileAndFormat
 	public:
 	// Available data formats
 	enum PairPotentialExportFormat { BlockPairPotential, DLPOLYTABLEPairPotential, nPairPotentialExportFormats };
-	// Return number of available formats
-	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
-	// Return current format as PairPotentialExportFormat
-	PairPotentialExportFormat pairPotentialFormat() const;
 	// Constructor
 	PairPotentialExportFileFormat(const char* filename = NULL, PairPotentialExportFormat format = BlockPairPotential);
+
+
+	/*
+	 * Format Access
+	 */
+	public:
+	// Return enum options for PairPotentialExportFormat
+	static EnumOptions<PairPotentialExportFileFormat::PairPotentialExportFormat> pairPotentialExportFormats();
+	// Return number of available formats
+	int nFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
+	// Return current format as PairPotentialExportFormat
+	PairPotentialExportFormat pairPotentialFormat() const;
 
 
 	/*

--- a/src/io/export/trajectory.cpp
+++ b/src/io/export/trajectory.cpp
@@ -26,9 +26,25 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-// Trajectory Type Keywords
-const char* TrajectoryExportFormatKeywords[] = { "xyz" };
-const char* NiceTrajectoryExportFormatKeywords[] = { "XYZ Trajectory" };
+// Constructor
+TrajectoryExportFileFormat::TrajectoryExportFileFormat(const char* filename, TrajectoryExportFormat format) : FileAndFormat(filename, format)
+{
+}
+
+/*
+ * Format Access
+ */
+
+// Return enum options for TrajectoryExportFormat
+EnumOptions<TrajectoryExportFileFormat::TrajectoryExportFormat> TrajectoryExportFileFormat::trajectoryExportFormats()
+{
+	static EnumOptionsList TrajectoryExportFormats = EnumOptionsList() <<
+		EnumOption(TrajectoryExportFileFormat::XYZTrajectory, 	"xyz",		"XYZ Trajectory");
+
+	static EnumOptions<TrajectoryExportFileFormat::TrajectoryExportFormat> options("TrajectoryExportFileFormat", TrajectoryExportFormats);
+
+	return options;
+}
 
 // Return number of available formats
 int TrajectoryExportFileFormat::nFormats() const
@@ -36,27 +52,22 @@ int TrajectoryExportFileFormat::nFormats() const
 	return TrajectoryExportFileFormat::nTrajectoryExportFormats;
 }
 
-// Return formats array
-const char** TrajectoryExportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* TrajectoryExportFileFormat::formatKeyword(int id) const
 {
-	return TrajectoryExportFormatKeywords;
+	return trajectoryExportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** TrajectoryExportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* TrajectoryExportFileFormat::formatDescription(int id) const
 {
-	return NiceTrajectoryExportFormatKeywords;
+	return trajectoryExportFormats().descriptionByIndex(id);
 }
 
 // Return current format as TrajectoryExportFormat
 TrajectoryExportFileFormat::TrajectoryExportFormat TrajectoryExportFileFormat::trajectoryFormat() const
 {
 	return (TrajectoryExportFileFormat::TrajectoryExportFormat) format_;
-}
-
-// Constructor
-TrajectoryExportFileFormat::TrajectoryExportFileFormat(const char* filename, TrajectoryExportFormat format) : FileAndFormat(filename, format)
-{
 }
 
 /*
@@ -107,7 +118,11 @@ bool TrajectoryExportFileFormat::exportData(Configuration* cfg)
 	// Append frame in supplied format
 	bool frameResult = false;
 	if (trajectoryFormat() == TrajectoryExportFileFormat::XYZTrajectory) frameResult = exportXYZ(parser, cfg);
-	else Messenger::error("Unrecognised trajectory format.\nKnown formats are: %s.\n", TrajectoryExportFileFormat().formats());
+	else
+	{
+		Messenger::error("Unrecognised trajectory format.\nKnown formats are:\n");
+		printAvailableFormats();
+	}
 
 	parser.closeFiles();
 

--- a/src/io/export/trajectory.cpp
+++ b/src/io/export/trajectory.cpp
@@ -105,18 +105,21 @@ bool TrajectoryExportFileFormat::exportData(Configuration* cfg)
 		return false;
 	}
 
-	bool headerResult = false;
-
 	// Write header?
 	if (!fileExists)
 	{
-		// if (format == OneThatNeedsAHeader) headerResult = writeAHeader(parser, cfg);
-		// else result = Messenger::error("Unrecognised trajectory format so can't write header.\nKnown formats are: %s.\n", TrajectoryExportFileFormat().formats());
+		auto headerResult = false;
+
+		if (format_ == XYZTrajectory) headerResult = true;
+// 		else if (format_ == OneThatNeedsAHeaderTrajectory) headerResult = writeAHeader(parser, cfg);
+		else headerResult = Messenger::error("Unrecognised trajectory format so can't write header.\nKnown formats are:\n");
+		printAvailableFormats();
+
+		if (!headerResult) return false;
 	}
-	if (!headerResult) return false;
 
 	// Append frame in supplied format
-	bool frameResult = false;
+	auto frameResult = false;
 	if (trajectoryFormat() == TrajectoryExportFileFormat::XYZTrajectory) frameResult = exportXYZ(parser, cfg);
 	else
 	{

--- a/src/io/export/trajectory.h
+++ b/src/io/export/trajectory.h
@@ -31,18 +31,26 @@ class Configuration;
 class TrajectoryExportFileFormat : public FileAndFormat
 {
 	public:
-	// Available trajectory formats
+	// Trajectory Export Formats
 	enum TrajectoryExportFormat { XYZTrajectory, nTrajectoryExportFormats };
-	// Return number of available formats
-	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
-	// Return current format as TrajectoryExportFormat
-	TrajectoryExportFormat trajectoryFormat() const;
 	// Constructor
 	TrajectoryExportFileFormat(const char* filename = NULL, TrajectoryExportFormat format = XYZTrajectory);
+
+
+	/*
+	 * Format Access
+	 */
+	public:
+	// Return enum options for TrajectoryExportFormat
+	static EnumOptions<TrajectoryExportFileFormat::TrajectoryExportFormat> trajectoryExportFormats();
+	// Return number of available formats
+	int nFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
+	// Return current format as TrajectoryExportFormat
+	TrajectoryExportFormat trajectoryFormat() const;
 
 
 	/*

--- a/src/io/fileandformat.cpp
+++ b/src/io/fileandformat.cpp
@@ -53,25 +53,9 @@ FileAndFormat::operator const char*() const
 // Convert text string to format index
 int FileAndFormat::format(const char* s) const
 {
-	for (int n=0; n<nFormats(); ++n) if (DissolveSys::sameString(s, formats()[n])) return n;
+	for (int n=0; n<nFormats(); ++n) if (DissolveSys::sameString(s, formatKeyword(n))) return n;
 
 	return nFormats();
-}
-
-// Convert format index to text string
-const char* FileAndFormat::format(int id) const
-{
-	if ((id < 0) || (id >= nFormats())) return "???";
-
-	return formats()[id];
-}
-
-// Convert format index to nice text string
-const char* FileAndFormat::niceFormat(int id) const
-{
-	if ((id < 0) || (id >= nFormats())) return "???";
-
-	return niceFormats()[id];
 }
 
 // Set format index
@@ -90,14 +74,20 @@ int FileAndFormat::formatIndex() const
 const char* FileAndFormat::format() const
 {
 	if ((format_ < 0) || (format_ >= nFormats())) return "???";
-	else return format(format_);
+	else return formatKeyword(format_);
 }
 
 // Return nice format string
-const char* FileAndFormat::niceFormat() const
+const char* FileAndFormat::description() const
 {
 	if ((format_ < 0) || (format_ >= nFormats())) return "???";
-	else return niceFormats()[format_];
+	else return formatDescription(format_);
+}
+
+// Print available formats
+void FileAndFormat::printAvailableFormats() const
+{
+	for (int n=0; n<nFormats(); ++n) Messenger::print("  %12s  %s\n", formatKeyword(n), formatDescription(n));
 }
 
 /*
@@ -158,7 +148,7 @@ bool FileAndFormat::read(LineParser& parser, int startArg, const char* endKeywor
 	{
 		Messenger::print("Unrecognised format '%s' given for file. Recognised formats are:\n\n", parser.argc(startArg));
 
-		for (int n=0; n<nFormats(); ++n) Messenger::print("  %12s  %s\n", format(n), niceFormat(n));
+		printAvailableFormats();
 
 		return false;
 	}
@@ -195,7 +185,7 @@ bool FileAndFormat::read(LineParser& parser, int startArg, const char* endKeywor
 // Write format / filename to specified parser
 bool FileAndFormat::writeFilenameAndFormat(LineParser& parser, const char* prefix)
 {
-	return parser.writeLineF("%s%s  '%s'\n", prefix, format(format_), filename_.get());
+	return parser.writeLineF("%s%s  '%s'\n", prefix, formatKeyword(format_), filename_.get());
 }
 
 // Write options and end block

--- a/src/io/fileandformat.h
+++ b/src/io/fileandformat.h
@@ -53,24 +53,22 @@ class FileAndFormat
 	public:
 	// Return number of available formats
 	virtual int nFormats() const = 0;
-	// Return formats array
-	virtual const char** formats() const = 0;
-	// Return nice formats array
-	virtual const char** niceFormats() const = 0;
+	// Return format keyword for supplied index
+	virtual const char* formatKeyword(int id) const = 0;
+	// Return description string for supplied index
+	virtual const char* formatDescription(int id) const = 0;
 	// Convert text string to format index
 	int format(const char* s) const;
-	// Convert format index to text string
-	const char* format(int id) const;
-	// Convert format index to nice text string
-	const char* niceFormat(int id) const;
 	// Set format index
 	void setFormatIndex(int id);
 	// Return format index
 	int formatIndex() const;
 	// Return format string
 	const char* format() const;
-	// Return nice format string
-	const char* niceFormat() const;
+	// Return description string
+	const char* description() const;
+	// Print available formats
+	void printAvailableFormats() const;
 
 
 	/*

--- a/src/io/import/coordinates.cpp
+++ b/src/io/import/coordinates.cpp
@@ -23,10 +23,6 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-// Coordinate Type Keywords
-const char* CoordinateImportFormatKeywords[] = { "xyz", "dlpoly", "epsr" };
-const char* NiceCoordinateImportFormatKeywords[] = { "XYZ", "DL_POLY", "EPSR (ATO)" };
-
 // Constructor
 CoordinateImportFileFormat::CoordinateImportFileFormat(CoordinateImportFormat format) : FileAndFormat(format)
 {
@@ -41,22 +37,35 @@ CoordinateImportFileFormat::~CoordinateImportFileFormat()
  * Format Access
  */
 
+// Return enum options for CoordinateImportFormat
+EnumOptions<CoordinateImportFileFormat::CoordinateImportFormat> CoordinateImportFileFormat::coordinateImportFormats()
+{
+	static EnumOptionsList CoordinateImportFormats = EnumOptionsList() <<
+		EnumOption(CoordinateImportFileFormat::XYZCoordinates, 		"xyz",		"Simple XYZ") <<
+		EnumOption(CoordinateImportFileFormat::DLPOLYCoordinates, 	"dlpoly",	"DL_POLY CONFIG") <<
+		EnumOption(CoordinateImportFileFormat::EPSRCoordinates, 	"epsr",		"EPSR ATO");
+
+	static EnumOptions<CoordinateImportFileFormat::CoordinateImportFormat> options("CoordinateImportFileFormat", CoordinateImportFormats);
+
+	return options;
+}
+
 // Return number of available formats
 int CoordinateImportFileFormat::nFormats() const
 {
 	return CoordinateImportFileFormat::nCoordinateImportFormats;
 }
 
-// Return formats array
-const char** CoordinateImportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* CoordinateImportFileFormat::formatKeyword(int id) const
 {
-	return CoordinateImportFormatKeywords;
+	return coordinateImportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** CoordinateImportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* CoordinateImportFileFormat::formatDescription(int id) const
 {
-	return NiceCoordinateImportFormatKeywords;
+	return coordinateImportFormats().descriptionByIndex(id);
 }
 
 // Return current format as CoordinateImportFormat
@@ -92,7 +101,7 @@ bool CoordinateImportFileFormat::importData(LineParser& parser, Array< Vec3<doub
 	if (coordinateFormat() == CoordinateImportFileFormat::XYZCoordinates) result = importXYZ(parser, r);
 	else if (coordinateFormat() == CoordinateImportFileFormat::DLPOLYCoordinates) result = importDLPOLY(parser, r);
 	else if (coordinateFormat() == CoordinateImportFileFormat::EPSRCoordinates) result = importEPSR(parser, r);
-	else Messenger::error("Don't know how to load coordinates in format '%s'.\n", CoordinateImportFileFormat().format(coordinateFormat()));
+	else Messenger::error("Don't know how to load coordinates in format '%s'.\n", formatKeyword(coordinateFormat()));
 
 	return result;
 }

--- a/src/io/import/coordinates.h
+++ b/src/io/import/coordinates.h
@@ -44,12 +44,14 @@ class CoordinateImportFileFormat : public FileAndFormat
 	 * Format Access
 	 */
 	public:
+	// Return enum options for CoordinateImportFormat
+	static EnumOptions<CoordinateImportFileFormat::CoordinateImportFormat> coordinateImportFormats();
 	// Return number of available formats
 	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
 	// Return current format as CoordinateImportFormat
 	CoordinateImportFormat coordinateFormat() const;
 

--- a/src/io/import/data1d.cpp
+++ b/src/io/import/data1d.cpp
@@ -24,10 +24,6 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-// Data1D Type Keywords
-const char* Data1DImportFormatKeywords[] = { "xy", "histogram", "mint" };
-const char* NiceData1DImportFormatKeywords[] = { "Simple XY data (x = bin centres)", "Histogrammed Data (x = bin left-boundaries)", "Gudrun output (mint01)" };
-
 // Constructor
 Data1DImportFileFormat::Data1DImportFileFormat(Data1DImportFileFormat::Data1DImportFormat format) : FileAndFormat(format)
 {
@@ -46,22 +42,35 @@ Data1DImportFileFormat::~Data1DImportFileFormat()
  * Format Access
  */
 
+// Return enum options for Data1DImportFormat
+EnumOptions<Data1DImportFileFormat::Data1DImportFormat> Data1DImportFileFormat::data1DImportFormats()
+{
+	static EnumOptionsList Data1DImportFormats = EnumOptionsList() <<
+		EnumOption(Data1DImportFileFormat::XYData1D, 		"xy",		"Simple XY data (x = bin centres)") <<
+		EnumOption(Data1DImportFileFormat::HistogramData1D, 	"histogram",	"Histogrammed Data (x = bin left-boundaries)") <<
+		EnumOption(Data1DImportFileFormat::GudrunMintData1D, 	"mint",		"Gudrun output (mint01)");
+
+	static EnumOptions<Data1DImportFileFormat::Data1DImportFormat> options("Data1DImportFileFormat", Data1DImportFormats);
+
+	return options;
+}
+
 // Return number of available formats
 int Data1DImportFileFormat::nFormats() const
 {
 	return Data1DImportFileFormat::nData1DImportFormats;
 }
 
-// Return formats array
-const char** Data1DImportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* Data1DImportFileFormat::formatKeyword(int id) const
 {
-	return Data1DImportFormatKeywords;
+	return data1DImportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** Data1DImportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* Data1DImportFileFormat::formatDescription(int id) const
 {
-	return NiceData1DImportFormatKeywords;
+	return data1DImportFormats().descriptionByIndex(id);
 }
 
 // Return current format as Data1DImportFormat
@@ -97,7 +106,7 @@ bool Data1DImportFileFormat::importData(LineParser& parser, Data1D& data)
 	if (data1DFormat() == Data1DImportFileFormat::XYData1D) result = importXY(parser, data);
 	else if (data1DFormat() == Data1DImportFileFormat::HistogramData1D) result = importHistogram(parser, data);
 	else if (data1DFormat() == Data1DImportFileFormat::GudrunMintData1D) result = importGudrunMint(parser, data);
-	else Messenger::error("Don't know how to load Data1D of format '%s'.\n", Data1DImportFileFormat().format(data1DFormat()));
+	else Messenger::error("Don't know how to load Data1D of format '%s'.\n", formatKeyword(data1DFormat()));
 
 	// If we failed, may as well return now
 	if (!result) return false;

--- a/src/io/import/data1d.h
+++ b/src/io/import/data1d.h
@@ -45,12 +45,14 @@ class Data1DImportFileFormat : public FileAndFormat
 	 * Format Access
 	 */
 	public:
+	// Return enum options for Data1DImportFormat
+	static EnumOptions<Data1DImportFileFormat::Data1DImportFormat> data1DImportFormats();
 	// Return number of available formats
 	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
 	// Return current format as Data1DImportFormat
 	Data1DImportFormat data1DFormat() const;
 

--- a/src/io/import/data2d.cpp
+++ b/src/io/import/data2d.cpp
@@ -24,10 +24,6 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-// Data2D Type Keywords
-const char* Data2DImportFormatKeywords[] = { "cartesian" };
-const char* NiceData2DImportFormatKeywords[] = { "Cartesian X,Y,f(X,Y) data" };
-
 // Constructor
 Data2DImportFileFormat::Data2DImportFileFormat(Data2DImportFormat format) : FileAndFormat(format)
 {
@@ -44,22 +40,33 @@ Data2DImportFileFormat::~Data2DImportFileFormat()
  * Format Access
  */
 
+// Return enum options for Data2DImportFormat
+EnumOptions<Data2DImportFileFormat::Data2DImportFormat> Data2DImportFileFormat::data2DImportFormats()
+{
+	static EnumOptionsList Data2DImportFormats = EnumOptionsList() <<
+		EnumOption(Data2DImportFileFormat::CartesianData2D, 	"cartesian",		"Cartesian X,Y,f(X,Y) data");
+
+	static EnumOptions<Data2DImportFileFormat::Data2DImportFormat> options("Data2DImportFileFormat", Data2DImportFormats);
+
+	return options;
+}
+
 // Return number of available formats
 int Data2DImportFileFormat::nFormats() const
 {
 	return Data2DImportFileFormat::nData2DImportFormats;
 }
 
-// Return formats array
-const char** Data2DImportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* Data2DImportFileFormat::formatKeyword(int id) const
 {
-	return Data2DImportFormatKeywords;
+	return data2DImportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** Data2DImportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* Data2DImportFileFormat::formatDescription(int id) const
 {
-	return NiceData2DImportFormatKeywords;
+	return data2DImportFormats().descriptionByIndex(id);
 }
 
 // Return current format as Data2DImportFormat
@@ -93,7 +100,7 @@ bool Data2DImportFileFormat::importData(LineParser& parser, Data2D& data)
 	// Import the data
 	bool result = false;
 	if (data2DFormat() == Data2DImportFileFormat::CartesianData2D) result = importCartesian(parser, data);
-	else Messenger::error("Don't know how to load Data2D of format '%s'.\n", Data2DImportFileFormat().format(data2DFormat()));
+	else Messenger::error("Don't know how to load Data2D of format '%s'.\n", formatKeyword(data2DFormat()));
 
 	return result;
 }

--- a/src/io/import/data2d.h
+++ b/src/io/import/data2d.h
@@ -47,12 +47,14 @@ class Data2DImportFileFormat : public FileAndFormat
 	 * Format Access
 	 */
 	public:
+	// Return enum options for Data2DImportFormat
+	static EnumOptions<Data2DImportFileFormat::Data2DImportFormat> data2DImportFormats();
 	// Return number of available formats
 	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
 	// Return current format as Data2DImportFormat
 	Data2DImportFormat data2DFormat() const;
 

--- a/src/io/import/data3d.cpp
+++ b/src/io/import/data3d.cpp
@@ -23,10 +23,6 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-// Data3D Type Keywords
-const char* Data3DImportFormatKeywords[] = { "cartesian" };
-const char* NiceData3DImportFormatKeywords[] = { "Cartesian X,Y,Z,f(x,y,z) data" };
-
 // Constructor
 Data3DImportFileFormat::Data3DImportFileFormat(Data3DImportFormat format) : FileAndFormat(format)
 {
@@ -41,22 +37,33 @@ Data3DImportFileFormat::~Data3DImportFileFormat()
  * Format Access
  */
 
+// Return enum options for Data3DImportFormat
+EnumOptions<Data3DImportFileFormat::Data3DImportFormat> Data3DImportFileFormat::data3DImportFormats()
+{
+	static EnumOptionsList Data3DImportFormats = EnumOptionsList() <<
+		EnumOption(Data3DImportFileFormat::CartesianData3D, 	"cartesian",		"Cartesian X,Y,Z,f(x,y,z) data");
+
+	static EnumOptions<Data3DImportFileFormat::Data3DImportFormat> options("Data3DImportFileFormat", Data3DImportFormats);
+
+	return options;
+}
+
 // Return number of available formats
 int Data3DImportFileFormat::nFormats() const
 {
 	return Data3DImportFileFormat::nData3DImportFormats;
 }
 
-// Return formats array
-const char** Data3DImportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* Data3DImportFileFormat::formatKeyword(int id) const
 {
-	return Data3DImportFormatKeywords;
+	return data3DImportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** Data3DImportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* Data3DImportFileFormat::formatDescription(int id) const
 {
-	return NiceData3DImportFormatKeywords;
+	return data3DImportFormats().descriptionByIndex(id);
 }
 
 // Return current format as Data3DImportFormat
@@ -123,7 +130,7 @@ bool Data3DImportFileFormat::importData(LineParser& parser, Data3D& data)
 	// Import the data
 	bool result = false;
 // 	if (data3DFormat() == Data3DImportFileFormat::CartesianData3D) result = importCartesian(parser, data);
-	Messenger::error("Don't know how to load Data3D of format '%s'.\n", Data3DImportFileFormat().format(data3DFormat()));
+	Messenger::error("Don't know how to load Data3D in format '%s'.\n", formatKeyword(data3DFormat()));
 
 	return result;
 }

--- a/src/io/import/data3d.h
+++ b/src/io/import/data3d.h
@@ -48,12 +48,14 @@ class Data3DImportFileFormat : public FileAndFormat
 	 * Format Access
 	 */
 	public:
+	// Return enum options for Data3DImportFormat
+	static EnumOptions<Data3DImportFileFormat::Data3DImportFormat> data3DImportFormats();
 	// Return number of available formats
 	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
 	// Return current format as Data3DImportFormat
 	Data3DImportFormat data3DFormat() const;
 

--- a/src/io/import/forces.cpp
+++ b/src/io/import/forces.cpp
@@ -42,22 +42,34 @@ ForceImportFileFormat::~ForceImportFileFormat()
  * Format Access
  */
 
+// Return enum options for ForceImportFormat
+EnumOptions<ForceImportFileFormat::ForceImportFormat> ForceImportFileFormat::forceImportFormats()
+{
+	static EnumOptionsList ForceImportFileFormats = EnumOptionsList() <<
+		EnumOption(ForceImportFileFormat::XYZForces, 		"xyz",		"Simple X,Y,Z,f(x,y,z) Data") <<
+		EnumOption(ForceImportFileFormat::DLPOLYForces, 	"dlpoly",	"DL_POLY Config File Forces");
+
+	static EnumOptions<ForceImportFileFormat::ForceImportFormat> options("ForceImportFileFormat", ForceImportFileFormats);
+
+	return options;
+}
+
 // Return number of available formats
 int ForceImportFileFormat::nFormats() const
 {
 	return ForceImportFileFormat::nForceImportFormats;
 }
 
-// Return formats array
-const char** ForceImportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* ForceImportFileFormat::formatKeyword(int id) const
 {
-	return ForcesFormatKeywords;
+	return forceImportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** ForceImportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* ForceImportFileFormat::formatDescription(int id) const
 {
-	return NiceForcesFormatKeywords;
+	return forceImportFormats().descriptionByIndex(id);
 }
 
 // Return current format as ForceImportFormat
@@ -92,7 +104,7 @@ bool ForceImportFileFormat::importData(LineParser& parser, Array<double>& fx, Ar
 	bool result = false;
 	if (forceFormat() == ForceImportFileFormat::XYZForces) result = importXYZ(parser, fx, fy, fz);
 	else if (forceFormat() == ForceImportFileFormat::DLPOLYForces) return importDLPOLY(parser, fx, fy, fz);
-	else Messenger::error("Don't know how to load forces in format '%s'.\n", ForceImportFileFormat().format(forceFormat()));
+	else Messenger::error("Don't know how to load forces in format '%s'.\n", formatKeyword(forceFormat()));
 
 	return result;
 }

--- a/src/io/import/forces.h
+++ b/src/io/import/forces.h
@@ -44,12 +44,14 @@ class ForceImportFileFormat : public FileAndFormat
 	 * Format Access
 	 */
 	public:
+	// Return enum options for ForceImportFormat
+	static EnumOptions<ForceImportFileFormat::ForceImportFormat> forceImportFormats();
 	// Return number of available formats
 	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
 	// Return current format as ForceImportFormat
 	ForceImportFormat forceFormat() const;
 

--- a/src/io/import/trajectory.cpp
+++ b/src/io/import/trajectory.cpp
@@ -22,10 +22,6 @@
 #include "io/import/trajectory.h"
 #include "base/sysfunc.h"
 
-// Trajectory Type Keywords
-const char* TrajectoryImportFormatKeywords[] = { "xyz" };
-const char* NiceTrajectoryImportFormatKeywords[] = { "XYZ" };
-
 // Constructor
 TrajectoryImportFileFormat::TrajectoryImportFileFormat(TrajectoryImportFormat format) : FileAndFormat(format)
 {
@@ -40,22 +36,33 @@ TrajectoryImportFileFormat::~TrajectoryImportFileFormat()
  * Format Access
  */
 
+// Return enum options for TrajectoryImportFormat
+EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat> TrajectoryImportFileFormat::trajectoryImportFormats()
+{
+	static EnumOptionsList TrajectoryImportFormats = EnumOptionsList() <<
+		EnumOption(TrajectoryImportFileFormat::XYZTrajectory, 	"xyz",		"XYZ Trajectory");
+
+	static EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat> options("TrajectoryImportFileFormat", TrajectoryImportFormats);
+
+	return options;
+}
+
 // Return number of available formats
 int TrajectoryImportFileFormat::nFormats() const
 {
 	return TrajectoryImportFileFormat::nTrajectoryImportFormats;
 }
 
-// Return formats array
-const char** TrajectoryImportFileFormat::formats() const
+// Return format keyword for supplied index
+const char* TrajectoryImportFileFormat::formatKeyword(int id) const
 {
-	return TrajectoryImportFormatKeywords;
+	return trajectoryImportFormats().keywordByIndex(id);
 }
 
-// Return nice formats array
-const char** TrajectoryImportFileFormat::niceFormats() const
+// Return description string for supplied index
+const char* TrajectoryImportFileFormat::formatDescription(int id) const
 {
-	return NiceTrajectoryImportFormatKeywords;
+	return trajectoryImportFormats().descriptionByIndex(id);
 }
 
 // Return current format as TrajectoryImportFormat

--- a/src/io/import/trajectory.h
+++ b/src/io/import/trajectory.h
@@ -43,12 +43,14 @@ class TrajectoryImportFileFormat : public FileAndFormat
 	 * Format Access
 	 */
 	public:
+	// Return enum options for TrajectoryImportFileFormat
+	static EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat> trajectoryImportFormats();
 	// Return number of available formats
 	int nFormats() const;
-	// Return formats array
-	const char** formats() const;
-	// Return nice formats array
-	const char** niceFormats() const;
+	// Return format keyword for supplied index
+	const char* formatKeyword(int id) const;
+	// Return description string for supplied index
+	const char* formatDescription(int id) const;
 	// Return current format as TrajectoryImportFormat
 	TrajectoryImportFormat trajectoryFormat() const;
 

--- a/src/modules/export/process.cpp
+++ b/src/modules/export/process.cpp
@@ -56,7 +56,7 @@ bool ExportModule::process(Dissolve& dissolve, ProcessPool& procPool)
 				// Only the pool master saves the data
 				if (procPool.isMaster())
 				{
-					Messenger::print("Export: Writing coordinates file (%s) for Configuration '%s'...\n", coordinatesFormat_.niceFormat(), cfg->name());
+					Messenger::print("Export: Writing coordinates file (%s) for Configuration '%s'...\n", coordinatesFormat_.description(), cfg->name());
 
 					if (!coordinatesFormat_.exportData(cfg))
 					{
@@ -86,7 +86,7 @@ bool ExportModule::process(Dissolve& dissolve, ProcessPool& procPool)
 
 			for (PairPotential* pp = dissolve.pairPotentials().first(); pp != NULL; pp = pp->next())
 			{
-				Messenger::print("Export: Writing pair potential file (%s) for %s-%s...\n", pairPotentialFormat_.niceFormat(), pp->atomTypeNameI(), pp->atomTypeNameJ());
+				Messenger::print("Export: Writing pair potential file (%s) for %s-%s...\n", pairPotentialFormat_.description(), pp->atomTypeNameI(), pp->atomTypeNameJ());
 
 				// Generate filename
 				pairPotentialFormat_.setFilename(CharString("%s-%s-%s.pp", rootPPName.get(), pp->atomTypeNameI(), pp->atomTypeNameJ()));
@@ -131,7 +131,7 @@ bool ExportModule::process(Dissolve& dissolve, ProcessPool& procPool)
 				// Only the pool master saves the data
 				if (procPool.isMaster())
 				{
-					Messenger::print("Export: Appending trajectory file (%s) for Configuration '%s'...\n", trajectoryFormat_.niceFormat(), cfg->name());
+					Messenger::print("Export: Appending trajectory file (%s) for Configuration '%s'...\n", trajectoryFormat_.description(), cfg->name());
 
 					if (!trajectoryFormat_.exportData(cfg))
 					{


### PR DESCRIPTION
Define formats for FileAndFormat with EnumOptions rather than bare enums, givine better handling and associated descriptions.﻿
