### PR TITLE
Remve ListItem from ForcefieldBondTerms

### DIFF
--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -197,25 +197,25 @@ void Forcefield::addImproperTerm(const char* typeI, const char* typeJ, const cha
 }
 
 // Return bond term for the supplied atom type pair (if it exists)
-optional<const ForcefieldBondTerm&> Forcefield::bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const
+optional<const ForcefieldBondTerm&> Forcefield::getBondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const
 {
 	return termMatch_(bondTerms_, i, j);
 }
 
 // Return angle term for the supplied atom type trio (if it exists)
-optional<const ForcefieldAngleTerm&> Forcefield::angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const
+optional<const ForcefieldAngleTerm&> Forcefield::getAngleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const
 {
 	return termMatch_(angleTerms_, i, j, k);
 }
 
 // Return torsion term for the supplied atom type quartet (if it exists)
-optional<const ForcefieldTorsionTerm&> Forcefield::torsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
+optional<const ForcefieldTorsionTerm&> Forcefield::getTorsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
 	return termMatch_(torsionTerms_, i, j, k, l);
 }
 
 // Return improper term for the supplied atom type quartet (if it exists)
-optional<const ForcefieldImproperTerm&> Forcefield::improperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
+optional<const ForcefieldImproperTerm&> Forcefield::getImproperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
 	return termMatch_(improperTerms_, i, j, k, l);
 }
@@ -320,7 +320,7 @@ bool Forcefield::assignIntramolecular(Species* sp, int flags) const
 		ForcefieldAtomType* typeJ = determineTypes ? determineAtomType(j) : atomTypeByName(j->atomType()->name(), j->element());
 		if (!typeJ) return Messenger::error("Couldn't locate object for atom type named '%s'.\n", j->atomType()->name());
 
-		auto opt_term = bondTerm(typeI, typeJ);
+		auto opt_term = getBondTerm(typeI, typeJ);
 		if (std::get<1>(opt_term)) {
 			return Messenger::error("Failed to locate parameters for bond %i-%i (%s-%s).\n", i->userIndex(), j->userIndex(), typeI->equivalentName(), typeJ->equivalentName());
 		}
@@ -346,7 +346,7 @@ bool Forcefield::assignIntramolecular(Species* sp, int flags) const
 		ForcefieldAtomType* typeK = determineTypes ? determineAtomType(k) : atomTypeByName(k->atomType()->name(), k->element());
 		if (!typeK) return Messenger::error("Couldn't locate object for atom type named '%s'.\n", k->atomType()->name());
 
-		auto opt_term = angleTerm(typeI, typeJ, typeK);
+		auto opt_term = getAngleTerm(typeI, typeJ, typeK);
 		if (std::get<1>(opt_term)) return Messenger::error("Failed to locate parameters for angle %i-%i-%i (%s-%s-%s).\n", i->userIndex(), j->userIndex(), k->userIndex(), typeI->equivalentName(), typeJ->equivalentName(), typeK->equivalentName());
 
 		const auto& term = std::get<0>(opt_term);
@@ -374,7 +374,7 @@ bool Forcefield::assignIntramolecular(Species* sp, int flags) const
 		ForcefieldAtomType* typeL = determineTypes ? determineAtomType(l) : atomTypeByName(l->atomType()->name(), l->element());
 		if (!typeL) return Messenger::error("Couldn't locate object for atom type named '%s'.\n", l->atomType()->name());
 
-		auto opt_term = torsionTerm(typeI, typeJ, typeK, typeL);
+		auto opt_term = getTorsionTerm(typeI, typeJ, typeK, typeL);
 		if (std::get<1>(opt_term)) return Messenger::error("Failed to locate parameters for torsion %i-%i-%i-%i (%s-%s-%s-%s).\n", i->userIndex(), j->userIndex(), k->userIndex(), l->userIndex(), typeI->equivalentName(), typeJ->equivalentName(), typeK->equivalentName(), typeL->equivalentName());
 
 		const auto& term = std::get<0>(opt_term);
@@ -419,7 +419,7 @@ bool Forcefield::assignIntramolecular(Species* sp, int flags) const
 						if (!typeL) return Messenger::error("Couldn't locate object for atom type named '%s'.\n", l->atomType()->name());
 						if (selectionOnly && (!l->isSelected())) continue;
 
