### PR TITLE
No List class for ForcefieldAtomType

### DIFF
--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -139,8 +139,15 @@ ForcefieldAtomType* Forcefield::atomTypeByName(const char* name, Element* elemen
 	for (int Z=startZ; Z<=endZ; ++Z)
 	{
 		// Go through types associated to the Element
-		for(ForcefieldAtomType& type : atomTypesByElementPrivate_[Z]) if (DissolveSys::sameString(type.name(), name)) return &type;
-	}
+		auto it = std::find_if(atomTypesByElementPrivate_[Z].begin(),
+				       atomTypesByElementPrivate_[Z].end(),
+				       [&name](ForcefieldAtomType& type) {
+					 return DissolveSys::sameString(type.name(), name);
+				       });
+                if (it != atomTypesByElementPrivate_[Z].end()) {
+                  return &it->get();
+                }
+        }
 
 	return NULL;
 }

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -93,9 +93,10 @@ ForcefieldAtomType* Forcefield::determineAtomType(SpeciesAtom* i, const std::vec
 	// Go through AtomTypes defined for the target's element, and check NETA scores
 	int bestScore = -1;
 	ForcefieldAtomType* bestType = NULL;
-	for(ForcefieldAtomType& type : atomTypes[i->element()->Z()])
+	for(const auto& typeRef : atomTypes[i->element()->Z()])
 	{
 		// Get the scoring for this type
+		auto& type = typeRef.get();
 		int score = type.neta().score(i);
 		if (score > bestScore)
 		{
@@ -152,7 +153,12 @@ ForcefieldAtomType* Forcefield::atomTypeById(int id, Element* element) const
 	for (int Z=startZ; Z<=endZ; ++Z)
 	{
 		// Go through types associated to the Element
-		for(ForcefieldAtomType& type : atomTypesByElementPrivate_[Z]) if (type.index() == id) return &type;
+		auto it = std::find_if(atomTypesByElementPrivate_[Z].begin(),
+				       atomTypesByElementPrivate_[Z].end(),
+				       [&id](ForcefieldAtomType& type) {
+					 return type.index() == id;
+				       });
+		if(it != atomTypesByElementPrivate_[Z].end()) return &it->get();
 	}
 
 	return NULL;

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -70,31 +70,23 @@ EnumOptions<Forcefield::ShortRangeType> Forcefield::shortRangeTypes()
 // Add new atom type with its own parameters
 void Forcefield::addAtomType(int Z, int index, const char* name, const char* netaDefinition, const char* description, double q, double data0, double data1, double data2, double data3)
 {
-	ForcefieldAtomType* atomType = new ForcefieldAtomType(this, Z, index, name, netaDefinition, description, q, data0, data1, data2, data3);
-
-	atomTypes_.own(atomType);
+	atomTypes_.emplace_back(this, Z, index, name, netaDefinition, description, q, data0, data1, data2, data3);
 	
-	atomTypesByElementPrivate_[Z].append(atomType);
+	atomTypesByElementPrivate_[Z].append(&atomTypes_.back());
 }
 
 // Add new atom type referencing existing parameters by name
 void Forcefield::addAtomType(int Z, int index, const char* name, const char* netaDefinition, const char* description, double q, const char* parameterReference)
 {
-	ForcefieldAtomType* atomType = new ForcefieldAtomType(this, Z, index, name, netaDefinition, description, q, parameterReference);
-
-	atomTypes_.own(atomType);
-	
-	atomTypesByElementPrivate_[Z].append(atomType);
+	atomTypesByElementPrivate_[Z].append(&atomTypes_.back());
 }
 
 // Copy existing atom type
 void Forcefield::copyAtomType(const ForcefieldAtomType& sourceType, const char* newTypeName, const char* netaDefinition, const char* equivalentName)
 {
-	ForcefieldAtomType* atomType = new ForcefieldAtomType(this, sourceType, newTypeName, netaDefinition, equivalentName);
-
-	atomTypes_.own(atomType);
+	atomTypes_.emplace_back(this, sourceType, newTypeName, netaDefinition, equivalentName);
 	
-	atomTypesByElementPrivate_[atomType->Z()].append(atomType);
+	atomTypesByElementPrivate_[atomTypes_.back().Z()].append(&atomTypes_.back());
 }
 
 // Determine and return atom type for specified SpeciesAtom from supplied Array of types

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -85,7 +85,7 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 	// Short-range parameter sets
 	List<ForcefieldParameters> shortRangeParameters_;
 	// Atom type data
-	List<ForcefieldAtomType> atomTypes_;
+	std::vector<ForcefieldAtomType> atomTypes_;
 	// Atom type data, grouped by element
 	Array< RefList<ForcefieldAtomType> > atomTypesByElementPrivate_;
 

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -23,6 +23,7 @@
 #define DISSOLVE_FORCEFIELD_H
 
 #include <algorithm>
+#include <functional>
 #include <tuple>
 #include <vector>
 #include "data/elements.h"
@@ -31,7 +32,6 @@
 #include "classes/speciesimproper.h"
 #include "classes/speciestorsion.h"
 #include "base/enumoptions.h"
-#include "templates/reflist.h"
 
 template<class T>using optional = std::tuple<T, bool>;
 
@@ -87,7 +87,7 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 	// Atom type data
 	std::vector<ForcefieldAtomType> atomTypes_;
 	// Atom type data, grouped by element
-	Array< RefList<ForcefieldAtomType> > atomTypesByElementPrivate_;
+	std::vector<std::vector<std::reference_wrapper<ForcefieldAtomType>>> atomTypesByElementPrivate_;
 
 	protected:
 	// Add short-range parameters
@@ -99,7 +99,7 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 	// Copy existing atom type
 	void copyAtomType(const ForcefieldAtomType& sourceType, const char* newTypeName, const char* netaDefinition = NULL, const char* equivalentName = NULL);
 	// Determine and return atom type for specified SpeciesAtom from supplied Array of types
-	static ForcefieldAtomType* determineAtomType(SpeciesAtom* i, const Array< RefList<ForcefieldAtomType> >& atomTypes);
+	static ForcefieldAtomType* determineAtomType(SpeciesAtom* i, const std::vector< std::vector<std::reference_wrapper<ForcefieldAtomType>>>& atomTypes);
 	// Determine and return atom type for specified SpeciesAtom
 	virtual ForcefieldAtomType* determineAtomType(SpeciesAtom* i) const;
 

--- a/src/data/ff/uff.cpp
+++ b/src/data/ff/uff.cpp
@@ -412,7 +412,8 @@ ForcefieldAtomType* Forcefield_UFF::determineAtomType(SpeciesAtom* i) const
 			break;
 		// Default - all elements with only one type
 		default:
-			return atomTypesByElementPrivate_.constAt(i->element()->Z()).firstItem();
+			ForcefieldAtomType& temp = atomTypesByElementPrivate_[i->element()->Z()].front();
+			return &temp;
 			break;
 	}
 

--- a/src/data/ff/uff.cpp
+++ b/src/data/ff/uff.cpp
@@ -412,8 +412,8 @@ ForcefieldAtomType* Forcefield_UFF::determineAtomType(SpeciesAtom* i) const
 			break;
 		// Default - all elements with only one type
 		default:
-			ForcefieldAtomType& temp = atomTypesByElementPrivate_[i->element()->Z()].front();
-			return &temp;
+			const auto& tempRef = atomTypesByElementPrivate_[i->element()->Z()].front();
+			return &tempRef.get();
 			break;
 	}
 

--- a/src/data/ffatomtype.cpp
+++ b/src/data/ffatomtype.cpp
@@ -25,7 +25,7 @@
 #include "neta/generator.h"
 
 // Constructors
-ForcefieldAtomType::ForcefieldAtomType(Forcefield* parent, int Z, int index, const char* name, const char* netaDefinition, const char* description, double q, double data0, double data1, double data2, double data3) : ElementReference(Z), ListItem<ForcefieldAtomType>()
+ForcefieldAtomType::ForcefieldAtomType(Forcefield* parent, int Z, int index, const char* name, const char* netaDefinition, const char* description, double q, double data0, double data1, double data2, double data3) : ElementReference(Z)
 {
 	index_ = index;
 	name_ = name;
@@ -40,7 +40,7 @@ ForcefieldAtomType::ForcefieldAtomType(Forcefield* parent, int Z, int index, con
 	// Generate NETA
 	if (!neta_.set(netaDefinition, parent)) Messenger::error("Failed to generate NETA for atom type '%s' in forcefield '%s' from string '%s'.\n", name_.get(), parent ? parent->name() : "???", netaDefinition);
 }
-ForcefieldAtomType::ForcefieldAtomType(Forcefield* parent, int Z, int index, const char* name, const char* netaDefinition, const char* description, double q, const char* parameterReference) : ElementReference(Z), ListItem<ForcefieldAtomType>()
+ForcefieldAtomType::ForcefieldAtomType(Forcefield* parent, int Z, int index, const char* name, const char* netaDefinition, const char* description, double q, const char* parameterReference) : ElementReference(Z)
 {
 	index_ = index;
 	name_ = name;
@@ -52,7 +52,7 @@ ForcefieldAtomType::ForcefieldAtomType(Forcefield* parent, int Z, int index, con
 	// Generate NETA
 	if (!neta_.set(netaDefinition, parent)) Messenger::error("Failed to generate NETA for atom type '%s' in forcefield '%s' from string '%s'.\n", name_.get(), parent ? parent->name() : "???", netaDefinition);
 }
-ForcefieldAtomType::ForcefieldAtomType(Forcefield* parent, const ForcefieldAtomType& sourceType, const char* newTypeName, const char* netaDefinition, const char* equivalentName) : ElementReference(sourceType.Z()), ListItem<ForcefieldAtomType>()
+ForcefieldAtomType::ForcefieldAtomType(Forcefield* parent, const ForcefieldAtomType& sourceType, const char* newTypeName, const char* netaDefinition, const char* equivalentName) : ElementReference(sourceType.Z())
 {
 	// Copy data from the supplied source
 	index_ = sourceType.index_;

--- a/src/data/ffatomtype.h
+++ b/src/data/ffatomtype.h
@@ -32,7 +32,7 @@ class Forcefield;
 class ForcefieldParameters;
 
 // Forcefield AtomType Base Class
-class ForcefieldAtomType : public ElementReference, public ListItem<ForcefieldAtomType>
+class ForcefieldAtomType : public ElementReference
 {
 	public:
 	// Constructors

--- a/src/neta/node.cpp
+++ b/src/neta/node.cpp
@@ -44,6 +44,13 @@ EnumOptions<NETANode::ComparisonOperator> NETANode::comparisonOperators()
 }
 
 // Constructors
+NETANode::NETANode() : ListItem<NETANode>()
+{
+	reverseLogic_ = false;
+	parent_ = nullptr;
+	nodeType_ = NETANode::BasicNode;
+}
+
 NETANode::NETANode(NETADefinition* parent, NETANode::NodeType type) : ListItem<NETANode>()
 {
 	reverseLogic_ = false;

--- a/src/neta/node.cpp
+++ b/src/neta/node.cpp
@@ -44,12 +44,6 @@ EnumOptions<NETANode::ComparisonOperator> NETANode::comparisonOperators()
 }
 
 // Constructors
-NETANode::NETANode() : ListItem<NETANode>()
-{
-	reverseLogic_ = false;
-	parent_ = nullptr;
-	nodeType_ = NETANode::BasicNode;
-}
 
 NETANode::NETANode(NETADefinition* parent, NETANode::NodeType type) : ListItem<NETANode>()
 {

--- a/src/neta/node.h
+++ b/src/neta/node.h
@@ -51,7 +51,7 @@ class NETANode : public ListItem<NETANode>
 	enum NETAResult { NoMatch = -1 };
 	// Constructor / Destructor
 	NETANode(NETADefinition* parent, NodeType type);
-	NETANode();
+	NETANode() = default;
 	virtual ~NETANode();
 
 

--- a/src/neta/node.h
+++ b/src/neta/node.h
@@ -51,6 +51,7 @@ class NETANode : public ListItem<NETANode>
 	enum NETAResult { NoMatch = -1 };
 	// Constructor / Destructor
 	NETANode(NETADefinition* parent, NodeType type);
+	NETANode();
 	virtual ~NETANode();
 
 


### PR DESCRIPTION
Remove the ListItem dependency from the ForcefieldAtomType class.

This is mostly just a changing of types, but there are two non-intuitive parts.

1) Storing ForcefieldAtomType in a vector requires that it supports the copy constructor which, eventually, requires that NETANode supports a default constructor.

2) `atomTypesByElementPrivate_` was changed from `Array< RefList<ForcefieldAtomType>` to `std::vector<std::vector<std::reference_wrapper<ForcefieldAtomType>>>` .  The `reference_wrapper` allows us to store references in the vector.  The price for this is that the type inference doesn't see through the `reference_wrapper`, so we need to manually declare the types at some points.