### PR TITLE
No list ffparameters

### DIFF
--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -22,8 +22,6 @@
 #ifndef DISSOLVE_SPECIES_H
 #define DISSOLVE_SPECIES_H
 
-#include "base/charstring.h"
-#include "base/version.h"
 #include "classes/atomtypelist.h"
 #include "classes/coordinateset.h"
 #include "classes/isotopologue.h"
@@ -36,6 +34,7 @@
 #include "io/import/coordinates.h"
 #include "templates/dynamicarray.h"
 #include "templates/objectstore.h"
+#include <memory>
 
 // Forward Declarations
 class Box;
@@ -247,15 +246,15 @@ class Species : public ListItem<Species>, public ObjectStore<Species>
 	 */
       private:
 	// Forcefield to source terms from
-	Forcefield *forcefield_;
+	std::shared_ptr<Forcefield> forcefield_;
 	// Auto-generate missing intramolecular terms, and remove invalid ones
 	bool autoUpdateIntramolecularTerms_;
 
       public:
 	// Set Forcefield to source terms from
-	void setForcefield(Forcefield *ff);
+	void setForcefield(std::shared_ptr<Forcefield> ff);
 	// Return Forcefield to source terms from
-	Forcefield *forcefield() const;
+	std::shared_ptr<Forcefield> forcefield() const;
 	// Set whether to auto-generate missing intramolecular terms, and remove invalid ones
 	void setAutoUpdateIntramolecularTerms(bool b);
 	// Return whether to auto-generate missing intramolecular terms, and remove invalid ones

--- a/src/classes/species_ff.cpp
+++ b/src/classes/species_ff.cpp
@@ -29,10 +29,10 @@
  */
 
 // Set Forcefield to source terms from
-void Species::setForcefield(Forcefield *ff) { forcefield_ = ff; }
+void Species::setForcefield(std::shared_ptr<Forcefield> ff) { forcefield_ = ff; }
 
 // Return Forcefield to source terms from
-Forcefield *Species::forcefield() const { return forcefield_; }
+std::shared_ptr<Forcefield> Species::forcefield() const { return forcefield_; }
 
 // Set whether to auto-generate missing intramolecular terms, and remove invalid ones
 void Species::setAutoUpdateIntramolecularTerms(bool b)

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -35,7 +35,7 @@
 #include "data/fftorsionterm.h"
 
 // Constructor / Destructor