-						auto opt_term = improperTerm(typeI, typeJ, typeK, typeL);
+						auto opt_term = getImproperTerm(typeI, typeJ, typeK, typeL);
 						if (!std::get<1>(opt_term))
 						{
 							const auto& term = std::get<0>(opt_term);

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -199,37 +199,25 @@ void Forcefield::addImproperTerm(const char* typeI, const char* typeJ, const cha
 // Return bond term for the supplied atom type pair (if it exists)
 optional<const ForcefieldBondTerm&> Forcefield::bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const
 {
-	return termMatch_(bondTerms_,
-			  [&](const ForcefieldBondTerm& term){
-			    return term.matches(i, j);
-			  });
+	return termMatch_(bondTerms_, i, j);
 }
 
 // Return angle term for the supplied atom type trio (if it exists)
 optional<const ForcefieldAngleTerm&> Forcefield::angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const
 {
-	return termMatch_(angleTerms_,
-			  [&](const ForcefieldAngleTerm& term){
-			    return term.matches(i, j, k);
-			  });
+	return termMatch_(angleTerms_, i, j, k);
 }
 
 // Return torsion term for the supplied atom type quartet (if it exists)
 optional<const ForcefieldTorsionTerm&> Forcefield::torsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
-	return termMatch_(torsionTerms_,
-			  [&](const ForcefieldTorsionTerm& term){
-			    return term.matches(i, j, k, l);
-			  });
+	return termMatch_(torsionTerms_, i, j, k, l);
 }
 
 // Return improper term for the supplied atom type quartet (if it exists)
 optional<const ForcefieldImproperTerm&> Forcefield::improperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
-	return termMatch_(improperTerms_,
-			  [&](const ForcefieldImproperTerm& term){
-			    return term.matches(i, j, k, l);
-			  });
+	return termMatch_(improperTerms_, i, j, k, l);
 }
 
 /*

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -205,7 +205,7 @@ void Forcefield::addImproperTerm(const char* typeI, const char* typeJ, const cha
 }
 
 // Return bond term for the supplied atom type pair (if it exists)
-std::tuple<const ForcefieldBondTerm&, bool> Forcefield::bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const
+optional<const ForcefieldBondTerm&> Forcefield::bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const
 {
 	auto it = std::find_if(bondTerms_.begin(), bondTerms_.end(),
 		     [&](const ForcefieldBondTerm& term){

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -22,6 +22,8 @@
 #ifndef DISSOLVE_FORCEFIELD_H
 #define DISSOLVE_FORCEFIELD_H
 
+#include <tuple>
+#include <vector>
 #include "data/elements.h"
 #include "classes/speciesangle.h"
 #include "classes/speciesbond.h"
@@ -112,7 +114,7 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 	 */
 	private:
 	// Bond terms of the Forcefield
-	List<ForcefieldBondTerm> bondTerms_;
+	std::vector<ForcefieldBondTerm> bondTerms_;
 	// Angle terms of the Forcefield
 	List<ForcefieldAngleTerm> angleTerms_;
 	// Torsion terms of the Forcefield
@@ -132,7 +134,7 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 
 	public:
 	// Return bond term for the supplied atom type pair (if it exists)
-	virtual ForcefieldBondTerm* bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
+	virtual std::tuple<const ForcefieldBondTerm&, bool> bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
 	// Return angle term for the supplied atom type trio (if it exists)
 	virtual ForcefieldAngleTerm* angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
 	// Return torsion term for the supplied atom type quartet (if it exists)

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -22,6 +22,7 @@
 #ifndef DISSOLVE_FORCEFIELD_H
 #define DISSOLVE_FORCEFIELD_H
 
+#include <algorithm>
 #include <tuple>
 #include <vector>
 #include "data/elements.h"
@@ -118,11 +119,11 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 	// Bond terms of the Forcefield
 	std::vector<ForcefieldBondTerm> bondTerms_;
 	// Angle terms of the Forcefield
-	List<ForcefieldAngleTerm> angleTerms_;
+	std::vector<ForcefieldAngleTerm> angleTerms_;
 	// Torsion terms of the Forcefield
-	List<ForcefieldTorsionTerm> torsionTerms_;
+	std::vector<ForcefieldTorsionTerm> torsionTerms_;
 	// Improper terms of the Forcefield
-	List<ForcefieldImproperTerm> improperTerms_;
+	std::vector<ForcefieldImproperTerm> improperTerms_;
 
 	protected:
 	// Add bond term
@@ -133,16 +134,18 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 	void addTorsionTerm(const char* typeI, const char* typeJ, const char* typeK, const char* typeL, SpeciesTorsion::TorsionFunction form, double data0 = 0.0, double data1 = 0.0, double data2 = 0.0, double data3 = 0.0);
 	// Add improper term
 	void addImproperTerm(const char* typeI, const char* typeJ, const char* typeK, const char* typeL, SpeciesImproper::ImproperFunction form, double data0 = 0.0, double data1 = 0.0, double data2 = 0.0, double data3 = 0.0);
+	// Match any kind of term
+	template<class T, class Filter> static optional<const T&> termMatch_(std::vector<T>, Filter);
 
 	public:
 	// Return bond term for the supplied atom type pair (if it exists)
 	virtual optional<const ForcefieldBondTerm&> bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
 	// Return angle term for the supplied atom type trio (if it exists)
