### PR TITLE
Remove ListItem from ancestry of BraggReflection

### DIFF
--- a/src/classes/braggreflection.h
+++ b/src/classes/braggreflection.h
@@ -31,7 +31,7 @@
 /* none */
 
 // BraggReflection Class
-class BraggReflection : public ListItem<BraggReflection>,  public GenericItemBase
+class BraggReflection : public GenericItemBase
 {
 	/*
 	 *  BraggReflection acts as a 'bin' for collecting contributions arising from a set of KVectors which occur at the same Q value.


### PR DESCRIPTION
As part of issue #245, we want to remove ListItem as a base from the list classes.  This PR removes it from BraggReflection, which never was put in a List to begin with.