-Forcefield::Forcefield() : ListItem<Forcefield>() {}
+Forcefield::Forcefield() {}
 
 Forcefield::~Forcefield() {}
 

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -105,22 +105,16 @@ ForcefieldAtomType *Forcefield::determineAtomType(SpeciesAtom *i, const std::vec
 ForcefieldAtomType *Forcefield::determineAtomType(SpeciesAtom *i) const { return determineAtomType(i, atomTypesByElementPrivate_); }
 
 // Ass short-range parameters
-void Forcefield::addParameters(const char *name, double data0, double data1, double data2, double data3)
-{
-	ForcefieldParameters *params = new ForcefieldParameters(name, data0, data1, data2, data3);
-
-	shortRangeParameters_.own(params);
-}
+void Forcefield::addParameters(const char *name, double data0, double data1, double data2, double data3) { shortRangeParameters_.emplace_back(name, data0, data1, data2, data3); }
 
 // Return named short-range parameters (if they exist)
-ForcefieldParameters *Forcefield::shortRangeParameters(const char *name) const
+const ForcefieldParameters *Forcefield::shortRangeParameters(const char *name) const
 {
-	ListIterator<ForcefieldParameters> paramsIterator(shortRangeParameters_);
-	while (ForcefieldParameters *params = paramsIterator.iterate())
-		if (DissolveSys::sameString(name, params->name()))
-			return params;
+	for (const ForcefieldParameters &params : shortRangeParameters_)
+		if (DissolveSys::sameString(name, params.name()))
+			return &params;
 
-	return NULL;
+	return nullptr;
 }
 
 // Return the named ForcefieldAtomType (if it exists)

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -20,7 +20,6 @@
 */
 
 #include "data/ff.h"
-#include "base/sysfunc.h"
 #include "classes/atomtype.h"
 #include "classes/box.h"
 #include "classes/coredata.h"
@@ -33,11 +32,6 @@
 #include "data/ffimproperterm.h"
 #include "data/ffparameters.h"
 #include "data/fftorsionterm.h"
-
-// Constructor / Destructor
-Forcefield::Forcefield() {}
-
-Forcefield::~Forcefield() {}
 
 /*
  * Definition

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -104,9 +104,9 @@ void Forcefield::addParameters(const char *name, double data0, double data1, dou
 // Return named short-range parameters (if they exist)
 const ForcefieldParameters *Forcefield::shortRangeParameters(const char *name) const
 {
-	for (const ForcefieldParameters &params : shortRangeParameters_)
-		if (DissolveSys::sameString(name, params.name()))
-			return &params;
+	auto it = std::find_if(shortRangeParameters_.begin(), shortRangeParameters_.end(), [&name](const ForcefieldParameters &params) { return DissolveSys::sameString(name, params.name()); });
+	if (it != shortRangeParameters_.end())
+		return &*it;
 
 	return nullptr;
 }

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -47,7 +47,7 @@ class Species;
 class SpeciesAtom;
 
 // Forcefield Base Class
-class Forcefield : public Elements, public ListItem<Forcefield>
+class Forcefield : public Elements
 {
       public:
 	// Constructor / Destructor

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -22,12 +22,17 @@
 #ifndef DISSOLVE_FORCEFIELD_H
 #define DISSOLVE_FORCEFIELD_H
 
-#include "base/enumoptions.h"
 #include "classes/speciesangle.h"
 #include "classes/speciesbond.h"
 #include "classes/speciesimproper.h"
 #include "classes/speciestorsion.h"
 #include "data/elements.h"
+#include "data/ffangleterm.h"
+#include "data/ffatomtype.h"
+#include "data/ffbondterm.h"
+#include "data/ffimproperterm.h"
+#include "data/ffparameters.h"
+#include "data/fftorsionterm.h"
 #include <algorithm>
 #include <functional>
 #include <tuple>
@@ -37,12 +42,6 @@ template <class T> using optional = std::tuple<T, bool>;
 
 // Forward Declarations
 class CoreData;
-class ForcefieldAngleTerm;
-class ForcefieldAtomType;
-class ForcefieldBondTerm;
-class ForcefieldImproperTerm;
-class ForcefieldParameters;
-class ForcefieldTorsionTerm;
 class Species;
 class SpeciesAtom;
 
@@ -51,8 +50,8 @@ class Forcefield : public Elements
 {
       public:
 	// Constructor / Destructor
-	Forcefield();
-	virtual ~Forcefield();
+	Forcefield() = default;
+	virtual ~Forcefield() = default;
 
 	/*
 	 * Definition
@@ -103,7 +102,7 @@ class Forcefield : public Elements
 
       public:
 	// Return named short-range parameters (if they exist)
-	const ForcefieldParameters* shortRangeParameters(const char* name) const;
+	const ForcefieldParameters *shortRangeParameters(const char *name) const;
 	// Return the named ForcefieldAtomType (if it exists)
 	virtual ForcefieldAtomType *atomTypeByName(const char *name, Element *element = NULL) const;
 	// Return the ForcefieldAtomType with specified id (if it exists)

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -81,7 +81,7 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 	 */
       protected:
 	// Short-range parameter sets
-	List<ForcefieldParameters> shortRangeParameters_;
+	std::vector<ForcefieldParameters> shortRangeParameters_;
 	// Atom type data
 	std::vector<ForcefieldAtomType> atomTypes_;
 	// Atom type data, grouped by element
@@ -103,7 +103,7 @@ class Forcefield : public Elements, public ListItem<Forcefield>
 
       public:
 	// Return named short-range parameters (if they exist)
-	ForcefieldParameters *shortRangeParameters(const char *name) const;
+	const ForcefieldParameters* shortRangeParameters(const char* name) const;
 	// Return the named ForcefieldAtomType (if it exists)
 	virtual ForcefieldAtomType *atomTypeByName(const char *name, Element *element = NULL) const;
 	// Return the ForcefieldAtomType with specified id (if it exists)

--- a/src/data/fflibrary.cpp
+++ b/src/data/fflibrary.cpp
@@ -80,6 +80,12 @@ std::shared_ptr<Forcefield> ForcefieldLibrary::forcefield(const char *name)
 		if (DissolveSys::sameString(ff->name(), name))
 			return ff;
 	}