-	virtual ForcefieldAngleTerm* angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
+	virtual optional<const ForcefieldAngleTerm&> angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
 	// Return torsion term for the supplied atom type quartet (if it exists)
-	virtual ForcefieldTorsionTerm* torsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
+	virtual optional<const ForcefieldTorsionTerm&> torsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
 	// Return improper term for the supplied atom type quartet (if it exists)
-	virtual ForcefieldImproperTerm* improperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
+	virtual optional<const ForcefieldImproperTerm&> improperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
 
 
 	/*
@@ -192,5 +195,11 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 	// Guess and return oxidation state for the specified SpeciesAtom
 	int guessOxidationState(const SpeciesAtom* i) const;
 };
+
+template<class T, class Filter> optional<const T&> Forcefield::termMatch_(std::vector<T> container, Filter filter)
+{
+	auto it = std::find_if(container.begin(), container.end(), filter);
+	return std::make_tuple(*it, it == container.end());
+}
 
 #endif

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -135,7 +135,7 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 	// Add improper term
 	void addImproperTerm(const char* typeI, const char* typeJ, const char* typeK, const char* typeL, SpeciesImproper::ImproperFunction form, double data0 = 0.0, double data1 = 0.0, double data2 = 0.0, double data3 = 0.0);
 	// Match any kind of term
-	template<class T, class Filter> static optional<const T&> termMatch_(std::vector<T>, Filter);
+	template<class T, typename... Args> static optional<const T&> termMatch_(std::vector<T>, Args ...);
 
 	public:
 	// Return bond term for the supplied atom type pair (if it exists)
@@ -196,9 +196,11 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 	int guessOxidationState(const SpeciesAtom* i) const;
 };
 
-template<class T, class Filter> optional<const T&> Forcefield::termMatch_(std::vector<T> container, Filter filter)
+template<class T, typename... Args> optional<const T&> Forcefield::termMatch_(std::vector<T> container, Args... args)
 {
-	auto it = std::find_if(container.begin(), container.end(), filter);
+	auto it = std::find_if(container.begin(), container.end(), [&](const T& item){
+		return item.matches(args...);
+	});
 	return std::make_tuple(*it, it == container.end());
 }
 

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -139,13 +139,13 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 
 	public:
 	// Return bond term for the supplied atom type pair (if it exists)
-	virtual optional<const ForcefieldBondTerm&> bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
+	virtual optional<const ForcefieldBondTerm&> getBondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
 	// Return angle term for the supplied atom type trio (if it exists)
-	virtual optional<const ForcefieldAngleTerm&> angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
+	virtual optional<const ForcefieldAngleTerm&> getAngleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
 	// Return torsion term for the supplied atom type quartet (if it exists)
-	virtual optional<const ForcefieldTorsionTerm&> torsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
+	virtual optional<const ForcefieldTorsionTerm&> getTorsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
 	// Return improper term for the supplied atom type quartet (if it exists)
-	virtual optional<const ForcefieldImproperTerm&> improperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
+	virtual optional<const ForcefieldImproperTerm&> getImproperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
 
 
 	/*
@@ -199,7 +199,7 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 template<class T, typename... Args> optional<const T&> Forcefield::termMatch_(std::vector<T> container, Args... args)
 {
 	auto it = std::find_if(container.begin(), container.end(), [&](const T& item){
-		return item.matches(args...);
+		return item.isMatch(args...);
 	});
 	return std::make_tuple(*it, it == container.end());
 }

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -32,6 +32,8 @@
 #include "base/enumoptions.h"
 #include "templates/reflist.h"
 
+template<class T>using optional = std::tuple<T, bool>;
+
 // Forward Declarations
 class CoreData;
 class ForcefieldAngleTerm;
@@ -134,7 +136,7 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 
 	public:
 	// Return bond term for the supplied atom type pair (if it exists)
-	virtual std::tuple<const ForcefieldBondTerm&, bool> bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
+	virtual optional<const ForcefieldBondTerm&> bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
 	// Return angle term for the supplied atom type trio (if it exists)
 	virtual ForcefieldAngleTerm* angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
 	// Return torsion term for the supplied atom type quartet (if it exists)

--- a/src/data/ff/oplsaa2005/base.h
+++ b/src/data/ff/oplsaa2005/base.h
@@ -61,11 +61,11 @@ class OPLSAA2005BaseForcefield : public Forcefield
 	// Return bond term for the supplied atom type pair (if it exists)
 	optional<const ForcefieldBondTerm&> bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
 	// Return angle term for the supplied atom type trio (if it exists)
-	ForcefieldAngleTerm* angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
+	optional<const ForcefieldAngleTerm&> angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
 	// Return torsion term for the supplied atom type quartet (if it exists)
-	ForcefieldTorsionTerm* torsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
+	optional<const ForcefieldTorsionTerm&> torsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
 	// Return improper term for the supplied atom type quartet (if it exists)
-	ForcefieldImproperTerm* improperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
+	optional<const ForcefieldImproperTerm&> improperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
 };
 
 #endif

--- a/src/data/ff/oplsaa2005/base.h
+++ b/src/data/ff/oplsaa2005/base.h
@@ -59,7 +59,7 @@ class OPLSAA2005BaseForcefield : public Forcefield
 	 */
 	public:
 	// Return bond term for the supplied atom type pair (if it exists)
