### PR TITLE
Make KVector no longer a subclass of ListItem

### DIFF
--- a/src/classes/kvector.cpp
+++ b/src/classes/kvector.cpp
@@ -24,7 +24,7 @@
 #include "base/processpool.h"
 
 // Constructor
-KVector::KVector(int h, int k, int l, int reflectionIndex, int nAtomTypes) : ListItem<KVector>()
+KVector::KVector(int h, int k, int l, int reflectionIndex, int nAtomTypes)
 {
 	hkl_.set(h, k, l);
 	braggReflectionIndex_ = reflectionIndex;

--- a/src/classes/kvector.h
+++ b/src/classes/kvector.h
@@ -31,7 +31,7 @@
 class BraggReflection;
 
 // K-Vector
-class KVector : public ListItem<KVector>,  public GenericItemBase
+class KVector : public GenericItemBase
 {
 	public:
 	// Constructor


### PR DESCRIPTION
This is a small part of removing the List class, as part of issue #245.  There's no lists of KVector, so this one was easy.