+	auto it = std::find_if(forcefields().begin(),
+			       forcefields().end(),
+			       [&name](const std::shared_ptr<Forcefield> ff) {
+				 return DissolveSys::sameString(ff->name(), name);
+			       });
+	if (it == forcefields().end()) return nullptr;
 
-	return nullptr;
+	return *it;
 }

--- a/src/data/fflibrary.cpp
+++ b/src/data/fflibrary.cpp
@@ -73,19 +73,16 @@ std::vector<std::shared_ptr<Forcefield>> &ForcefieldLibrary::forcefields()
 }
 
 // Return named Forcefield, if it exists
-std::shared_ptr<Forcefield> ForcefieldLibrary::forcefield(const char *name)
+std::shared_ptr<Forcefield> ForcefieldLibrary::forcefield(const string name)
 {
 	for (auto &ff : forcefields())
 	{
-		if (DissolveSys::sameString(ff->name(), name))
+		if (DissolveSys::sameString(ff->name(), name.c_str()))
 			return ff;
 	}
-	auto it = std::find_if(forcefields().begin(),
-			       forcefields().end(),
-			       [&name](const std::shared_ptr<Forcefield> ff) {
-				 return DissolveSys::sameString(ff->name(), name);
-			       });
-	if (it == forcefields().end()) return nullptr;
+	auto it = std::find_if(forcefields().begin(), forcefields().end(), [&name](const std::shared_ptr<Forcefield> ff) { return DissolveSys::sameString(ff->name(), name.c_str()); });
+	if (it == forcefields().end())
+		return nullptr;
 
 	return *it;
 }

--- a/src/data/fflibrary.cpp
+++ b/src/data/fflibrary.cpp
@@ -35,7 +35,7 @@
 #include "data/ff/uff.h"
 
 // Static Members
-List<Forcefield> ForcefieldLibrary::forcefields_;
+std::vector<std::shared_ptr<Forcefield>> ForcefieldLibrary::forcefields_;
 
 /*
  * Private Functions
@@ -44,18 +44,18 @@ List<Forcefield> ForcefieldLibrary::forcefields_;
 // Register Forcefields for use
 void ForcefieldLibrary::registerForcefields()
 {
-	forcefields_.own(new Forcefield_OPLSAA2005_Alcohols);
-	forcefields_.own(new Forcefield_OPLSAA2005_Alkanes);
-	forcefields_.own(new Forcefield_OPLSAA2005_Alkenes);
-	forcefields_.own(new Forcefield_OPLSAA2005_Aromatics);
-	forcefields_.own(new Forcefield_OPLSAA2005_Diols);
-	forcefields_.own(new Forcefield_OPLSAA2005_NobleGases);
-	forcefields_.own(new Forcefield_OPLSAA2005_Triols);
-	forcefields_.own(new Forcefield_SPCFw);
-	forcefields_.own(new Forcefield_UFF);
-	forcefields_.own(new Forcefield_NTf2_Ludwig);
-	forcefields_.own(new Forcefield_Py5_Ludwig);
-	forcefields_.own(new Forcefield_Py4OH_Ludwig);
+	forcefields_.push_back(std::make_shared<Forcefield_OPLSAA2005_Alcohols>());
+	forcefields_.push_back(std::make_shared<Forcefield_OPLSAA2005_Alkanes>());
+	forcefields_.push_back(std::make_shared<Forcefield_OPLSAA2005_Alkenes>());
+	forcefields_.push_back(std::make_shared<Forcefield_OPLSAA2005_Aromatics>());
+	forcefields_.push_back(std::make_shared<Forcefield_OPLSAA2005_Diols>());
+	forcefields_.push_back(std::make_shared<Forcefield_OPLSAA2005_NobleGases>());
+	forcefields_.push_back(std::make_shared<Forcefield_OPLSAA2005_Triols>());
+	forcefields_.push_back(std::make_shared<Forcefield_SPCFw>());
+	forcefields_.push_back(std::make_shared<Forcefield_UFF>());
+	forcefields_.push_back(std::make_shared<Forcefield_NTf2_Ludwig>());
+	forcefields_.push_back(std::make_shared<Forcefield_Py5_Ludwig>());
+	forcefields_.push_back(std::make_shared<Forcefield_Py4OH_Ludwig>());
 }
 
 /*
@@ -63,22 +63,23 @@ void ForcefieldLibrary::registerForcefields()
  */
 
 // Return list of available Forcefields