-	std::tuple<const ForcefieldBondTerm&, bool> bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
+	optional<const ForcefieldBondTerm&> bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
 	// Return angle term for the supplied atom type trio (if it exists)
 	ForcefieldAngleTerm* angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
 	// Return torsion term for the supplied atom type quartet (if it exists)

--- a/src/data/ff/oplsaa2005/base.h
+++ b/src/data/ff/oplsaa2005/base.h
@@ -59,7 +59,7 @@ class OPLSAA2005BaseForcefield : public Forcefield
 	 */
 	public:
 	// Return bond term for the supplied atom type pair (if it exists)
-	ForcefieldBondTerm* bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
+	std::tuple<const ForcefieldBondTerm&, bool> bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
 	// Return angle term for the supplied atom type trio (if it exists)
 	ForcefieldAngleTerm* angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
 	// Return torsion term for the supplied atom type quartet (if it exists)

--- a/src/data/ff/oplsaa2005/intramolecular.cpp
+++ b/src/data/ff/oplsaa2005/intramolecular.cpp
@@ -32,7 +32,7 @@
  */
 
 // Return bond term for the supplied atom type pair (if it exists)
-std::tuple<const ForcefieldBondTerm&, bool> OPLSAA2005BaseForcefield::bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const
+optional<const ForcefieldBondTerm&> OPLSAA2005BaseForcefield::bondTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const
 {
 	static std::vector<ForcefieldBondTerm> bondTerms =
 	{

--- a/src/data/ff/oplsaa2005/intramolecular.cpp
+++ b/src/data/ff/oplsaa2005/intramolecular.cpp
@@ -25,6 +25,7 @@
 #include "data/ff/oplsaa2005/base.h"
 #include "data/ffangleterm.h"
 #include "data/ffbondterm.h"
+#include "data/ffimproperterm.h"
 #include "data/fftorsionterm.h"
 
 /*
@@ -393,19 +394,15 @@ optional<const ForcefieldBondTerm&> OPLSAA2005BaseForcefield::bondTerm(const For
 		{ "Zn",	"OW",	SpeciesBond::HarmonicForm,	334.72,		2.05 }
 	};
 
-	auto it = std::find_if(bondTerms.begin(), bondTerms.end(),
-			       [&](ForcefieldBondTerm& term){
-				 return term.matches(i, j);
-			       });
-	return std::make_tuple(std::ref(*it),
-			       it == bondTerms.end());
+	return Forcefield::termMatch_(bondTerms, [&i, &j](const ForcefieldBondTerm& term) {
+	  return term.matches(i, j);
+	});
 }
 
 // Return angle term for the supplied atom type trio (if it exists)
-ForcefieldAngleTerm* OPLSAA2005BaseForcefield::angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const
+optional<const ForcefieldAngleTerm&> OPLSAA2005BaseForcefield::angleTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const
 {
-	static ForcefieldAngleTerm angleTerms[] =
-	{
+	static std::vector<ForcefieldAngleTerm> angleTerms = {
 		//	i	j	k	Type (Harmonic)			k	eq
 		{ "HW",	"OW",	"HW",	SpeciesAngle::HarmonicForm,	627.6,		109.5 },
 		/* { "HW",	"OW",	"LP",	SpeciesAngle::HarmonicForm,	418.4,		54.75 }, */
@@ -1414,16 +1411,15 @@ ForcefieldAngleTerm* OPLSAA2005BaseForcefield::angleTerm(const ForcefieldAtomTyp
 		{ "N",	"Zn",	"O",	SpeciesAngle::HarmonicForm,	167.36,		109.5 }
 	};
 
-	static const int nAngles = sizeof(angleTerms)/sizeof(ForcefieldAngleTerm);
-	for (int n=0; n<nAngles; ++n) if (angleTerms[n].matches(i, j, k)) return &angleTerms[n];
-
-	return NULL;
+	return Forcefield::termMatch_(angleTerms, [&i, &j, &k](const ForcefieldAngleTerm& term){
+	  return term.matches(i,j,k);
+	});
 }
 
 // Return torsion term for the supplied atom type quartet (if it exists)
-ForcefieldTorsionTerm* OPLSAA2005BaseForcefield::torsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
+optional<const ForcefieldTorsionTerm&> OPLSAA2005BaseForcefield::torsionTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
-	static ForcefieldTorsionTerm torsionTerms[] =
+	static std::vector<ForcefieldTorsionTerm> torsionTerms =
 	{
 		//	i	j	k	l	Type (CosineForm)		k		n	eq	s
 		{ "HC",	"CT",	"CT",	"HC",	SpeciesTorsion::Cos3Form,	0,	0,	1.2552,	0 },	// hydrocarbon
@@ -2174,14 +2170,16 @@ ForcefieldTorsionTerm* OPLSAA2005BaseForcefield::torsionTerm(const ForcefieldAto
 		{ "N2",	"CA",	"CA",	"CA",	SpeciesTorsion::Cos4Form,	0,	6.77808,	0,	-1.84096 }	// benzamidine
 	};
 
-	static const int nTorsions = sizeof(torsionTerms)/sizeof(ForcefieldTorsionTerm);
-	for (int n=0; n<nTorsions; ++n) if (torsionTerms[n].matches(i, j, k, l)) return &torsionTerms[n];
-
-	return NULL;
+	return Forcefield::termMatch_(torsionTerms, [&i, &j, &k, &l](const ForcefieldTorsionTerm& term){
+	  return term.matches(i,j,k,l);
+	});
 }
 
 // Return improper term for the supplied atom type quartet (if it exists)
-ForcefieldImproperTerm* OPLSAA2005BaseForcefield::improperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
+optional<const ForcefieldImproperTerm&> OPLSAA2005BaseForcefield::improperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
-	return NULL;
+	static std::vector<ForcefieldImproperTerm> improperTerms = {};
+	return Forcefield::termMatch_(improperTerms, [&i, &j, &k, &l](const ForcefieldImproperTerm& term){
+	  return term.matches(i,j,k,l);
+	});
 }