-List<Forcefield> &ForcefieldLibrary::forcefields()
+std::vector<std::shared_ptr<Forcefield>> &ForcefieldLibrary::forcefields()
 {
 	// If the list is empty, we haven't yet constructed the list...
-	if (forcefields_.nItems() == 0)
+	if (forcefields_.empty())
 		registerForcefields();
 
 	return forcefields_;
 }
 
 // Return named Forcefield, if it exists
-Forcefield *ForcefieldLibrary::forcefield(const char *name)
+std::shared_ptr<Forcefield> ForcefieldLibrary::forcefield(const char *name)
 {
-	ListIterator<Forcefield> ffIterator(forcefields());
-	while (Forcefield *ff = ffIterator.iterate())
+	for (auto &ff : forcefields())
+	{
 		if (DissolveSys::sameString(ff->name(), name))
 			return ff;
+	}
 
-	return NULL;
+	return nullptr;
 }

--- a/src/data/fflibrary.h
+++ b/src/data/fflibrary.h
@@ -23,6 +23,7 @@
 #define DISSOLVE_FORCEFIELD_LIBRARY_H
 
 #include "data/ff.h"
+#include <memory>
 
 // Forward Declarations
 /* none */
@@ -32,7 +33,7 @@ class ForcefieldLibrary
 {
       private:
 	// List of all available forcefields
-	static List<Forcefield> forcefields_;
+	static std::vector<std::shared_ptr<Forcefield>> forcefields_;
 
       private:
 	// Register Forcefields for use
@@ -40,9 +41,9 @@ class ForcefieldLibrary
 
       public:
 	// Return list of available Forcefields
-	static List<Forcefield> &forcefields();
+	static std::vector<std::shared_ptr<Forcefield>> &forcefields();
 	// Return named Forcefield, if it exists
-	static Forcefield *forcefield(const char *name);
+	static std::shared_ptr<Forcefield> forcefield(const char *name);
 };
 
 #endif

--- a/src/data/fflibrary.h
+++ b/src/data/fflibrary.h
@@ -24,6 +24,7 @@
 
 #include "data/ff.h"
 #include <memory>
+#include <string>
 
 // Forward Declarations
 /* none */

--- a/src/data/fflibrary.h
+++ b/src/data/fflibrary.h
@@ -43,7 +43,7 @@ class ForcefieldLibrary
 	// Return list of available Forcefields
 	static std::vector<std::shared_ptr<Forcefield>> &forcefields();
 	// Return named Forcefield, if it exists
-	static std::shared_ptr<Forcefield> forcefield(const char *name);
+	static std::shared_ptr<Forcefield> forcefield(const string name);
 };
 
 #endif

--- a/src/gui/addforcefieldtermswizard_funcs.cpp
+++ b/src/gui/addforcefieldtermswizard_funcs.cpp
@@ -224,7 +224,7 @@ bool AddForcefieldTermsWizard::progressionAllowed(int index) const
 	switch (index)
 	{
 	case (AddForcefieldTermsWizard::SelectForcefieldPage):
-		return (ui_.ForcefieldWidget->currentForcefield() != nullptr);
+		return (!ui_.ForcefieldWidget->currentForcefield());
 	default:
 		break;
 	}

--- a/src/gui/addforcefieldtermswizard_funcs.cpp
+++ b/src/gui/addforcefieldtermswizard_funcs.cpp
@@ -224,7 +224,7 @@ bool AddForcefieldTermsWizard::progressionAllowed(int index) const
 	switch (index)
 	{
 	case (AddForcefieldTermsWizard::SelectForcefieldPage):
-		return (ui_.ForcefieldWidget->currentForcefield());
+		return (ui_.ForcefieldWidget->currentForcefield() != nullptr);
 	default:
 		break;
 	}