--- a/src/data/ff/oplsaa2005/intramolecular.cpp
+++ b/src/data/ff/oplsaa2005/intramolecular.cpp
@@ -394,9 +394,7 @@ optional<const ForcefieldBondTerm&> OPLSAA2005BaseForcefield::bondTerm(const For
 		{ "Zn",	"OW",	SpeciesBond::HarmonicForm,	334.72,		2.05 }
 	};
 
-	return Forcefield::termMatch_(bondTerms, [&i, &j](const ForcefieldBondTerm& term) {
-	  return term.matches(i, j);
-	});
+	return Forcefield::termMatch_(bondTerms, i, j);
 }
 
 // Return angle term for the supplied atom type trio (if it exists)
@@ -1411,9 +1409,7 @@ optional<const ForcefieldAngleTerm&> OPLSAA2005BaseForcefield::angleTerm(const F
 		{ "N",	"Zn",	"O",	SpeciesAngle::HarmonicForm,	167.36,		109.5 }
 	};
 
-	return Forcefield::termMatch_(angleTerms, [&i, &j, &k](const ForcefieldAngleTerm& term){
-	  return term.matches(i,j,k);
-	});
+	return Forcefield::termMatch_(angleTerms, i, j, k);
 }
 
 // Return torsion term for the supplied atom type quartet (if it exists)
@@ -2170,16 +2166,12 @@ optional<const ForcefieldTorsionTerm&> OPLSAA2005BaseForcefield::torsionTerm(con
 		{ "N2",	"CA",	"CA",	"CA",	SpeciesTorsion::Cos4Form,	0,	6.77808,	0,	-1.84096 }	// benzamidine
 	};
 
-	return Forcefield::termMatch_(torsionTerms, [&i, &j, &k, &l](const ForcefieldTorsionTerm& term){
-	  return term.matches(i,j,k,l);
-	});
+	return Forcefield::termMatch_(torsionTerms, i, j, k, l);
 }
 
 // Return improper term for the supplied atom type quartet (if it exists)
 optional<const ForcefieldImproperTerm&> OPLSAA2005BaseForcefield::improperTerm(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
 	static std::vector<ForcefieldImproperTerm> improperTerms = {};
-	return Forcefield::termMatch_(improperTerms, [&i, &j, &k, &l](const ForcefieldImproperTerm& term){
-	  return term.matches(i,j,k,l);
-	});
+	return Forcefield::termMatch_(improperTerms, i, j, k, l);
 }

--- a/src/data/ffangleterm.cpp
+++ b/src/data/ffangleterm.cpp
@@ -46,7 +46,7 @@ ForcefieldAngleTerm::~ForcefieldAngleTerm()
  */
 
 // Return if this term matches the atom types supplied