@@ -235,7 +235,7 @@ bool AddForcefieldTermsWizard::progressionAllowed(int index) const
 // Perform any necessary actions before moving to the next page
 bool AddForcefieldTermsWizard::prepareForNextPage(int currentIndex)
 {
-	Forcefield *ff = ui_.ForcefieldWidget->currentForcefield();
+	auto ff = ui_.ForcefieldWidget->currentForcefield();
 	switch (currentIndex)
 	{
 	case (AddForcefieldTermsWizard::SelectForcefieldPage):

--- a/src/gui/selectforcefielddialog.h
+++ b/src/gui/selectforcefielddialog.h
@@ -54,7 +54,7 @@ class SelectForcefieldDialog : public QDialog
 
       public:
 	// Run the dialog, returning the selected Forcefield
-	Forcefield *selectForcefield(Forcefield *currentFF);
+	std::shared_ptr<Forcefield> selectForcefield(std::shared_ptr<Forcefield> currentFF);
 };
 
 #endif

--- a/src/gui/selectforcefielddialog_funcs.cpp
+++ b/src/gui/selectforcefielddialog_funcs.cpp
@@ -46,7 +46,7 @@ void SelectForcefieldDialog::on_SelectButton_clicked(bool checked) { accept(); }
 void SelectForcefieldDialog::on_CancelButton_clicked(bool checked) { reject(); }
 
 // Run the dialog, returning the selected Forcefield
-Forcefield *SelectForcefieldDialog::selectForcefield(Forcefield *currentFF)
+std::shared_ptr<Forcefield> SelectForcefieldDialog::selectForcefield(std::shared_ptr<Forcefield> currentFF)
 {
 	ui_.ForcefieldWidget->setCurrentForcefield(currentFF);
 

--- a/src/gui/selectforcefieldwidget.h
+++ b/src/gui/selectforcefieldwidget.h
@@ -27,6 +27,9 @@
 #include "templates/list.h"
 #include <QWidget>
 
+Q_DECLARE_SMART_POINTER_METATYPE(std::shared_ptr)
+Q_DECLARE_METATYPE(std::shared_ptr<Forcefield>)
+
 // Forward Declarations
 class Dissolve;
 class Forcefield;
@@ -38,7 +41,7 @@ class SelectForcefieldWidget : public QWidget
 
       public:
 	// Constructor
-	SelectForcefieldWidget(QWidget *parent, const List<Forcefield> &forcefields = ForcefieldLibrary::forcefields());
+	SelectForcefieldWidget(QWidget *parent, const std::vector<std::shared_ptr<Forcefield>> &forcefields = ForcefieldLibrary::forcefields());
 	// Destructor
 	~SelectForcefieldWidget();
 
@@ -46,13 +49,13 @@ class SelectForcefieldWidget : public QWidget
 	// Main form declaration
 	Ui::SelectForcefieldWidget ui_;
 	// Available forcefields
-	const List<Forcefield> &forcefields_;
+	const std::vector<std::shared_ptr<Forcefield>> &forcefields_;
 	// Whether the widget is refreshing
 	bool refreshing_;
 
       private:
 	// Update the list of Forcefields, optionally filtering them by name and description
-	void updateForcefieldsList(Forcefield *current = NULL, QString filter = QString());
+	void updateForcefieldsList(std::shared_ptr<Forcefield> current = NULL, QString filter = QString());
 
       private slots:
 	void on_FilterEdit_textChanged(const QString &text);
@@ -65,9 +68,9 @@ class SelectForcefieldWidget : public QWidget
 
       public:
 	// Set the current forcefield
-	void setCurrentForcefield(Forcefield *currentFF);
+	void setCurrentForcefield(std::shared_ptr<Forcefield> currentFF);
 	// Return the currently-selected Forcefield
-	Forcefield *currentForcefield() const;
+	std::shared_ptr<Forcefield> currentForcefield() const;
 };
 
 #endif

--- a/src/gui/selectforcefieldwidget_funcs.cpp
+++ b/src/gui/selectforcefieldwidget_funcs.cpp
@@ -25,18 +25,17 @@
 #include <QRegExp>
 
 // Constructor
-SelectForcefieldWidget::SelectForcefieldWidget(QWidget *parent, const List<Forcefield> &forcefields) : QWidget(parent), forcefields_(forcefields)
+SelectForcefieldWidget::SelectForcefieldWidget(QWidget *parent, const std::vector<std::shared_ptr<Forcefield>> &forcefields) : QWidget(parent), forcefields_(forcefields)
 {
 	ui_.setupUi(this);
 
 	refreshing_ = true;
 
 	// Populate the list with available forcefields
-	ListIterator<Forcefield> forcefieldIterator(forcefields_);
-	while (Forcefield *ff = forcefieldIterator.iterate())
+	for (std::shared_ptr<Forcefield> ff : forcefields_)
 	{
 		QListWidgetItem *item = new QListWidgetItem(ff->name(), ui_.ForcefieldsList);
-		item->setData(Qt::UserRole, VariantPointer<Forcefield>(ff));
+		item->setData(Qt::UserRole, QVariant::fromValue(ff));
 	}
 
 	refreshing_ = false;
@@ -46,7 +45,7 @@ SelectForcefieldWidget::SelectForcefieldWidget(QWidget *parent, const List<Force
 SelectForcefieldWidget::~SelectForcefieldWidget() {}
 
 // Update the list of Forcefields, optionally filtering them by name and description
-void SelectForcefieldWidget::updateForcefieldsList(Forcefield *current, QString filter)
+void SelectForcefieldWidget::updateForcefieldsList(std::shared_ptr<Forcefield> current, QString filter)
 {
 	// Loop over items in the list
 	for (int n = 0; n < ui_.ForcefieldsList->count(); ++n)
@@ -54,7 +53,7 @@ void SelectForcefieldWidget::updateForcefieldsList(Forcefield *current, QString 
 		QListWidgetItem *item = ui_.ForcefieldsList->item(n);
 		if (!item)
 			continue;
-		Forcefield *ff = VariantPointer<Forcefield>(item->data(Qt::UserRole));
+		std::shared_ptr<Forcefield> ff = item->data(Qt::UserRole).value<std::shared_ptr<Forcefield>>();
 		if (ff == current)
 		{
 			ui_.ForcefieldsList->setCurrentRow(n);
@@ -100,7 +99,7 @@ void SelectForcefieldWidget::on_ForcefieldsList_currentItemChanged(QListWidgetIt
 	}
 
 	// Get the selected forcefield
-	Forcefield *ff = VariantPointer<Forcefield>(current->data(Qt::UserRole));
+	std::shared_ptr<Forcefield> ff = current->data(Qt::UserRole).value<std::shared_ptr<Forcefield>>();
 
 	// Update the informational text
 	ui_.ForcefieldDetailsTextEdit->setText(ff->description());
@@ -117,14 +116,14 @@ void SelectForcefieldWidget::on_ForcefieldsList_itemDoubleClicked(QListWidgetIte
 }
 
 // Set the current forcefield
-void SelectForcefieldWidget::setCurrentForcefield(Forcefield *currentFF) { updateForcefieldsList(currentFF, ui_.FilterEdit->text()); }
+void SelectForcefieldWidget::setCurrentForcefield(std::shared_ptr<Forcefield> currentFF) { updateForcefieldsList(currentFF, ui_.FilterEdit->text()); }
 
 // Return the currently-selected Forcefield
-Forcefield *SelectForcefieldWidget::currentForcefield() const
+std::shared_ptr<Forcefield> SelectForcefieldWidget::currentForcefield() const
 {
 	QListWidgetItem *item = ui_.ForcefieldsList->currentItem();
 	if (item == NULL)
 		return NULL;
 
-	return VariantPointer<Forcefield>(item->data(Qt::UserRole));
+	return item->data(Qt::UserRole).value<std::shared_ptr<Forcefield>>();
 }

--- a/src/neta/node.cpp
+++ b/src/neta/node.cpp
@@ -39,7 +39,6 @@ EnumOptions<NETANode::ComparisonOperator> NETANode::comparisonOperators()
 }
 
 // Constructors
-
 NETANode::NETANode(NETADefinition *parent, NETANode::NodeType type) : ListItem<NETANode>()
 {
 	reverseLogic_ = false;


### PR DESCRIPTION
This removes the last references to the List class in the Forcefields classes.

This is mostly just converting types, changing names, and upgrading to algorithms.  The most surprising change is likely to be the `Q_DECLARE_SMART_POINTER_METATYPE` and `Q_DECLARE_METATYPE` in selectforcefieldwidget.h.  These were necessary to allow shared pointers to Forcefield to be stored in a QVariant.