-bool ForcefieldAngleTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const
+bool ForcefieldAngleTerm::isMatch(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const
 {
 	if (!DissolveSys::sameWildString(typeJ_, j->equivalentName())) return false;
 	if (DissolveSys::sameWildString(typeI_, i->equivalentName()) && DissolveSys::sameWildString(typeK_, k->equivalentName())) return true;

--- a/src/data/ffangleterm.cpp
+++ b/src/data/ffangleterm.cpp
@@ -24,7 +24,7 @@
 #include "data/ff.h"
 
 // Constructor
-ForcefieldAngleTerm::ForcefieldAngleTerm(const char* typeI, const char* typeJ, const char* typeK, SpeciesAngle::AngleFunction form, double data0, double data1, double data2, double data3) : ListItem<ForcefieldAngleTerm>()
+ForcefieldAngleTerm::ForcefieldAngleTerm(const char* typeI, const char* typeJ, const char* typeK, SpeciesAngle::AngleFunction form, double data0, double data1, double data2, double data3)
 {
 	typeI_ = typeI;
 	typeJ_ = typeJ;
@@ -46,7 +46,7 @@ ForcefieldAngleTerm::~ForcefieldAngleTerm()
  */
 
 // Return if this term matches the atom types supplied
-bool ForcefieldAngleTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k)
+bool ForcefieldAngleTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const
 {
 	if (!DissolveSys::sameWildString(typeJ_, j->equivalentName())) return false;
 	if (DissolveSys::sameWildString(typeI_, i->equivalentName()) && DissolveSys::sameWildString(typeK_, k->equivalentName())) return true;

--- a/src/data/ffangleterm.h
+++ b/src/data/ffangleterm.h
@@ -52,7 +52,7 @@ class ForcefieldAngleTerm
 
 	public:
 	// Return if this term matches the atom types supplied
-	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
+	bool isMatch(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
 	// Return functional form index of interaction
 	SpeciesAngle::AngleFunction form() const;
 	// Return array of parameters

--- a/src/data/ffangleterm.h
+++ b/src/data/ffangleterm.h
@@ -31,7 +31,7 @@ class Forcefield;
 class ForcefieldAtomType;
 
 // Forcefield Angle Term
-class ForcefieldAngleTerm : public ListItem<ForcefieldAngleTerm>
+class ForcefieldAngleTerm
 {
 	public:
 	// Constructor / Destructor
@@ -52,7 +52,7 @@ class ForcefieldAngleTerm : public ListItem<ForcefieldAngleTerm>
 
 	public:
 	// Return if this term matches the atom types supplied
-	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k);
+	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k) const;
 	// Return functional form index of interaction
 	SpeciesAngle::AngleFunction form() const;
 	// Return array of parameters

--- a/src/data/ffbondterm.cpp
+++ b/src/data/ffbondterm.cpp
@@ -45,7 +45,7 @@ ForcefieldBondTerm::~ForcefieldBondTerm()
  */
 
 // Return if this term matches the atom types supplied
-bool ForcefieldBondTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const
+bool ForcefieldBondTerm::isMatch(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const
 {
 	if (DissolveSys::sameWildString(typeI_, i->equivalentName()) && DissolveSys::sameWildString(typeJ_, j->equivalentName())) return true;
 	if (DissolveSys::sameWildString(typeJ_, i->equivalentName()) && DissolveSys::sameWildString(typeI_, j->equivalentName())) return true;

--- a/src/data/ffbondterm.cpp
+++ b/src/data/ffbondterm.cpp
@@ -24,7 +24,7 @@
 #include "data/ff.h"
 
 // Constructor
-ForcefieldBondTerm::ForcefieldBondTerm(const char* typeI, const char* typeJ, SpeciesBond::BondFunction form, double data0, double data1, double data2, double data3) : ListItem<ForcefieldBondTerm>()
+ForcefieldBondTerm::ForcefieldBondTerm(const char* typeI, const char* typeJ, SpeciesBond::BondFunction form, double data0, double data1, double data2, double data3)
 {
 	typeI_ = typeI;
 	typeJ_ = typeJ;
@@ -45,7 +45,7 @@ ForcefieldBondTerm::~ForcefieldBondTerm()
  */
 
 // Return if this term matches the atom types supplied
-bool ForcefieldBondTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j)
+bool ForcefieldBondTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const
 {
 	if (DissolveSys::sameWildString(typeI_, i->equivalentName()) && DissolveSys::sameWildString(typeJ_, j->equivalentName())) return true;
 	if (DissolveSys::sameWildString(typeJ_, i->equivalentName()) && DissolveSys::sameWildString(typeI_, j->equivalentName())) return true;

--- a/src/data/ffbondterm.h
+++ b/src/data/ffbondterm.h
@@ -31,7 +31,7 @@ class Forcefield;
 class ForcefieldAtomType;
 
 // Forcefield Bond Term
-class ForcefieldBondTerm : public ListItem<ForcefieldBondTerm>
+class ForcefieldBondTerm
 {
 	public:
 	// Constructor / Destructor
@@ -52,7 +52,7 @@ class ForcefieldBondTerm : public ListItem<ForcefieldBondTerm>
 
 	public:
 	// Return if this term matches the atom types supplied
-	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j);
+	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
 	// Return functional form index of interaction
 	SpeciesBond::BondFunction form() const;
 	// Return array of parameters

--- a/src/data/ffbondterm.h
+++ b/src/data/ffbondterm.h
@@ -52,7 +52,7 @@ class ForcefieldBondTerm
 
 	public:
 	// Return if this term matches the atom types supplied
-	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
+	bool isMatch(const ForcefieldAtomType* i, const ForcefieldAtomType* j) const;
 	// Return functional form index of interaction
 	SpeciesBond::BondFunction form() const;
 	// Return array of parameters

--- a/src/data/ffimproperterm.cpp
+++ b/src/data/ffimproperterm.cpp
@@ -24,7 +24,7 @@
 #include "data/ff.h"
 
 // Constructor
-ForcefieldImproperTerm::ForcefieldImproperTerm(const char* typeI, const char* typeJ, const char* typeK, const char* typeL, SpeciesImproper::ImproperFunction form, double data0, double data1, double data2, double data3) : ListItem<ForcefieldImproperTerm>()
+ForcefieldImproperTerm::ForcefieldImproperTerm(const char* typeI, const char* typeJ, const char* typeK, const char* typeL, SpeciesImproper::ImproperFunction form, double data0, double data1, double data2, double data3)
 {
 	typeI_ = typeI;
 	typeJ_ = typeJ;
@@ -47,7 +47,7 @@ ForcefieldImproperTerm::~ForcefieldImproperTerm()
  */
 
 // Return if this term matches the atom types supplied
-bool ForcefieldImproperTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l)
+bool ForcefieldImproperTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
 	if (DissolveSys::sameWildString(typeI_, i->equivalentName()) && DissolveSys::sameWildString(typeJ_, j->equivalentName()) && DissolveSys::sameWildString(typeK_, k->equivalentName()) && DissolveSys::sameWildString(typeL_, l->equivalentName())) return true;
 	if (DissolveSys::sameWildString(typeL_, i->equivalentName()) && DissolveSys::sameWildString(typeK_, j->equivalentName()) && DissolveSys::sameWildString(typeJ_, k->equivalentName()) && DissolveSys::sameWildString(typeI_, l->equivalentName())) return true;

--- a/src/data/ffimproperterm.cpp
+++ b/src/data/ffimproperterm.cpp
@@ -47,7 +47,7 @@ ForcefieldImproperTerm::~ForcefieldImproperTerm()
  */
 
 // Return if this term matches the atom types supplied
-bool ForcefieldImproperTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
+bool ForcefieldImproperTerm::isMatch(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
 	if (DissolveSys::sameWildString(typeI_, i->equivalentName()) && DissolveSys::sameWildString(typeJ_, j->equivalentName()) && DissolveSys::sameWildString(typeK_, k->equivalentName()) && DissolveSys::sameWildString(typeL_, l->equivalentName())) return true;
 	if (DissolveSys::sameWildString(typeL_, i->equivalentName()) && DissolveSys::sameWildString(typeK_, j->equivalentName()) && DissolveSys::sameWildString(typeJ_, k->equivalentName()) && DissolveSys::sameWildString(typeI_, l->equivalentName())) return true;

--- a/src/data/ffimproperterm.h
+++ b/src/data/ffimproperterm.h
@@ -52,7 +52,7 @@ class ForcefieldImproperTerm
 
 	public:
 	// Return if this term matches the atom types supplied
-	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
+	bool isMatch(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
 	// Return functional form index of interaction
 	SpeciesImproper::ImproperFunction form() const;
 	// Return array of parameters

--- a/src/data/ffimproperterm.h
+++ b/src/data/ffimproperterm.h
@@ -31,7 +31,7 @@ class Forcefield;
 class ForcefieldAtomType;
 
 // Forcefield Improper Term
-class ForcefieldImproperTerm : public ListItem<ForcefieldImproperTerm>
+class ForcefieldImproperTerm
 {
 	public:
 	// Constructor / Destructor
@@ -52,7 +52,7 @@ class ForcefieldImproperTerm : public ListItem<ForcefieldImproperTerm>
 
 	public:
 	// Return if this term matches the atom types supplied
-	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l);
+	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
 	// Return functional form index of interaction
 	SpeciesImproper::ImproperFunction form() const;
 	// Return array of parameters

--- a/src/data/fftorsionterm.cpp
+++ b/src/data/fftorsionterm.cpp
@@ -47,7 +47,7 @@ ForcefieldTorsionTerm::~ForcefieldTorsionTerm()
  */
 
 // Return if this term matches the atom types supplied
-bool ForcefieldTorsionTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
+bool ForcefieldTorsionTerm::isMatch(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
 	if (DissolveSys::sameWildString(typeI_, i->equivalentName()) && DissolveSys::sameWildString(typeJ_, j->equivalentName()) && DissolveSys::sameWildString(typeK_, k->equivalentName()) && DissolveSys::sameWildString(typeL_, l->equivalentName())) return true;
 	if (DissolveSys::sameWildString(typeL_, i->equivalentName()) && DissolveSys::sameWildString(typeK_, j->equivalentName()) && DissolveSys::sameWildString(typeJ_, k->equivalentName()) && DissolveSys::sameWildString(typeI_, l->equivalentName())) return true;

--- a/src/data/fftorsionterm.cpp
+++ b/src/data/fftorsionterm.cpp
@@ -24,7 +24,7 @@
 #include "data/ff.h"
 
 // Constructor
-ForcefieldTorsionTerm::ForcefieldTorsionTerm(const char* typeI, const char* typeJ, const char* typeK, const char* typeL, SpeciesTorsion::TorsionFunction form, double data0, double data1, double data2, double data3) : ListItem<ForcefieldTorsionTerm>()
+ForcefieldTorsionTerm::ForcefieldTorsionTerm(const char* typeI, const char* typeJ, const char* typeK, const char* typeL, SpeciesTorsion::TorsionFunction form, double data0, double data1, double data2, double data3)
 {
 	typeI_ = typeI;
 	typeJ_ = typeJ;
@@ -47,7 +47,7 @@ ForcefieldTorsionTerm::~ForcefieldTorsionTerm()
  */
 
 // Return if this term matches the atom types supplied
-bool ForcefieldTorsionTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l)
+bool ForcefieldTorsionTerm::matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const
 {
 	if (DissolveSys::sameWildString(typeI_, i->equivalentName()) && DissolveSys::sameWildString(typeJ_, j->equivalentName()) && DissolveSys::sameWildString(typeK_, k->equivalentName()) && DissolveSys::sameWildString(typeL_, l->equivalentName())) return true;
 	if (DissolveSys::sameWildString(typeL_, i->equivalentName()) && DissolveSys::sameWildString(typeK_, j->equivalentName()) && DissolveSys::sameWildString(typeJ_, k->equivalentName()) && DissolveSys::sameWildString(typeI_, l->equivalentName())) return true;

--- a/src/data/fftorsionterm.h
+++ b/src/data/fftorsionterm.h
@@ -31,7 +31,7 @@ class Forcefield;
 class ForcefieldAtomType;
 
 // Forcefield Torsion Term
-class ForcefieldTorsionTerm : public ListItem<ForcefieldTorsionTerm>
+class ForcefieldTorsionTerm
 {
 	public:
 	// Constructor / Destructor
@@ -52,7 +52,7 @@ class ForcefieldTorsionTerm : public ListItem<ForcefieldTorsionTerm>
 
 	public:
 	// Return if this term matches the atom types supplied
-	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l);
+	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
 	// Return functional form index of interaction
 	SpeciesTorsion::TorsionFunction form() const;
 	// Return array of parameters

--- a/src/data/fftorsionterm.h
+++ b/src/data/fftorsionterm.h
@@ -52,7 +52,7 @@ class ForcefieldTorsionTerm
 
 	public:
 	// Return if this term matches the atom types supplied
-	bool matches(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
+	bool isMatch(const ForcefieldAtomType* i, const ForcefieldAtomType* j, const ForcefieldAtomType* k, const ForcefieldAtomType* l) const;
 	// Return functional form index of interaction
 	SpeciesTorsion::TorsionFunction form() const;
 	// Return array of parameters


### PR DESCRIPTION
The ultimate goal of this PR was to remove the ListItem dependency from `ForcefieldBondTerm`, as part of issue #257.  As part of that process, this replaces the List of `ForcefieldBondTerm` with a std::vector.

Since the class was largely contained in this instance, it was possible to use a direct class and references, instead of needing a vector of `shared_ptr`.  The only price for this is that it's not possible to return NULL if bond term being searched for isn't present.  The appropriate solution hear would be to return an optional reference, but that will have to wait until either we add Boost or we upgrade to c++17.  In the meantime, I've put in a local `optional` to make the code clearer and to make it easier to find the locations that need updating when the dependencies change.

There's of Terms classes that will be updated in a later PR after this one, but I thought it was worth hammering out just one class at first and then use the final strategy on all of the other classes.