### PR TITLE
Add XRay - Part 2a

### DIFF
--- a/Recent.md
+++ b/Recent.md
@@ -1,0 +1,5 @@
+## Release 0.7.0
+
+### Incompatibilities with 0.6.X
+
+- The `Weights` class is now known as `NeutronWeights` in order to make way for the new `XRayWeights` class. Existing restart files will still contain references to `Weights`, which can be search/replaced to `NeutronWeights` to allow compatibility with 0.7.X.

--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(classes
   speciesring.cpp
   speciessite.cpp
   speciestorsion.cpp
+  xrayweights.cpp
   
   atom.h
   atomtypedata.h
@@ -122,6 +123,7 @@ add_library(classes
   speciesring.h
   speciessite.h
   speciestorsion.h
+  xrayweights.h
 )
 
 include_directories(

--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(classes
   masterintra.cpp
   molecule.cpp
   moleculedistributor.cpp
+  neutronweights.cpp
   pairpotential.cpp
   potentialmap.cpp
   partialset.cpp
@@ -67,7 +68,6 @@ add_library(classes
   speciesring.cpp
   speciessite.cpp
   speciestorsion.cpp
-  weights.cpp
   
   atom.h
   atomtypedata.h
@@ -102,6 +102,7 @@ add_library(classes
   masterintra.h
   molecule.h
   moleculedistributor.h
+  neutronweights.h
   pairpotential.h
   potentialmap.h
   partialset.h
@@ -121,7 +122,6 @@ add_library(classes
   speciesring.h
   speciessite.h
   speciestorsion.h
-  weights.h
 )
 
 include_directories(

--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -38,9 +38,8 @@ IsotopologueCollection::~IsotopologueCollection() {}
 // Remove any sets from the collection that are empty
 void IsotopologueCollection::pruneEmptySets()
 {
-	std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(), [&](IsotopologueSet &set) {
-		return set.nIsotopologues() == 0;
-	});
+	std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
+		       [&](IsotopologueSet &set) { return set.nIsotopologues() == 0; });
 }
 
 // Clear all existing data
@@ -51,9 +50,8 @@ void IsotopologueCollection::add(Configuration *cfg, Isotopologue *iso, double r
 {
 	printf("TRYING TO ADD ISO %s TO CFG %s...\n", iso->name(), cfg->name());
 	// Check if a set already exists for this Configuration
-	auto it = std::find_if(isotopologueSets_.begin(), isotopologueSets_.end(), [&](IsotopologueSet &set) {
-		return set.configuration() == cfg;
-	});
+	auto it = std::find_if(isotopologueSets_.begin(), isotopologueSets_.end(),
+			       [&](IsotopologueSet &set) { return set.configuration() == cfg; });
 	if (it == isotopologueSets_.end())
 	{
 		isotopologueSets_.emplace_back(this, cfg);
@@ -66,17 +64,14 @@ void IsotopologueCollection::add(Configuration *cfg, Isotopologue *iso, double r
 // Remove the specified set from the collection
 void IsotopologueCollection::remove(IsotopologueSet *set)
 {
-	std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(), [&](IsotopologueSet &data) {
-		return &data == set;
-	});
+	std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(), [&](IsotopologueSet &data) { return &data == set; });
 }
 
 // Remove the Configuration from the collection
 void IsotopologueCollection::remove(Configuration *cfg)
 {
-	std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(), [&](IsotopologueSet &set) {
-		return set.configuration() == cfg;
-	});
+	std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
+		       [&](IsotopologueSet &set) { return set.configuration() == cfg; });
 }
 
 // Remove the Species from the specified set
@@ -119,18 +114,16 @@ const std::vector<IsotopologueSet> &IsotopologueCollection::isotopologueSets() c
 // Return whether a set exists for the supplied Configuration
 bool IsotopologueCollection::contains(const Configuration *cfg) const
 {
-	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(), [&](const IsotopologueSet &set) {
-		return set.configuration() == cfg;
-	});
+	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
+			       [&](const IsotopologueSet &set) { return set.configuration() == cfg; });
 	return (it != isotopologueSets_.end());
 }
 
 // Return IsotopologueSet for the specified Configuration
 optional<const IsotopologueSet> IsotopologueCollection::getIsotopologueSet(const Configuration *cfg) const
 {
-	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(), [&](const IsotopologueSet &set) {
-		return set.configuration() == cfg;
-	});
+	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
+			       [&](const IsotopologueSet &set) { return set.configuration() == cfg; });
 
 	return std::make_tuple(*it, it == isotopologueSets_.end());
 }
@@ -138,9 +131,8 @@ optional<const IsotopologueSet> IsotopologueCollection::getIsotopologueSet(const
 // Return whether the Species has a defined set of isotopologues in the specified Configuration
 bool IsotopologueCollection::contains(const Configuration *cfg, const Species *sp) const
 {
-	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(), [&](const IsotopologueSet &set) {
-		return set.configuration() == cfg;
-	});
+	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
+			       [&](const IsotopologueSet &set) { return set.configuration() == cfg; });
 
 	return (it != isotopologueSets_.end() ? it->contains(sp) : false);
 }
@@ -148,9 +140,8 @@ bool IsotopologueCollection::contains(const Configuration *cfg, const Species *s
 // Return Isotopologues for the Species in the specified Configuration
 optional<const Isotopologues> IsotopologueCollection::getIsotopologues(const Configuration *cfg, const Species *sp) const
 {
-	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(), [&](const IsotopologueSet &set) {
-		return set.configuration() == cfg;
-	});
+	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
+			       [&](const IsotopologueSet &set) { return set.configuration() == cfg; });
 
 	if (it != isotopologueSets_.end())
 		return it->getIsotopologues(sp);
@@ -165,10 +156,9 @@ void IsotopologueCollection::complete(const RefList<Configuration> &configuratio
 	for (Configuration *cfg : configurations)
 	{
 		// Retrieve / create a set for this Configuration
-		auto it = std::find_if(isotopologueSets_.begin(), isotopologueSets_.end(), [&](IsotopologueSet &set) {
-			return set.configuration() == cfg;
-		});
-		IsotopologueSet* setForCfg = nullptr;
+		auto it = std::find_if(isotopologueSets_.begin(), isotopologueSets_.end(),
+				       [&](IsotopologueSet &set) { return set.configuration() == cfg; });
+		IsotopologueSet *setForCfg = nullptr;
 		if (it == isotopologueSets_.end())
 		{
 			isotopologueSets_.emplace_back(this, cfg);

--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -38,8 +38,8 @@ IsotopologueCollection::~IsotopologueCollection() {}
 // Remove any sets from the collection that are empty
 void IsotopologueCollection::pruneEmptySets()
 {
-	std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-		       [&](IsotopologueSet &set) { return set.nIsotopologues() == 0; });
+	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
+		       [&](IsotopologueSet &set) { return set.nIsotopologues() == 0; }), isotopologueSets_.end());
 }
 
 // Clear all existing data
@@ -63,14 +63,14 @@ void IsotopologueCollection::add(Configuration *cfg, Isotopologue *iso, double r
 // Remove the specified set from the collection
 void IsotopologueCollection::remove(IsotopologueSet *set)
 {
-	std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(), [&](IsotopologueSet &data) { return &data == set; });
+	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(), [&](IsotopologueSet &data) { return &data == set; }), isotopologueSets_.end());
 }
 
 // Remove the Configuration from the collection
 void IsotopologueCollection::remove(Configuration *cfg)
 {
-	std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-		       [&](IsotopologueSet &set) { return set.configuration() == cfg; });
+	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
+		       [&](IsotopologueSet &set) { return set.configuration() == cfg; }), isotopologueSets_.end());
 }
 
 // Remove the Species from the specified set

--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -39,7 +39,8 @@ IsotopologueCollection::~IsotopologueCollection() {}
 void IsotopologueCollection::pruneEmptySets()
 {
 	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-		       [](IsotopologueSet &set) { return set.nIsotopologues() == 0; }), isotopologueSets_.end());
+					       [](IsotopologueSet &set) { return set.nIsotopologues() == 0; }),
+				isotopologueSets_.end());
 }
 
 // Clear all existing data
@@ -64,14 +65,19 @@ void IsotopologueCollection::add(Configuration *cfg, Isotopologue *iso, double r
 // Remove the specified set from the collection
 void IsotopologueCollection::remove(IsotopologueSet *set)
 {
-	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(), [set](IsotopologueSet &data) { return &data == set; }), isotopologueSets_.end());
+	printf("REMOVINT SET %p (%p)\n", set, &isotopologueSets_[0]);
+	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
+					       [set](IsotopologueSet &data) { return &data == set; }),
+				isotopologueSets_.end());
+	printf("NUMBER of set now in data is %i\n", isotopologueSets_.size());
 }
 
 // Remove the Configuration from the collection
 void IsotopologueCollection::remove(Configuration *cfg)
 {
 	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-		       [cfg](IsotopologueSet &set) { return set.configuration() == cfg; }), isotopologueSets_.end());
+					       [cfg](IsotopologueSet &set) { return set.configuration() == cfg; }),
+				isotopologueSets_.end());
 }
 
 // Remove the Species from the specified set
@@ -109,13 +115,16 @@ void IsotopologueCollection::remove(Isotopologue *iso)
 }
 
 // Return defined sets
-const std::vector<IsotopologueSet> &IsotopologueCollection::isotopologueSets() const { return isotopologueSets_; }
+std::vector<IsotopologueSet> &IsotopologueCollection::isotopologueSets() { return isotopologueSets_; }
+
+// Return defined sets (const)
+const std::vector<IsotopologueSet> &IsotopologueCollection::constIsotopologueSets() const { return isotopologueSets_; }
 
 // Return whether a set exists for the supplied Configuration
 bool IsotopologueCollection::contains(const Configuration *cfg) const
 {
 	return std::any_of(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
-			       [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
+			   [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
 }
 
 // Return IsotopologueSet for the specified Configuration

--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -48,7 +48,6 @@ void IsotopologueCollection::clear() { isotopologueSets_.clear(); }
 // Add Isotopologue weight for the specified Configuration / Species
 void IsotopologueCollection::add(Configuration *cfg, Isotopologue *iso, double relativeWeight)
 {
-	printf("TRYING TO ADD ISO %s TO CFG %s...\n", iso->name(), cfg->name());
 	// Check if a set already exists for this Configuration
 	auto it = std::find_if(isotopologueSets_.begin(), isotopologueSets_.end(),
 			       [&](IsotopologueSet &set) { return set.configuration() == cfg; });

--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -113,9 +113,8 @@ const std::vector<IsotopologueSet> &IsotopologueCollection::isotopologueSets() c
 // Return whether a set exists for the supplied Configuration
 bool IsotopologueCollection::contains(const Configuration *cfg) const
 {
-	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
+	return std::any_of(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
 			       [&](const IsotopologueSet &set) { return set.configuration() == cfg; });
-	return (it != isotopologueSets_.end());
 }
 
 // Return IsotopologueSet for the specified Configuration

--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -39,7 +39,7 @@ IsotopologueCollection::~IsotopologueCollection() {}
 void IsotopologueCollection::pruneEmptySets()
 {
 	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-		       [&](IsotopologueSet &set) { return set.nIsotopologues() == 0; }), isotopologueSets_.end());
+		       [](IsotopologueSet &set) { return set.nIsotopologues() == 0; }), isotopologueSets_.end());
 }
 
 // Clear all existing data
@@ -50,7 +50,8 @@ void IsotopologueCollection::add(Configuration *cfg, Isotopologue *iso, double r
 {
 	// Check if a set already exists for this Configuration
 	auto it = std::find_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-			       [&](IsotopologueSet &set) { return set.configuration() == cfg; });
+			       [cfg](IsotopologueSet &set) { return set.configuration() == cfg; });
+
 	if (it == isotopologueSets_.end())
 	{
 		isotopologueSets_.emplace_back(this, cfg);
@@ -63,14 +64,14 @@ void IsotopologueCollection::add(Configuration *cfg, Isotopologue *iso, double r
 // Remove the specified set from the collection
 void IsotopologueCollection::remove(IsotopologueSet *set)
 {
-	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(), [&](IsotopologueSet &data) { return &data == set; }), isotopologueSets_.end());
+	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(), [set](IsotopologueSet &data) { return &data == set; }), isotopologueSets_.end());
 }
 
 // Remove the Configuration from the collection
 void IsotopologueCollection::remove(Configuration *cfg)
 {
 	isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-		       [&](IsotopologueSet &set) { return set.configuration() == cfg; }), isotopologueSets_.end());
+		       [cfg](IsotopologueSet &set) { return set.configuration() == cfg; }), isotopologueSets_.end());
 }
 
 // Remove the Species from the specified set
@@ -114,14 +115,14 @@ const std::vector<IsotopologueSet> &IsotopologueCollection::isotopologueSets() c
 bool IsotopologueCollection::contains(const Configuration *cfg) const
 {
 	return std::any_of(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
-			       [&](const IsotopologueSet &set) { return set.configuration() == cfg; });
+			       [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
 }
 
 // Return IsotopologueSet for the specified Configuration
 optional<const IsotopologueSet> IsotopologueCollection::getIsotopologueSet(const Configuration *cfg) const
 {
 	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
-			       [&](const IsotopologueSet &set) { return set.configuration() == cfg; });
+			       [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
 
 	return std::make_tuple(*it, it == isotopologueSets_.end());
 }
@@ -130,7 +131,7 @@ optional<const IsotopologueSet> IsotopologueCollection::getIsotopologueSet(const
 bool IsotopologueCollection::contains(const Configuration *cfg, const Species *sp) const
 {
 	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
-			       [&](const IsotopologueSet &set) { return set.configuration() == cfg; });
+			       [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
 
 	return (it != isotopologueSets_.end() ? it->contains(sp) : false);
 }
@@ -139,7 +140,7 @@ bool IsotopologueCollection::contains(const Configuration *cfg, const Species *s
 optional<const Isotopologues> IsotopologueCollection::getIsotopologues(const Configuration *cfg, const Species *sp) const
 {
 	auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
-			       [&](const IsotopologueSet &set) { return set.configuration() == cfg; });
+			       [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
 
 	if (it != isotopologueSets_.end())
 		return it->getIsotopologues(sp);
@@ -155,7 +156,8 @@ void IsotopologueCollection::complete(const RefList<Configuration> &configuratio
 	{
 		// Retrieve / create a set for this Configuration
 		auto it = std::find_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-				       [&](IsotopologueSet &set) { return set.configuration() == cfg; });
+				       [cfg](IsotopologueSet &set) { return set.configuration() == cfg; });
+
 		IsotopologueSet *setForCfg = nullptr;
 		if (it == isotopologueSets_.end())
 		{

--- a/src/classes/isotopologuecollection.h
+++ b/src/classes/isotopologuecollection.h
@@ -69,7 +69,9 @@ class IsotopologueCollection : public GenericItemBase
 	// Remove any occurrences of the specified Isotopologue from the collection
 	void remove(Isotopologue *iso);
 	// Return defined sets
-	const std::vector<IsotopologueSet> &isotopologueSets() const;
+	std::vector<IsotopologueSet> &isotopologueSets();
+	// Return defined sets (const)
+	const std::vector<IsotopologueSet> &constIsotopologueSets() const;
 	// Return whether a set exists for the supplied Configuration
 	bool contains(const Configuration *cfg) const;
 	// Return IsotopologueSet for the specified Configuration

--- a/src/classes/isotopologuecollection.h
+++ b/src/classes/isotopologuecollection.h
@@ -24,7 +24,6 @@
 
 #include "classes/isotopologueset.h"
 #include "genericitems/base.h"
-#include "templates/list.h"
 #include "templates/reflist.h"
 
 // Forward Declarations

--- a/src/classes/isotopologuecollection.h
+++ b/src/classes/isotopologuecollection.h
@@ -19,8 +19,8 @@
 	along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef DISSOLVE_ISOTOPOLOGUECOLLETION_H
-#define DISSOLVE_ISOTOPOLOGUECOLLETION_H
+#ifndef DISSOLVE_ISOTOPOLOGUECOLLECTION_H
+#define DISSOLVE_ISOTOPOLOGUECOLLECTION_H
 
 #include "classes/isotopologueset.h"
 #include "genericitems/base.h"
@@ -46,7 +46,7 @@ class IsotopologueCollection : public GenericItemBase
 	 */
 	private:
 	// IsotopologueSets for individual Configurations
-	List<IsotopologueSet> isotopologueSets_;
+	std::vector<IsotopologueSet> isotopologueSets_;
 
 	private:
 	// Remove any sets from the collection that are empty
@@ -70,15 +70,15 @@ class IsotopologueCollection : public GenericItemBase
 	// Remove any occurrences of the specified Isotopologue from the collection
 	void remove(Isotopologue *iso);
 	// Return defined sets
-	List<IsotopologueSet> &isotopologueSets();
+	const std::vector<IsotopologueSet> &isotopologueSets() const;
 	// Return whether a set exists for the supplied Configuration
 	bool contains(const Configuration *cfg) const;
 	// Return IsotopologueSet for the specified Configuration
-	const IsotopologueSet *isotopologueSet(const Configuration *cfg) const;
+	optional<const IsotopologueSet> getIsotopologueSet(const Configuration *cfg) const;
 	// Return whether the Species has a defined set of isotopologues in the specified Configuration
 	bool contains(const Configuration *cfg, const Species *sp) const;
 	// Return Isotopologues for the Species in the specified Configuration
-	const Isotopologues *isotopologues(const Configuration *cfg, const Species *sp) const;
+	optional<const Isotopologues> getIsotopologues(const Configuration *cfg, const Species *sp) const;
 	// Complete the collection by making sure it contains every Species in every Configuration in the supplied list
 	void complete(const RefList<Configuration> &configurations);
 

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -117,7 +117,7 @@ bool Isotopologues::set(const Isotopologue *iso, double relativeWeight)
 
 	// Find the specified Isotopologue
 	auto it = std::find_if(mix_.begin(), mix_.end(),
-			       [&](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
+			       [iso](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
 
 	if (it == mix_.end())
 	{
@@ -138,20 +138,20 @@ bool Isotopologues::set(const Isotopologue *iso, double relativeWeight)
 void Isotopologues::remove(const Isotopologue *iso)
 {
 	mix_.erase(std::remove_if(mix_.begin(), mix_.end(),
-		       [&](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; }), mix_.end());
+		       [iso](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; }), mix_.end());
 }
 
 // Remove the specified IsotopologueWeight
 void Isotopologues::remove(IsotopologueWeight *isoWeight)
 {
-	mix_.erase(std::remove_if(mix_.begin(), mix_.end(), [&](IsotopologueWeight &data) { return isoWeight == &data; }), mix_.end());
+	mix_.erase(std::remove_if(mix_.begin(), mix_.end(), [isoWeight](IsotopologueWeight &data) { return isoWeight == &data; }), mix_.end());
 }
 
 // Return whether the mix contains the specified Isotopologue
 bool Isotopologues::contains(const Isotopologue *iso) const
 {
 	return std::any_of(mix_.cbegin(), mix_.cend(),
-			       [&](const IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
+			       [iso](const IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
 }
 
 // Return Isotopologue/weight mix

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -26,7 +26,7 @@
 #include "classes/coredata.h"
 #include "classes/species.h"
 
-Isotopologues::Isotopologues(Species* species, int speciesPopulation) : ListItem<Isotopologues>(), species_(species), speciesPopulation_(speciesPopulation) {}
+Isotopologues::Isotopologues(Species* species, int speciesPopulation) : species_(species), speciesPopulation_(speciesPopulation) {}
 
 Isotopologues::~Isotopologues() {}
 

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -27,7 +27,9 @@
 #include "classes/species.h"
 #include <algorithm>
 
-Isotopologues::Isotopologues(Species* species, int speciesPopulation) : species_(species), speciesPopulation_(speciesPopulation) {}
+Isotopologues::Isotopologues(Species *species, int speciesPopulation) : species_(species), speciesPopulation_(speciesPopulation)
+{
+}
 
 Isotopologues::~Isotopologues() {}
 
@@ -52,9 +54,8 @@ int Isotopologues::speciesPopulation() const { return speciesPopulation_; }
 void Isotopologues::pruneMissing()
 {
 	// Go through list of Isotopologues present in this mix, removing any that no longer exist
-	std::remove_if(mix_.begin(), mix_.end(), [&](IsotopologueWeight &isoWeight) {
-		return !species_->hasIsotopologue(isoWeight.isotopologue());
-	});
+	std::remove_if(mix_.begin(), mix_.end(),
+		       [&](IsotopologueWeight &isoWeight) { return !species_->hasIsotopologue(isoWeight.isotopologue()); });
 }
 
 // Add next available Isotopologue to list
@@ -115,9 +116,8 @@ bool Isotopologues::set(const Isotopologue *iso, double relativeWeight)
 	}
 
 	// Find the specified Isotopologue
-	auto it = std::find_if(mix_.begin(), mix_.end(), [&](IsotopologueWeight &isoWeight) {
-		return isoWeight.isotopologue() == iso;
-	});
+	auto it = std::find_if(mix_.begin(), mix_.end(),
+			       [&](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
 
 	if (it == mix_.end())
 	{
@@ -137,26 +137,23 @@ bool Isotopologues::set(const Isotopologue *iso, double relativeWeight)
 // Remove references to the specified Isotopologue
 void Isotopologues::remove(const Isotopologue *iso)
 {
-	std::remove_if(mix_.begin(), mix_.end(), [&](IsotopologueWeight &isoWeight) {
-		return isoWeight.isotopologue() == iso;
-	});
+	std::remove_if(mix_.begin(), mix_.end(),
+		       [&](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
 }
 
 // Remove the specified IsotopologueWeight
 void Isotopologues::remove(IsotopologueWeight *isoWeight)
 {
-	auto it = std::find_if(mix_.begin(), mix_.end(), [&](IsotopologueWeight &data) {
-		return isoWeight == &data;
-	});
-	if (it != mix_.end()) mix_.erase(it);
+	auto it = std::find_if(mix_.begin(), mix_.end(), [&](IsotopologueWeight &data) { return isoWeight == &data; });
+	if (it != mix_.end())
+		mix_.erase(it);
 }
 
 // Return whether the mix contains the specified Isotopologue
 bool Isotopologues::contains(const Isotopologue *iso) const
 {
-	auto it = std::find_if(mix_.cbegin(), mix_.cend(), [&](const IsotopologueWeight &isoWeight) {
-		return isoWeight.isotopologue() == iso;
-	});
+	auto it = std::find_if(mix_.cbegin(), mix_.cend(),
+			       [&](const IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
 
 	return (it != mix_.end());
 }

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -160,7 +160,10 @@ bool Isotopologues::contains(const Isotopologue *iso) const
 }
 
 // Return Isotopologue/weight mix
-const std::vector<IsotopologueWeight> &Isotopologues::mix() const { return mix_; }
+std::vector<IsotopologueWeight> &Isotopologues::mix() { return mix_; }
+
+// Return Isotopologue/weight mix (const)
+const std::vector<IsotopologueWeight> &Isotopologues::constMix() const { return mix_; }
 
 // Return number of Isotopologues in list
 int Isotopologues::nIsotopologues() const { return mix_.size(); }

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -54,8 +54,10 @@ int Isotopologues::speciesPopulation() const { return speciesPopulation_; }
 void Isotopologues::pruneMissing()
 {
 	// Go through list of Isotopologues present in this mix, removing any that no longer exist
-	mix_.erase(std::remove_if(mix_.begin(), mix_.end(),
-		       [&](IsotopologueWeight &isoWeight) { return !species_->hasIsotopologue(isoWeight.isotopologue()); }), mix_.end());
+	mix_.erase(std::remove_if(
+			   mix_.begin(), mix_.end(),
+			   [&](IsotopologueWeight &isoWeight) { return !species_->hasIsotopologue(isoWeight.isotopologue()); }),
+		   mix_.end());
 }
 
 // Add next available Isotopologue to list
@@ -138,20 +140,23 @@ bool Isotopologues::set(const Isotopologue *iso, double relativeWeight)
 void Isotopologues::remove(const Isotopologue *iso)
 {
 	mix_.erase(std::remove_if(mix_.begin(), mix_.end(),
-		       [iso](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; }), mix_.end());
+				  [iso](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; }),
+		   mix_.end());
 }
 
 // Remove the specified IsotopologueWeight
 void Isotopologues::remove(IsotopologueWeight *isoWeight)
 {
-	mix_.erase(std::remove_if(mix_.begin(), mix_.end(), [isoWeight](IsotopologueWeight &data) { return isoWeight == &data; }), mix_.end());
+	mix_.erase(
+		std::remove_if(mix_.begin(), mix_.end(), [isoWeight](IsotopologueWeight &data) { return isoWeight == &data; }),
+		mix_.end());
 }
 
 // Return whether the mix contains the specified Isotopologue
 bool Isotopologues::contains(const Isotopologue *iso) const
 {
 	return std::any_of(mix_.cbegin(), mix_.cend(),
-			       [iso](const IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
+			   [iso](const IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
 }
 
 // Return Isotopologue/weight mix

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -152,10 +152,8 @@ void Isotopologues::remove(IsotopologueWeight *isoWeight)
 // Return whether the mix contains the specified Isotopologue
 bool Isotopologues::contains(const Isotopologue *iso) const
 {
-	auto it = std::find_if(mix_.cbegin(), mix_.cend(),
+	return std::any_of(mix_.cbegin(), mix_.cend(),
 			       [&](const IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
-
-	return (it != mix_.end());
 }
 
 // Return Isotopologue/weight mix

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -54,8 +54,8 @@ int Isotopologues::speciesPopulation() const { return speciesPopulation_; }
 void Isotopologues::pruneMissing()
 {
 	// Go through list of Isotopologues present in this mix, removing any that no longer exist
-	std::remove_if(mix_.begin(), mix_.end(),
-		       [&](IsotopologueWeight &isoWeight) { return !species_->hasIsotopologue(isoWeight.isotopologue()); });
+	mix_.erase(std::remove_if(mix_.begin(), mix_.end(),
+		       [&](IsotopologueWeight &isoWeight) { return !species_->hasIsotopologue(isoWeight.isotopologue()); }), mix_.end());
 }
 
 // Add next available Isotopologue to list
@@ -137,8 +137,8 @@ bool Isotopologues::set(const Isotopologue *iso, double relativeWeight)
 // Remove references to the specified Isotopologue
 void Isotopologues::remove(const Isotopologue *iso)
 {
-	std::remove_if(mix_.begin(), mix_.end(),
-		       [&](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
+	mix_.erase(std::remove_if(mix_.begin(), mix_.end(),
+		       [&](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; }), mix_.end());
 }
 
 // Remove the specified IsotopologueWeight

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -144,9 +144,7 @@ void Isotopologues::remove(const Isotopologue *iso)
 // Remove the specified IsotopologueWeight
 void Isotopologues::remove(IsotopologueWeight *isoWeight)
 {
-	auto it = std::find_if(mix_.begin(), mix_.end(), [&](IsotopologueWeight &data) { return isoWeight == &data; });
-	if (it != mix_.end())
-		mix_.erase(it);
+	mix_.erase(std::remove_if(mix_.begin(), mix_.end(), [&](IsotopologueWeight &data) { return isoWeight == &data; }), mix_.end());
 }
 
 // Return whether the mix contains the specified Isotopologue

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -26,11 +26,7 @@
 #include "classes/coredata.h"
 #include "classes/species.h"
 
-Isotopologues::Isotopologues() : ListItem<Isotopologues>()
-{
-	species_ = NULL;
-	speciesPopulation_ = 0;
-}
+Isotopologues::Isotopologues(Species* species, int speciesPopulation) : ListItem<Isotopologues>(), species_(species), speciesPopulation_(speciesPopulation) {}
 
 Isotopologues::~Isotopologues() {}
 

--- a/src/classes/isotopologues.h
+++ b/src/classes/isotopologues.h
@@ -72,7 +72,9 @@ class Isotopologues : public GenericItemBase
 	// Return whether the mix contains the specified Isotopologue
 	bool contains(const Isotopologue *iso) const;
 	// Return Isotopologue/weight mix
-	const std::vector<IsotopologueWeight> &mix() const;
+	std::vector<IsotopologueWeight> &mix();
+	// Return Isotopologue/weight mix (const)
+	const std::vector<IsotopologueWeight> &constMix() const;
 	// Return number of Isotopologues in mix
 	int nIsotopologues() const;
 	// Return total relative population

--- a/src/classes/isotopologues.h
+++ b/src/classes/isotopologues.h
@@ -24,7 +24,7 @@
 
 #include "classes/isotopologueweight.h"
 #include "genericitems/base.h"
-#include "templates/list.h"
+#include <vector>
 
 // Forward Declarations
 class Species;
@@ -48,7 +48,7 @@ class Isotopologues : public GenericItemBase
 	// Integer population of associated Species
 	int speciesPopulation_;
 	// Weighted Isotopologue mixture
-	List<IsotopologueWeight> mix_;
+	std::vector<IsotopologueWeight> mix_;
 
 	public:
 	// Set associated Species and population
@@ -57,12 +57,12 @@ class Isotopologues : public GenericItemBase
 	Species *species() const;
 	// Return associated Species population
 	int speciesPopulation() const;
-	// Update Isotopologue RefList
-	void update();
+	/// Prune defunct Isotopologue entries
+	void pruneMissing();
 	// Add next available Isotopologue to list
 	bool addNext();
 	// Add specific Isotopologue to list
-	bool add(const Isotopologue *iso, double relativeWeight);
+	void add(const Isotopologue *iso, double relativeWeight);
 	// Set Isotopologue component in list
 	bool set(const Isotopologue *iso, double relativeWeight);
 	// Remove references to the specified Isotopologue
@@ -70,9 +70,9 @@ class Isotopologues : public GenericItemBase
 	// Remove the specified IsotopologueWeight
 	void remove(IsotopologueWeight *isoWeight);
 	// Return whether the mix contains the specified Isotopologue
-	const IsotopologueWeight *contains(const Isotopologue *iso) const;
-	// Return Isotopologue mix
-	const List<IsotopologueWeight> &mix() const;
+	bool contains(const Isotopologue *iso) const;
+	// Return Isotopologue/weight mix
+	const std::vector<IsotopologueWeight> &mix() const;
 	// Return number of Isotopologues in mix
 	int nIsotopologues() const;
 	// Return total relative population

--- a/src/classes/isotopologues.h
+++ b/src/classes/isotopologues.h
@@ -36,7 +36,7 @@ class LineParser;
 class Isotopologues : public ListItem<Isotopologues>, public GenericItemBase
 {
 	public:
-	Isotopologues();
+	Isotopologues(Species* species = nullptr, int speciesPopulation = 0);
 	~Isotopologues();
 
 	/*

--- a/src/classes/isotopologues.h
+++ b/src/classes/isotopologues.h
@@ -33,7 +33,7 @@ class ProcessPool;
 class LineParser;
 
 // Isotopologues
-class Isotopologues : public ListItem<Isotopologues>, public GenericItemBase
+class Isotopologues : public GenericItemBase
 {
 	public:
 	Isotopologues(Species* species = nullptr, int speciesPopulation = 0);

--- a/src/classes/isotopologues.h
+++ b/src/classes/isotopologues.h
@@ -36,7 +36,7 @@ class LineParser;
 class Isotopologues : public GenericItemBase
 {
 	public:
-	Isotopologues(Species* species = nullptr, int speciesPopulation = 0);
+	Isotopologues(Species *species = nullptr, int speciesPopulation = 0);
 	~Isotopologues();
 
 	/*

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -65,7 +65,7 @@ Configuration *IsotopologueSet::configuration() const { return configuration_; }
 void IsotopologueSet::add(Isotopologue *iso, double relativeWeight)
 {
 	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(),
-			       [&](Isotopologues &data) { return data.species() == iso->parent(); });
+			       [iso](Isotopologues &data) { return data.species() == iso->parent(); });
 	if (it != isotopologues_.end())
 		it->add(iso, relativeWeight);
 	else
@@ -78,7 +78,7 @@ void IsotopologueSet::add(Isotopologue *iso, double relativeWeight)
 // Remove specified Species from the list (if it exists)
 void IsotopologueSet::remove(Species *sp)
 {
-	isotopologues_.erase(std::remove_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) { return data.species() == sp; }), isotopologues_.end());
+	isotopologues_.erase(std::remove_if(isotopologues_.begin(), isotopologues_.end(), [sp](Isotopologues &data) { return data.species() == sp; }), isotopologues_.end());
 }
 
 // Remove any occurrences of the specified Isotopologue
@@ -86,7 +86,7 @@ void IsotopologueSet::remove(Isotopologue *iso)
 {
 	// Get parent Isotopologues from the contained Species pointer
 	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(),
-			       [&](Isotopologues &data) { return data.species() == iso->parent(); });
+			       [iso](Isotopologues &data) { return data.species() == iso->parent(); });
 
 	if (it != isotopologues_.end())
 	{
@@ -103,7 +103,7 @@ void IsotopologueSet::remove(IsotopologueWeight *isoWeight)
 {
 	// Get Isotopologues related to the IsotopologueWeight's Species pointer
 	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(),
-			       [&](Isotopologues &data) { return data.species() == isoWeight->isotopologue()->parent(); });
+			       [isoWeight](Isotopologues &data) { return data.species() == isoWeight->isotopologue()->parent(); });
 
 	if (it != isotopologues_.end())
 	{
@@ -119,14 +119,14 @@ void IsotopologueSet::remove(IsotopologueWeight *isoWeight)
 bool IsotopologueSet::contains(const Species *sp) const
 {
 	return std::any_of(isotopologues_.cbegin(), isotopologues_.cend(),
-			       [&](const Isotopologues &data) { return data.species() == sp; });
+			       [sp](const Isotopologues &data) { return data.species() == sp; });
 }
 
 // Return IsotopologueSet for the specified Species
 optional<const Isotopologues> IsotopologueSet::getIsotopologues(const Species *sp) const
 {
 	auto it = std::find_if(isotopologues_.cbegin(), isotopologues_.cend(),
-			       [&](const Isotopologues &data) { return data.species() == sp; });
+			       [sp](const Isotopologues &data) { return data.species() == sp; });
 
 	return std::make_tuple(*it, it == isotopologues_.end());
 }

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -78,7 +78,9 @@ void IsotopologueSet::add(Isotopologue *iso, double relativeWeight)
 // Remove specified Species from the list (if it exists)
 void IsotopologueSet::remove(Species *sp)
 {
-	isotopologues_.erase(std::remove_if(isotopologues_.begin(), isotopologues_.end(), [sp](Isotopologues &data) { return data.species() == sp; }), isotopologues_.end());
+	isotopologues_.erase(std::remove_if(isotopologues_.begin(), isotopologues_.end(),
+					    [sp](Isotopologues &data) { return data.species() == sp; }),
+			     isotopologues_.end());
 }
 
 // Remove any occurrences of the specified Isotopologue
@@ -102,8 +104,9 @@ void IsotopologueSet::remove(Isotopologue *iso)
 void IsotopologueSet::remove(IsotopologueWeight *isoWeight)
 {
 	// Get Isotopologues related to the IsotopologueWeight's Species pointer
-	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(),
-			       [isoWeight](Isotopologues &data) { return data.species() == isoWeight->isotopologue()->parent(); });
+	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(), [isoWeight](Isotopologues &data) {
+		return data.species() == isoWeight->isotopologue()->parent();
+	});
 
 	if (it != isotopologues_.end())
 	{
@@ -119,7 +122,7 @@ void IsotopologueSet::remove(IsotopologueWeight *isoWeight)
 bool IsotopologueSet::contains(const Species *sp) const
 {
 	return std::any_of(isotopologues_.cbegin(), isotopologues_.cend(),
-			       [sp](const Isotopologues &data) { return data.species() == sp; });
+			   [sp](const Isotopologues &data) { return data.species() == sp; });
 }
 
 // Return IsotopologueSet for the specified Species

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -138,7 +138,10 @@ optional<const Isotopologues> IsotopologueSet::getIsotopologues(const Species *s
 int IsotopologueSet::nIsotopologues() const { return isotopologues_.size(); }
 
 // Return vector of all Isotopologues
-const std::vector<Isotopologues> &IsotopologueSet::isotopologues() const { return isotopologues_; }
+std::vector<Isotopologues> &IsotopologueSet::isotopologues() { return isotopologues_; }
+
+// Return vector of all Isotopologues (const)
+const std::vector<Isotopologues> &IsotopologueSet::constIsotopologues() const { return isotopologues_; }
 
 /*
  * GenericItemBase Implementations

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -25,13 +25,9 @@
 #include "classes/configuration.h"
 #include "classes/coredata.h"
 #include "classes/species.h"
+#include <algorithm>
 
-IsotopologueSet::IsotopologueSet() : ListItem<IsotopologueSet>()
-{
-	parentCollection_ = NULL;
-
-	clear();
-}
+IsotopologueSet::IsotopologueSet(IsotopologueCollection* parent, Configuration* cfg) : ListItem<IsotopologueSet>(), parentCollection_(parent), configuration_(cfg) { }
 
 IsotopologueSet::~IsotopologueSet() {}
 
@@ -65,83 +61,87 @@ Configuration *IsotopologueSet::configuration() const { return configuration_; }
 // Add Isotopologue with the specified relative weight
 void IsotopologueSet::add(Isotopologue *iso, double relativeWeight)
 {
-	// Find the parent Species of the isotopologue in our list
-	Isotopologues *topes = NULL;
-	for (topes = isotopologues_.first(); topes != NULL; topes = topes->next())
-		if (topes->species() == iso->parent())
-			break;
-
-	// Create a new Isotopologues if we need it
-	if (!topes)
+	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) {
+		return data.species() == iso->parent();
+	});
+	if (it != isotopologues_.end())
+		it->add(iso, relativeWeight);
+	else
 	{
-		topes = isotopologues_.add();
-		topes->setSpecies(iso->parent(), 0);
+		isotopologues_.emplace_back(iso->parent(), 0);
+		isotopologues_.back().add(iso, relativeWeight);
 	}
-
-	topes->add(iso, relativeWeight);
 }
 
 // Remove specified Species from the list (if it exists)
 void IsotopologueSet::remove(Species *sp)
 {
-	Isotopologues *topes = isotopologues(sp);
-	if (topes)
-		isotopologues_.remove(topes);
+	std::remove_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) {
+		return data.species() == sp;
+	});
 }
 
 // Remove any occurrences of the specified Isotopologue
 void IsotopologueSet::remove(Isotopologue *iso)
 {
-	Isotopologues *topes = isotopologues(iso->parent());
-	if (topes)
-	{
-		topes->remove(iso);
+	// Get parent Isotopologues from the contained Species pointer
+	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) {
+		return data.species() == iso->parent();
+	});
 
-		// Check for an empty list...
-		if (topes->nIsotopologues() == 0)
-			isotopologues_.remove(topes);
+	if (it != isotopologues_.end())
+	{
+		it->remove(iso);
+
+		// Check for Isotopologues now being empty
+		if (it->nIsotopologues() == 0)
+			isotopologues_.erase(it);
 	}
 }
 
 // Remove the specified IsotopologueWeight
 void IsotopologueSet::remove(IsotopologueWeight *isoWeight)
 {
-	Isotopologues *topes = isotopologues(isoWeight->isotopologue()->parent());
-	if (topes)
-	{
-		topes->remove(isoWeight);
+	// Get Isotopologues related to the IsotopologueWeight's Species pointer
+	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) {
+		return data.species() == isoWeight->isotopologue()->parent();
+	});
 
-		// Check for an empty list...
-		if (topes->nIsotopologues() == 0)
-			isotopologues_.remove(topes);
+	if (it != isotopologues_.end())
+	{
+		it->remove(isoWeight);
+
+		// Check for Isotopologues now being empty
+		if (it->nIsotopologues() == 0)
+			isotopologues_.erase(it);
 	}
 }
 
-// Return whether an IsotopologueSet for the specified Species exists
+// Return whether Isotopologues for the specified Species exists
 bool IsotopologueSet::contains(const Species *sp) const
 {
-	for (Isotopologues *topes = isotopologues_.first(); topes != NULL; topes = topes->next())
-		if (topes->species() == sp)
-			return true;
+	auto it = std::find_if(isotopologues_.cbegin(), isotopologues_.cend(), [&](const Isotopologues &data) {
+		return data.species() == sp;
+	});
 
-	return false;
+	return (it != isotopologues_.end());
 }
 
 // Return IsotopologueSet for the specified Species
-Isotopologues *IsotopologueSet::isotopologues(const Species *sp)
+optional<const Isotopologues> IsotopologueSet::getIsotopologues(const Species *sp) const
 {
-	for (Isotopologues *topes = isotopologues_.first(); topes != NULL; topes = topes->next())
-		if (topes->species() == sp)
-			return topes;
+	auto it = std::find_if(isotopologues_.cbegin(), isotopologues_.cend(), [&](const Isotopologues &data) {
+		return data.species() == sp;
+	});
 
-	return NULL;
+	return std::make_tuple(*it, it == isotopologues_.end());
 }
 
 // Return number of Isotopologues defined
-int IsotopologueSet::nIsotopologues() const { return isotopologues_.nItems(); }
+int IsotopologueSet::nIsotopologues() const { return isotopologues_.size(); }
 
-// Return list of all Isotopologues
-const List<Isotopologues> &IsotopologueSet::isotopologues() const { return isotopologues_; }
+// Return vector of all Isotopologues
+const std::vector<Isotopologues> &IsotopologueSet::isotopologues() const { return isotopologues_; }
 
 /*
  * GenericItemBase Implementations
@@ -167,8 +167,8 @@ bool IsotopologueSet::read(LineParser &parser, const CoreData &coreData)
 	for (int n = 0; n < nSpecies; ++n)
 	{
 		// Add a new isotopologue set and read it
-		Isotopologues *topes = isotopologues_.add();
-		if (!topes->read(parser, coreData))
+		isotopologues_.emplace_back();
+		if (!isotopologues_.back().read(parser, coreData))
 			return false;
 	}
 
@@ -179,13 +179,12 @@ bool IsotopologueSet::read(LineParser &parser, const CoreData &coreData)
 bool IsotopologueSet::write(LineParser &parser)
 {
 	// Write Configuration name and number of Isotopologues we have defined
-	if (!parser.writeLineF("'%s'  %i\n", configuration_->name(), isotopologues_.nItems()))
+	if (!parser.writeLineF("'%s'  %i\n", configuration_->name(), isotopologues_.size()))
 		return false;
 
 	// Write details for each set of Isotopologues
-	ListIterator<Isotopologues> isotopologuesIterator(isotopologues_);
-	while (Isotopologues *topes = isotopologuesIterator.iterate())
-		if (!topes->write(parser))
+	for (auto topes : isotopologues_)
+		if (!topes.write(parser))
 			return false;
 
 	return true;

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -27,7 +27,7 @@
 #include "classes/species.h"
 #include <algorithm>
 
-IsotopologueSet::IsotopologueSet(IsotopologueCollection* parent, Configuration* cfg) : ListItem<IsotopologueSet>(), parentCollection_(parent), configuration_(cfg) { }
+IsotopologueSet::IsotopologueSet(IsotopologueCollection* parent, Configuration* cfg) : parentCollection_(parent), configuration_(cfg) { }
 
 IsotopologueSet::~IsotopologueSet() {}
 

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -27,7 +27,10 @@
 #include "classes/species.h"
 #include <algorithm>
 
-IsotopologueSet::IsotopologueSet(IsotopologueCollection* parent, Configuration* cfg) : parentCollection_(parent), configuration_(cfg) { }
+IsotopologueSet::IsotopologueSet(IsotopologueCollection *parent, Configuration *cfg)
+	: parentCollection_(parent), configuration_(cfg)
+{
+}
 
 IsotopologueSet::~IsotopologueSet() {}
 
@@ -61,9 +64,8 @@ Configuration *IsotopologueSet::configuration() const { return configuration_; }
 // Add Isotopologue with the specified relative weight
 void IsotopologueSet::add(Isotopologue *iso, double relativeWeight)
 {
-	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) {
-		return data.species() == iso->parent();
-	});
+	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(),
+			       [&](Isotopologues &data) { return data.species() == iso->parent(); });
 	if (it != isotopologues_.end())
 		it->add(iso, relativeWeight);
 	else
@@ -76,18 +78,15 @@ void IsotopologueSet::add(Isotopologue *iso, double relativeWeight)
 // Remove specified Species from the list (if it exists)
 void IsotopologueSet::remove(Species *sp)
 {
-	std::remove_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) {
-		return data.species() == sp;
-	});
+	std::remove_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) { return data.species() == sp; });
 }
 
 // Remove any occurrences of the specified Isotopologue
 void IsotopologueSet::remove(Isotopologue *iso)
 {
 	// Get parent Isotopologues from the contained Species pointer
-	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) {
-		return data.species() == iso->parent();
-	});
+	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(),
+			       [&](Isotopologues &data) { return data.species() == iso->parent(); });
 
 	if (it != isotopologues_.end())
 	{
@@ -103,9 +102,8 @@ void IsotopologueSet::remove(Isotopologue *iso)
 void IsotopologueSet::remove(IsotopologueWeight *isoWeight)
 {
 	// Get Isotopologues related to the IsotopologueWeight's Species pointer
-	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) {
-		return data.species() == isoWeight->isotopologue()->parent();
-	});
+	auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(),
+			       [&](Isotopologues &data) { return data.species() == isoWeight->isotopologue()->parent(); });
 
 	if (it != isotopologues_.end())
 	{
@@ -120,9 +118,8 @@ void IsotopologueSet::remove(IsotopologueWeight *isoWeight)
 // Return whether Isotopologues for the specified Species exists
 bool IsotopologueSet::contains(const Species *sp) const
 {
-	auto it = std::find_if(isotopologues_.cbegin(), isotopologues_.cend(), [&](const Isotopologues &data) {
-		return data.species() == sp;
-	});
+	auto it = std::find_if(isotopologues_.cbegin(), isotopologues_.cend(),
+			       [&](const Isotopologues &data) { return data.species() == sp; });
 
 	return (it != isotopologues_.end());
 }
@@ -130,9 +127,8 @@ bool IsotopologueSet::contains(const Species *sp) const
 // Return IsotopologueSet for the specified Species
 optional<const Isotopologues> IsotopologueSet::getIsotopologues(const Species *sp) const
 {
-	auto it = std::find_if(isotopologues_.cbegin(), isotopologues_.cend(), [&](const Isotopologues &data) {
-		return data.species() == sp;
-	});
+	auto it = std::find_if(isotopologues_.cbegin(), isotopologues_.cend(),
+			       [&](const Isotopologues &data) { return data.species() == sp; });
 
 	return std::make_tuple(*it, it == isotopologues_.end());
 }

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -78,7 +78,7 @@ void IsotopologueSet::add(Isotopologue *iso, double relativeWeight)
 // Remove specified Species from the list (if it exists)
 void IsotopologueSet::remove(Species *sp)
 {
-	std::remove_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) { return data.species() == sp; });
+	isotopologues_.erase(std::remove_if(isotopologues_.begin(), isotopologues_.end(), [&](Isotopologues &data) { return data.species() == sp; }), isotopologues_.end());
 }
 
 // Remove any occurrences of the specified Isotopologue

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -118,10 +118,8 @@ void IsotopologueSet::remove(IsotopologueWeight *isoWeight)
 // Return whether Isotopologues for the specified Species exists
 bool IsotopologueSet::contains(const Species *sp) const
 {
-	auto it = std::find_if(isotopologues_.cbegin(), isotopologues_.cend(),
+	return std::any_of(isotopologues_.cbegin(), isotopologues_.cend(),
 			       [&](const Isotopologues &data) { return data.species() == sp; });
-
-	return (it != isotopologues_.end());
 }
 
 // Return IsotopologueSet for the specified Species

--- a/src/classes/isotopologueset.h
+++ b/src/classes/isotopologueset.h
@@ -24,7 +24,6 @@
 
 #include "classes/isotopologues.h"
 #include "genericitems/base.h"
-#include "templates/list.h"
 #include <vector>
 
 template <class T> using optional = std::tuple<T, bool>;
@@ -37,7 +36,7 @@ class IsotopologueCollection;
 class LineParser;
 
 // IsotopologueSet - Isotopologues for one or more Species in a single Configuration
-class IsotopologueSet : public ListItem<IsotopologueSet>, public GenericItemBase
+class IsotopologueSet : public GenericItemBase
 {
 	public:
 	IsotopologueSet(IsotopologueCollection* parent = nullptr, Configuration* cfg = nullptr);

--- a/src/classes/isotopologueset.h
+++ b/src/classes/isotopologueset.h
@@ -25,6 +25,9 @@
 #include "classes/isotopologues.h"
 #include "genericitems/base.h"
 #include "templates/list.h"
+#include <vector>
+
+template <class T> using optional = std::tuple<T, bool>;
 
 // Forward Declarations
 class Configuration;
@@ -37,7 +40,7 @@ class LineParser;
 class IsotopologueSet : public ListItem<IsotopologueSet>, public GenericItemBase
 {
 	public:
-	IsotopologueSet();
+	IsotopologueSet(IsotopologueCollection* parent = nullptr, Configuration* cfg = nullptr);
 	~IsotopologueSet();
 
 	/*
@@ -60,7 +63,7 @@ class IsotopologueSet : public ListItem<IsotopologueSet>, public GenericItemBase
 	// Configuration in which the Species are used
 	Configuration *configuration_;
 	// Isotopologue mixtures for individual Species
-	List<Isotopologues> isotopologues_;
+	std::vector<Isotopologues> isotopologues_;
 
 	public:
 	// Clear all existing data
@@ -77,14 +80,14 @@ class IsotopologueSet : public ListItem<IsotopologueSet>, public GenericItemBase
 	void remove(Isotopologue *iso);
 	// Remove the specified IsotopologueWeight
 	void remove(IsotopologueWeight *isoWeight);
-	// Return whether an IsotopologueSet for the specified Species exists
+	// Return whether Isotopologues for the specified Species exists
 	bool contains(const Species *sp) const;
 	// Return Isotopologues for the specified Species
-	Isotopologues *isotopologues(const Species *sp);
+	optional<const Isotopologues> getIsotopologues(const Species *sp) const;
 	// Return number of Isotopologues defined
 	int nIsotopologues() const;
-	// Return list of all Isotopologues
-	const List<Isotopologues> &isotopologues() const;
+	// Return vector of all Isotopologues
+	const std::vector<Isotopologues> &isotopologues() const;
 
 	/*
 	 * GenericItemBase Implementations

--- a/src/classes/isotopologueset.h
+++ b/src/classes/isotopologueset.h
@@ -39,7 +39,7 @@ class LineParser;
 class IsotopologueSet : public GenericItemBase
 {
 	public:
-	IsotopologueSet(IsotopologueCollection* parent = nullptr, Configuration* cfg = nullptr);
+	IsotopologueSet(IsotopologueCollection *parent = nullptr, Configuration *cfg = nullptr);
 	~IsotopologueSet();
 
 	/*

--- a/src/classes/isotopologueset.h
+++ b/src/classes/isotopologueset.h
@@ -86,7 +86,9 @@ class IsotopologueSet : public GenericItemBase
 	// Return number of Isotopologues defined
 	int nIsotopologues() const;
 	// Return vector of all Isotopologues
-	const std::vector<Isotopologues> &isotopologues() const;
+	std::vector<Isotopologues> &isotopologues();
+	// Return vector of all Isotopologues (const)
+	const std::vector<Isotopologues> &constIsotopologues() const;
 
 	/*
 	 * GenericItemBase Implementations

--- a/src/classes/isotopologueweight.cpp
+++ b/src/classes/isotopologueweight.cpp
@@ -21,10 +21,7 @@
 
 #include "classes/isotopologueweight.h"
 
-IsotopologueWeight::IsotopologueWeight(const Isotopologue *iso, double weight) : ListItem<IsotopologueWeight>()
-{
-	set(iso, weight);
-}
+IsotopologueWeight::IsotopologueWeight(const Isotopologue *iso, double weight) : isotopologue_(iso), weight_(weight) {}
 
 IsotopologueWeight::~IsotopologueWeight() {}
 

--- a/src/classes/isotopologueweight.h
+++ b/src/classes/isotopologueweight.h
@@ -33,7 +33,7 @@ class ProcessPool;
 class LineParser;
 
 // Isotopologue Weight
-class IsotopologueWeight : public ListItem<IsotopologueWeight>
+class IsotopologueWeight
 {
 	public:
 	IsotopologueWeight(const Isotopologue *iso = nullptr, double weight = 1.0);

--- a/src/classes/isotopologueweight.h
+++ b/src/classes/isotopologueweight.h
@@ -36,7 +36,7 @@ class LineParser;
 class IsotopologueWeight : public ListItem<IsotopologueWeight>
 {
 	public:
-	IsotopologueWeight(const Isotopologue *iso = NULL, double weight = 1.0);
+	IsotopologueWeight(const Isotopologue *iso = nullptr, double weight = 1.0);
 	~IsotopologueWeight();
 
 	/*

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -403,8 +403,6 @@ bool NeutronWeights::read(LineParser &parser, const CoreData &coreData)
 		return false;
 	if (!GenericItemContainer<Array2D<double>>::read(weights_, parser))
 		return false;
-	if (!GenericItemContainer<Array2D<double>>::read(boundWeights_, parser))
-		return false;
 	if (!GenericItemContainer<Array2D<double>>::read(intramolecularWeights_, parser))
 		return false;
 

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -75,7 +75,8 @@ void NeutronWeights::addIsotopologue(Species *sp, int speciesPopulation, const I
 {
 	// Does an Isotopologues definition already exist for the supplied Species?
 	auto it = std::find_if(isotopologueMixtures_.begin(), isotopologueMixtures_.end(),
-			       [&](Isotopologues &data) { return data.species() == sp; });
+			       [sp](Isotopologues &data) { return data.species() == sp; });
+
 	if (it == isotopologueMixtures_.end())
 	{
 		isotopologueMixtures_.emplace_back(sp, speciesPopulation);
@@ -90,7 +91,7 @@ bool NeutronWeights::containsIsotopologues(Species *sp) const
 {
 	// Does an Isotopologues definition already exist for the supplied Species?
 	auto it = std::find_if(isotopologueMixtures_.cbegin(), isotopologueMixtures_.cend(),
-			       [&](const Isotopologues &data) { return data.species() == sp; });
+			       [sp](const Isotopologues &data) { return data.species() == sp; });
 
 	return it != isotopologueMixtures_.end();
 }

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -74,9 +74,8 @@ void NeutronWeights::addIsotopologue(Species *sp, int speciesPopulation, const I
 				     double isotopologueRelativePopulation)
 {
 	// Does an Isotopologues definition already exist for the supplied Species?
-	auto it = std::find_if(isotopologueMixtures_.begin(), isotopologueMixtures_.end(), [&](Isotopologues &data) {
-		return data.species() == sp;
-	});
+	auto it = std::find_if(isotopologueMixtures_.begin(), isotopologueMixtures_.end(),
+			       [&](Isotopologues &data) { return data.species() == sp; });
 	if (it == isotopologueMixtures_.end())
 	{
 		isotopologueMixtures_.emplace_back(sp, speciesPopulation);
@@ -90,9 +89,8 @@ void NeutronWeights::addIsotopologue(Species *sp, int speciesPopulation, const I
 bool NeutronWeights::containsIsotopologues(Species *sp) const
 {
 	// Does an Isotopologues definition already exist for the supplied Species?
-	auto it = std::find_if(isotopologueMixtures_.cbegin(), isotopologueMixtures_.cend(), [&](const Isotopologues &data) {
-		return data.species() == sp;
-	});
+	auto it = std::find_if(isotopologueMixtures_.cbegin(), isotopologueMixtures_.cend(),
+			       [&](const Isotopologues &data) { return data.species() == sp; });
 
 	return it != isotopologueMixtures_.end();
 }
@@ -108,11 +106,10 @@ void NeutronWeights::print() const
 		{
 			if (it == topes.mix().begin())
 				Messenger::print("  %-15s  %-15s  %-10i  %f\n", topes.species()->name(),
-						 it->isotopologue()->name(), topes.speciesPopulation(),
-						 it->weight());
+						 it->isotopologue()->name(), topes.speciesPopulation(), it->weight());
 			else
-				Messenger::print("                   %-15s              %f\n",
-						 it->isotopologue()->name(), it->weight());
+				Messenger::print("                   %-15s              %f\n", it->isotopologue()->name(),
+						 it->weight());
 		}
 	}
 

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -1,6 +1,6 @@
 /*
-	*** Weights Container
-	*** src/classes/weights.cpp
+	*** Neutron Weights Container
+	*** src/classes/neutronweights.cpp
 	Copyright T. Youngs 2012-2020
 
 	This file is part of Dissolve.
@@ -19,25 +19,25 @@
 	along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "classes/weights.h"
 #include "base/lineparser.h"
 #include "base/processpool.h"
 #include "classes/atomtype.h"
+#include "classes/neutronweights.h"
 #include "classes/species.h"
 #include "data/isotopes.h"
 #include "genericitems/array2ddouble.h"
 #include "templates/broadcastlist.h"
 
-Weights::Weights()
+NeutronWeights::NeutronWeights()
 {
 	boundCoherentSquareOfAverage_ = 0.0;
 	boundCoherentAverageOfSquares_ = 0.0;
 	valid_ = false;
 }
 
-Weights::Weights(const Weights &source) { (*this) = source; }
+NeutronWeights::NeutronWeights(const NeutronWeights &source) { (*this) = source; }
 
-void Weights::operator=(const Weights &source)
+void NeutronWeights::operator=(const NeutronWeights &source)
 {
 	// Isotopologue Mix
 	isotopologueMixtures_ = source.isotopologueMixtures_;
@@ -56,7 +56,7 @@ void Weights::operator=(const Weights &source)
  */
 
 // Clear contents
-void Weights::clear()
+void NeutronWeights::clear()
 {
 	isotopologueMixtures_.clear();
 	atomTypes_.clear();
@@ -70,8 +70,8 @@ void Weights::clear()
 }
 
 // Add Isotopologue for Species
-bool Weights::addIsotopologue(Species *sp, int speciesPopulation, const Isotopologue *iso,
-			      double isotopologueRelativePopulation)
+bool NeutronWeights::addIsotopologue(Species *sp, int speciesPopulation, const Isotopologue *iso,
+				     double isotopologueRelativePopulation)
 {
 	// Check that the Species is in the list...
 	Isotopologues *mix = hasIsotopologues(sp);
@@ -92,7 +92,7 @@ bool Weights::addIsotopologue(Species *sp, int speciesPopulation, const Isotopol
 }
 
 // Return whether the IsotopologueSet contains a mixtures definition for the provided Species
-Isotopologues *Weights::hasIsotopologues(Species *sp) const
+Isotopologues *NeutronWeights::hasIsotopologues(Species *sp) const
 {
 	for (Isotopologues *topes = isotopologueMixtures_.first(); topes != NULL; topes = topes->next())
 		if (topes->species() == sp)
@@ -101,7 +101,7 @@ Isotopologues *Weights::hasIsotopologues(Species *sp) const
 }
 
 // Print atomtype / weights information
-void Weights::print() const
+void NeutronWeights::print() const
 {
 	Messenger::print("  Species          Isotopologue     nTotMols    Fraction\n");
 	Messenger::print("  ------------------------------------------------------\n");
@@ -133,7 +133,7 @@ void Weights::print() const
  */
 
 // Calculate weighting matrices based on current AtomType / Isotope information
-void Weights::calculateWeightingMatrices()
+void NeutronWeights::calculateWeightingMatrices()
 {
 	// Create weights matrices and calculate average scattering lengths
 	// Note: Multiplier of 0.1 on b terms converts from units of fm (1e-11 m) to barn (1e-12 m)
@@ -195,7 +195,8 @@ void Weights::calculateWeightingMatrices()
 			// Find this AtomType in our local AtomTypeList
 			int typeI = atomTypes_.indexOf(atd1->atomType());
 			if (typeI == -1)
-				Messenger::error("Failed to find AtomType '%s' in local Weights.\n", atd1->atomTypeName());
+				Messenger::error("Failed to find AtomType '%s' in local NeutronWeights.\n",
+						 atd1->atomTypeName());
 
 			// Inner loop
 			for (atd2 = atd1; atd2 != NULL; atd2 = atd2->next())
@@ -203,7 +204,7 @@ void Weights::calculateWeightingMatrices()
 				// Get AtomType for this Atom and find it in our local AtomTypeList
 				int typeJ = atomTypes_.indexOf(atd2->atomType());
 				if (typeJ == -1)
-					Messenger::error("Failed to find AtomType '%s' in local Weights.\n",
+					Messenger::error("Failed to find AtomType '%s' in local NeutronWeights.\n",
 							 atd2->atomTypeName());
 
 				intraFlag.at(typeI, typeJ) = true;
@@ -291,7 +292,7 @@ void Weights::calculateWeightingMatrices()
 }
 
 // Create AtomType list and matrices based on stored Isotopologues information
-void Weights::createFromIsotopologues(const AtomTypeList &exchangeableTypes)
+void NeutronWeights::createFromIsotopologues(const AtomTypeList &exchangeableTypes)
 {
 	// Loop over Isotopologues entries and ensure relative populations of Isotopologues sum to 1.0
 	for (Isotopologues *topes = isotopologueMixtures_.first(); topes != NULL; topes = topes->next())
@@ -325,7 +326,7 @@ void Weights::createFromIsotopologues(const AtomTypeList &exchangeableTypes)
 }
 
 // Reduce data to be naturally-weighted
-void Weights::naturalise()
+void NeutronWeights::naturalise()
 {
 	atomTypes_.naturalise();
 
@@ -335,47 +336,47 @@ void Weights::naturalise()
 }
 
 // Return AtomTypeList
-AtomTypeList &Weights::atomTypes() { return atomTypes_; }
+AtomTypeList &NeutronWeights::atomTypes() { return atomTypes_; }
 
 // Return number of used AtomTypes
-int Weights::nUsedTypes() const { return atomTypes_.nItems(); }
+int NeutronWeights::nUsedTypes() const { return atomTypes_.nItems(); }
 
 // Return concentration product for types i and j
-double Weights::concentrationProduct(int i, int j) const { return concentrationProducts_.constAt(i, j); }
+double NeutronWeights::concentrationProduct(int i, int j) const { return concentrationProducts_.constAt(i, j); }
 
 // Return bound coherent scattering product for types i
-double Weights::boundCoherentProduct(int i, int j) const { return boundCoherentProducts_.constAt(i, j); }
+double NeutronWeights::boundCoherentProduct(int i, int j) const { return boundCoherentProducts_.constAt(i, j); }
 
 // Return full weighting for types i and j (ci * cj * bi * bj * [2-dij])
-double Weights::weight(int i, int j) const { return weights_.constAt(i, j); }
+double NeutronWeights::weight(int i, int j) const { return weights_.constAt(i, j); }
 
 // Return full bound weighting for types i and j
-double Weights::boundWeight(int i, int j) const { return boundWeights_.constAt(i, j); }
+double NeutronWeights::boundWeight(int i, int j) const { return boundWeights_.constAt(i, j); }
 
 // Return full weights matrix
-Array2D<double> &Weights::weights() { return weights_; }
+Array2D<double> &NeutronWeights::weights() { return weights_; }
 
 // Return full bound scattering weights matrix
-Array2D<double> &Weights::boundWeights() { return boundWeights_; }
+Array2D<double> &NeutronWeights::boundWeights() { return boundWeights_; }
 
 // Return bound coherent average squared scattering (<b>**2)
-double Weights::boundCoherentSquareOfAverage() const { return boundCoherentSquareOfAverage_; }
+double NeutronWeights::boundCoherentSquareOfAverage() const { return boundCoherentSquareOfAverage_; }
 
 // Return bound coherent squared average scattering (<b**2>)
-double Weights::boundCoherentAverageOfSquares() const { return boundCoherentAverageOfSquares_; }
+double NeutronWeights::boundCoherentAverageOfSquares() const { return boundCoherentAverageOfSquares_; }
 
 // Return whether the structure is valid (i.e. has been finalised)
-bool Weights::isValid() const { return valid_; }
+bool NeutronWeights::isValid() const { return valid_; }
 
 /*
  * GenericItemBase Implementations
  */
 
 // Return class name
-const char *Weights::itemClassName() { return "Weights"; }
+const char *NeutronWeights::itemClassName() { return "NeutronWeights"; }
 
 // Read data through specified LineParser
-bool Weights::read(LineParser &parser, const CoreData &coreData)
+bool NeutronWeights::read(LineParser &parser, const CoreData &coreData)
 {
 	clear();
 
@@ -415,7 +416,7 @@ bool Weights::read(LineParser &parser, const CoreData &coreData)
 }
 
 // Write data through specified LineParser
-bool Weights::write(LineParser &parser)
+bool NeutronWeights::write(LineParser &parser)
 {
 	// Write AtomTypeList
 	if (!atomTypes_.write(parser))
@@ -451,7 +452,7 @@ bool Weights::write(LineParser &parser)
  */
 
 // Broadcast item contents
-bool Weights::broadcast(ProcessPool &procPool, const int root, const CoreData &coreData)
+bool NeutronWeights::broadcast(ProcessPool &procPool, const int root, const CoreData &coreData)
 {
 #ifdef PARALLEL
 	BroadcastList<Isotopologues> isoMixBroadcaster(procPool, root, isotopologueMixtures_, coreData);
@@ -478,27 +479,29 @@ bool Weights::broadcast(ProcessPool &procPool, const int root, const CoreData &c
 }
 
 // Check item equality
-bool Weights::equality(ProcessPool &procPool)
+bool NeutronWeights::equality(ProcessPool &procPool)
 {
 #ifdef PARALLEL
 	if (!atomTypes_.equality(procPool))
-		return Messenger::error("Weights AtomTypes are not equivalent.\n");
+		return Messenger::error("NeutronWeights AtomTypes are not equivalent.\n");
 	if (!procPool.equality(concentrationProducts_))
-		return Messenger::error("Weights concentration matrix is not equivalent.\n");
+		return Messenger::error("NeutronWeights concentration matrix is not equivalent.\n");
 	if (!procPool.equality(boundCoherentProducts_))
-		return Messenger::error("Weights bound coherent matrix is not equivalent.\n");
+		return Messenger::error("NeutronWeights bound coherent matrix is not equivalent.\n");
 	if (!procPool.equality(weights_))
 		return Messenger::error("Unbound weights matrix is not equivalent.\n");
 	if (!procPool.equality(boundWeights_))
 		return Messenger::error("Bound weights matrix is not equivalent.\n");
 	if (!procPool.equality(boundCoherentAverageOfSquares_))
-		return Messenger::error("Weights bound coherent average of squares is not equivalent (process %i has %e).\n",
-					procPool.poolRank(), boundCoherentAverageOfSquares_);
+		return Messenger::error(
+			"NeutronWeights bound coherent average of squares is not equivalent (process %i has %e).\n",
+			procPool.poolRank(), boundCoherentAverageOfSquares_);
 	if (!procPool.equality(boundCoherentSquareOfAverage_))
-		return Messenger::error("Weights bound coherent square of average is not equivalent (process %i has %e).\n",
-					procPool.poolRank(), boundCoherentSquareOfAverage_);
+		return Messenger::error(
+			"NeutronWeights bound coherent square of average is not equivalent (process %i has %e).\n",
+			procPool.poolRank(), boundCoherentSquareOfAverage_);
 	if (!procPool.equality(valid_))
-		return Messenger::error("Weights validity is not equivalent (process %i has %i).\n", procPool.poolRank(),
+		return Messenger::error("NeutronWeights validity is not equivalent (process %i has %i).\n", procPool.poolRank(),
 					valid_);
 #endif
 	return true;

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -103,9 +103,9 @@ void NeutronWeights::print() const
 	Messenger::print("  ------------------------------------------------------\n");
 	for (auto &topes : isotopologueMixtures_)
 	{
-		for (auto it = topes.mix().begin(); it != topes.mix().end(); ++it)
+		for (auto it = topes.constMix().begin(); it != topes.constMix().end(); ++it)
 		{
-			if (it == topes.mix().begin())
+			if (it == topes.constMix().begin())
 				Messenger::print("  %-15s  %-15s  %-10i  %f\n", topes.species()->name(),
 						 it->isotopologue()->name(), topes.speciesPopulation(), it->weight());
 			else

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -384,7 +384,7 @@ bool NeutronWeights::read(LineParser &parser, const CoreData &coreData)
 	if (!atomTypes_.read(parser, coreData))
 		return false;
 
-	// Read Isotopologues-tures
+	// Read isotopologue mixtures
 	isotopologueMixtures_.clear();
 	if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
 		return false;
@@ -424,7 +424,7 @@ bool NeutronWeights::write(LineParser &parser)
 	if (!atomTypes_.write(parser))
 		return false;
 
-	// Write Isotopologues-tures
+	// Write isotopologue mixtures
 	if (!parser.writeLineF("%i  # nItems\n", isotopologueMixtures_.nItems()))
 		return false;
 	ListIterator<Isotopologues> mixIterator(isotopologueMixtures_);

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -26,7 +26,7 @@
 #include "classes/species.h"
 #include "data/isotopes.h"
 #include "genericitems/array2ddouble.h"
-#include "templates/broadcastlist.h"
+#include "templates/broadcastvector.h"
 
 NeutronWeights::NeutronWeights()
 {
@@ -448,7 +448,7 @@ bool NeutronWeights::write(LineParser &parser)
 bool NeutronWeights::broadcast(ProcessPool &procPool, const int root, const CoreData &coreData)
 {
 #ifdef PARALLEL
-	BroadcastList<Isotopologues> isoMixBroadcaster(procPool, root, isotopologueMixtures_, coreData);
+	BroadcastVector<Isotopologues> isoMixBroadcaster(procPool, root, isotopologueMixtures_, coreData);
 	if (isoMixBroadcaster.failed())
 		return false;
 	if (!atomTypes_.broadcast(procPool, root, coreData))

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -354,10 +354,10 @@ double NeutronWeights::weight(int i, int j) const { return weights_.constAt(i, j
 double NeutronWeights::intramolecularWeight(int i, int j) const { return intramolecularWeights_.constAt(i, j); }
 
 // Return full weights matrix
-Array2D<double> &NeutronWeights::weights() { return weights_; }
+const Array2D<double> &NeutronWeights::weights() const { return weights_; }
 
 // Return full intramolecular scattering weights matrix
-Array2D<double> &NeutronWeights::intramolecularWeights() { return intramolecularWeights_; }
+const Array2D<double> &NeutronWeights::intramolecularWeights() const { return intramolecularWeights_; }
 
 // Return bound coherent average squared scattering (<b>**2)
 double NeutronWeights::boundCoherentSquareOfAverage() const { return boundCoherentSquareOfAverage_; }

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -73,31 +73,31 @@ void NeutronWeights::clear()
 bool NeutronWeights::addIsotopologue(Species *sp, int speciesPopulation, const Isotopologue *iso,
 				     double isotopologueRelativePopulation)
 {
-	// Check that the Species is in the list...
-	Isotopologues *mix = hasIsotopologues(sp);
-	if (mix == NULL)
+	// Does an Isotopologues definition already exist for the supplied Species?
+	auto it = std::find_if(isotopologueMixtures_.begin(), isotopologueMixtures_.end(), [&](Isotopologues &data) {
+		return data.species() == sp;
+	});
+	if (it == isotopologueMixtures_.end())
 	{
-		mix = isotopologueMixtures_.add();
-		mix->setSpecies(sp, speciesPopulation);
+		isotopologueMixtures_.emplace_back(sp, speciesPopulation);
+		if (!isotopologueMixtures_.back().add(iso, isotopologueRelativePopulation))
+			return Messenger::error("Failed to add Isotopologue to IsotopologueSet.\n");
 	}
-
-	// Add/update Isotopologue provided?
-	if (!mix->add(iso, isotopologueRelativePopulation))
-	{
-		Messenger::error("Failed to add Isotopologue to IsotopologueSet.\n");
-		return false;
-	}
-
+	else if (!it->add(iso, isotopologueRelativePopulation))
+		return Messenger::error("Failed to add Isotopologue to IsotopologueSet.\n");
+	
 	return true;
 }
 
-// Return whether the IsotopologueSet contains a mixtures definition for the provided Species
-Isotopologues *NeutronWeights::hasIsotopologues(Species *sp) const
+// Return whether an Isotopologues definition exists for the provided Species
+bool NeutronWeights::containsIsotopologues(Species *sp) const
 {
-	for (Isotopologues *topes = isotopologueMixtures_.first(); topes != NULL; topes = topes->next())
-		if (topes->species() == sp)
-			return topes;
-	return NULL;
+	// Does an Isotopologues definition already exist for the supplied Species?
+	auto it = std::find_if(isotopologueMixtures_.cbegin(), isotopologueMixtures_.cend(), [&](const Isotopologues &data) {
+		return data.species() == sp;
+	});
+
+	return it != isotopologueMixtures_.end();
 }
 
 // Print atomtype / weights information
@@ -105,14 +105,14 @@ void NeutronWeights::print() const
 {
 	Messenger::print("  Species          Isotopologue     nTotMols    Fraction\n");
 	Messenger::print("  ------------------------------------------------------\n");
-	for (Isotopologues *topes = isotopologueMixtures_.first(); topes != NULL; topes = topes->next())
+	for (auto &topes : isotopologueMixtures_)
 	{
-		ListIterator<IsotopologueWeight> weightIterator(topes->mix());
+		ListIterator<IsotopologueWeight> weightIterator(topes.mix());
 		while (IsotopologueWeight *isoWeight = weightIterator.iterate())
 		{
 			if (weightIterator.isFirst())
-				Messenger::print("  %-15s  %-15s  %-10i  %f\n", topes->species()->name(),
-						 isoWeight->isotopologue()->name(), topes->speciesPopulation(),
+				Messenger::print("  %-15s  %-15s  %-10i  %f\n", topes.species()->name(),
+						 isoWeight->isotopologue()->name(), topes.speciesPopulation(),
 						 isoWeight->weight());
 			else
 				Messenger::print("                   %-15s              %f\n",
@@ -180,13 +180,13 @@ void NeutronWeights::calculateWeightingMatrices()
 	Array2D<bool> globalFlag(atomTypes_.nItems(), atomTypes_.nItems(), true);
 	intraNorm = 0.0;
 	globalFlag = false;
-	for (Isotopologues *topes = isotopologueMixtures_.first(); topes != NULL; topes = topes->next())
+	for (auto &topes : isotopologueMixtures_)
 	{
 		// Get weighting for associated Species population
-		double speciesWeight = double(topes->speciesPopulation());
+		double speciesWeight = double(topes.speciesPopulation());
 
 		// Using the underlying Species, construct a flag matrix which states the AtomType interactions we have present
-		Species *sp = topes->species();
+		Species *sp = topes.species();
 		const AtomTypeList &speciesAtomTypes = sp->usedAtomTypes();
 		const int nAtoms = sp->nAtoms();
 		intraFlag = false;
@@ -212,7 +212,7 @@ void NeutronWeights::calculateWeightingMatrices()
 		}
 
 		// Loop over Isotopologues defined for this mixture
-		ListIterator<IsotopologueWeight> weightIterator(topes->mix());
+		ListIterator<IsotopologueWeight> weightIterator(topes.mix());
 		while (IsotopologueWeight *isoWeight = weightIterator.iterate())
 		{
 			// Sum the scattering lengths of each pair of AtomTypes, weighted by the speciesWeight and the
@@ -295,26 +295,26 @@ void NeutronWeights::calculateWeightingMatrices()
 void NeutronWeights::createFromIsotopologues(const AtomTypeList &exchangeableTypes)
 {
 	// Loop over Isotopologues entries and ensure relative populations of Isotopologues sum to 1.0
-	for (Isotopologues *topes = isotopologueMixtures_.first(); topes != NULL; topes = topes->next())
-		topes->normalise();
+	for (auto &topes : isotopologueMixtures_)
+		topes.normalise();
 
 	// Fill atomTypes_ list with AtomType populations, based on Isotopologues relative populations and associated Species
 	// populations
 	atomTypes_.clear();
-	for (Isotopologues *topes = isotopologueMixtures_.first(); topes != NULL; topes = topes->next())
+	for (auto &topes : isotopologueMixtures_)
 	{
 		// We must now loop over the Isotopologues in the topesture
-		ListIterator<IsotopologueWeight> weightIterator(topes->mix());
+		ListIterator<IsotopologueWeight> weightIterator(topes.mix());
 		while (IsotopologueWeight *isoWeight = weightIterator.iterate())
 		{
 			const Isotopologue *tope = isoWeight->isotopologue();
 
 			// Loop over Atoms in the Species, searching for the AtomType/Isotope entry in the isotopes list of the
 			// Isotopologue
-			for (SpeciesAtom *i = topes->species()->firstAtom(); i != NULL; i = i->next())
+			for (SpeciesAtom *i = topes.species()->firstAtom(); i != NULL; i = i->next())
 			{
 				Isotope *iso = tope->atomTypeIsotope(i->atomType());
-				atomTypes_.addIsotope(i->atomType(), iso, isoWeight->weight() * topes->speciesPopulation());
+				atomTypes_.addIsotope(i->atomType(), iso, isoWeight->weight() * topes.speciesPopulation());
 			}
 		}
 	}
@@ -391,8 +391,8 @@ bool NeutronWeights::read(LineParser &parser, const CoreData &coreData)
 	int nItems = parser.argi(0);
 	for (int n = 0; n < nItems; ++n)
 	{
-		Isotopologues *mix = isotopologueMixtures_.add();
-		if (!mix->read(parser, coreData))
+		isotopologueMixtures_.emplace_back();
+		if (!isotopologueMixtures_.back().read(parser, coreData))
 			return false;
 	}
 
@@ -423,11 +423,10 @@ bool NeutronWeights::write(LineParser &parser)
 		return false;
 
 	// Write isotopologue mixtures
-	if (!parser.writeLineF("%i  # nItems\n", isotopologueMixtures_.nItems()))
+	if (!parser.writeLineF("%i  # nItems\n", isotopologueMixtures_.size()))
 		return false;
-	ListIterator<Isotopologues> mixIterator(isotopologueMixtures_);
-	while (Isotopologues *mix = mixIterator.iterate())
-		if (!mix->write(parser))
+	for (auto &topes : isotopologueMixtures_)
+		if (!topes.write(parser))
 			return false;
 
 	// Write arrays using static methods in the relevant GenericItemContainer

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -19,10 +19,10 @@
 	along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "classes/neutronweights.h"
 #include "base/lineparser.h"
 #include "base/processpool.h"
 #include "classes/atomtype.h"
-#include "classes/neutronweights.h"
 #include "classes/species.h"
 #include "data/isotopes.h"
 #include "genericitems/array2ddouble.h"

--- a/src/classes/neutronweights.h
+++ b/src/classes/neutronweights.h
@@ -1,6 +1,6 @@
 /*
-	*** Weights Container
-	*** src/classes/weights.h
+	*** Neutron Weights Container
+	*** src/classes/neutronweights.h
 	Copyright T. Youngs 2012-2020
 
 	This file is part of Dissolve.
@@ -19,8 +19,8 @@
 	along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef DISSOLVE_WEIGHTS_H
-#define DISSOLVE_WEIGHTS_H
+#ifndef DISSOLVE_NEUTRONWEIGHTS_H
+#define DISSOLVE_NEUTRONWEIGHTS_H
 
 #include "classes/atomtypelist.h"
 #include "classes/isotopologues.h"
@@ -31,13 +31,13 @@
 // Forward Declarations
 /* none */
 
-// Weights Container
-class Weights : public GenericItemBase
+// Neutron Weights Container
+class NeutronWeights : public GenericItemBase
 {
 	public:
-	Weights();
-	Weights(const Weights &source);
-	void operator=(const Weights &source);
+	NeutronWeights();
+	NeutronWeights(const NeutronWeights &source);
+	void operator=(const NeutronWeights &source);
 
 	/*
 	 * Construction

--- a/src/classes/neutronweights.h
+++ b/src/classes/neutronweights.h
@@ -51,7 +51,7 @@ class NeutronWeights : public GenericItemBase
 	// Clear contents
 	void clear();
 	// Add Species Isotopologue to the relevant mixture
-	bool addIsotopologue(Species *sp, int speciesPopulation, const Isotopologue *iso,
+	void addIsotopologue(Species *sp, int speciesPopulation, const Isotopologue *iso,
 			     double isotopologueRelativePopulation);
 	// Return whether an Isotopologues definition exists for the provided Species
 	bool containsIsotopologues(Species *sp) const;

--- a/src/classes/neutronweights.h
+++ b/src/classes/neutronweights.h
@@ -100,9 +100,9 @@ class NeutronWeights : public GenericItemBase
 	// Return full intramolecular weighting for types i and j
 	double intramolecularWeight(int i, int j) const;
 	// Return full scattering weights matrix
-	Array2D<double> &weights();
+	const Array2D<double> &weights() const;
 	// Return full intramolecular scattering weights matrix
-	Array2D<double> &intramolecularWeights();
+	const Array2D<double> &intramolecularWeights() const;
 	// Return bound coherent average squared scattering (<b>**2)
 	double boundCoherentSquareOfAverage() const;
 	// Return bound coherent squared average scattering (<b**2>)

--- a/src/classes/neutronweights.h
+++ b/src/classes/neutronweights.h
@@ -69,8 +69,8 @@ class NeutronWeights : public GenericItemBase
 	Array2D<double> boundCoherentProducts_;
 	// Full scattering weights
 	Array2D<double> weights_;
-	// Bound scattering weights
-	Array2D<double> boundWeights_;
+	// Intramolecular scattering weights
+	Array2D<double> intramolecularWeights_;
 	// Bound coherent average squared scattering (<b>**2)
 	double boundCoherentSquareOfAverage_;
 	// Bound coherent squared average scattering (<b**2>)
@@ -97,12 +97,12 @@ class NeutronWeights : public GenericItemBase
 	double boundCoherentProduct(int i, int j) const;
 	// Return full weighting for types i and j (ci * cj * bi * bj * [2-dij])
 	double weight(int i, int j) const;
-	// Return bound weighting for types i and j
-	double boundWeight(int i, int j) const;
+	// Return full intramolecular weighting for types i and j
+	double intramolecularWeight(int i, int j) const;
 	// Return full scattering weights matrix
 	Array2D<double> &weights();
-	// Return full bound scattering weights matrix
-	Array2D<double> &boundWeights();
+	// Return full intramolecular scattering weights matrix
+	Array2D<double> &intramolecularWeights();
 	// Return bound coherent average squared scattering (<b>**2)
 	double boundCoherentSquareOfAverage() const;
 	// Return bound coherent squared average scattering (<b**2>)

--- a/src/classes/neutronweights.h
+++ b/src/classes/neutronweights.h
@@ -27,6 +27,7 @@
 #include "genericitems/base.h"
 #include "templates/array2d.h"
 #include "templates/list.h"
+#include <vector>
 
 // Forward Declarations
 /* none */
@@ -44,7 +45,7 @@ class NeutronWeights : public GenericItemBase
 	 */
 	private:
 	// List of Isotopologues for Species
-	List<Isotopologues> isotopologueMixtures_;
+	std::vector<Isotopologues> isotopologueMixtures_;
 
 	public:
 	// Clear contents
@@ -52,8 +53,8 @@ class NeutronWeights : public GenericItemBase
 	// Add Species Isotopologue to the relevant mixture
 	bool addIsotopologue(Species *sp, int speciesPopulation, const Isotopologue *iso,
 			     double isotopologueRelativePopulation);
-	// Return whether we have a mixtures definition for the provided Species
-	Isotopologues *hasIsotopologues(Species *sp) const;
+	// Return whether an Isotopologues definition exists for the provided Species
+	bool containsIsotopologues(Species *sp) const;
 	// Print atomtype / weights information
 	void print() const;
 

--- a/src/classes/partialset.h
+++ b/src/classes/partialset.h
@@ -23,7 +23,7 @@
 #define DISSOLVE_PARTIALSET_H
 
 #include "classes/atomtypelist.h"
-#include "classes/weights.h"
+#include "classes/neutronweights.h"
 #include "math/data1d.h"
 #include "math/histogram1d.h"
 #include "templates/array2d.h"

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -21,7 +21,7 @@
 
 #include "classes/scatteringmatrix.h"
 #include "classes/atomtype.h"
-#include "classes/weights.h"
+#include "classes/neutronweights.h"
 #include "math/interpolator.h"
 #include "math/svd.h"
 #include <algorithm>
@@ -263,7 +263,7 @@ bool ScatteringMatrix::finalise()
 }
 
 // Add reference data
-bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, Weights &dataWeights, double factor)
+bool ScatteringMatrix::addReferenceData(const Data1D& weightedData, NeutronWeights& dataWeights, double factor)
 {
 	// Make sure that the scattering weights are valid
 	if (!dataWeights.isValid())

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -267,9 +267,7 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, NeutronWeigh
 {
 	// Make sure that the scattering weights are valid
 	if (!dataWeights.isValid())
-	{
 		return Messenger::error("Reference data '%s' does not have valid scattering weights.\n", weightedData.name());
-	}
 
 	// Extend the scattering matrix by one row
 	A_.addRow(typePairs_.nItems());

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -263,7 +263,7 @@ bool ScatteringMatrix::finalise()
 }
 
 // Add reference data
-bool ScatteringMatrix::addReferenceData(const Data1D& weightedData, NeutronWeights& dataWeights, double factor)
+bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, NeutronWeights &dataWeights, double factor)
 {
 	// Make sure that the scattering weights are valid
 	if (!dataWeights.isValid())

--- a/src/classes/scatteringmatrix.h
+++ b/src/classes/scatteringmatrix.h
@@ -85,7 +85,7 @@ class ScatteringMatrix
 	// Finalise
 	bool finalise();
 	// Add reference data with its associated Weights, applying optional factor to those weights and the data itself
-	bool addReferenceData(const Data1D& weightedData, NeutronWeights& dataWeights, double factor = 1.0);
+	bool addReferenceData(const Data1D &weightedData, NeutronWeights &dataWeights, double factor = 1.0);
 	// Add reference partial data between specified AtomTypes, applying optional factor to the weight and the data itself
 	bool addPartialReferenceData(Data1D &weightedData, AtomType *at1, AtomType *at2, double dataWeight,
 				     double factor = 1.0);

--- a/src/classes/scatteringmatrix.h
+++ b/src/classes/scatteringmatrix.h
@@ -30,7 +30,7 @@
 
 // Forward Declarations
 class AtomType;
-class Weights;
+class NeutronWeights;
 
 // Scattering Matrix Container
 class ScatteringMatrix
@@ -85,7 +85,7 @@ class ScatteringMatrix
 	// Finalise
 	bool finalise();
 	// Add reference data with its associated Weights, applying optional factor to those weights and the data itself
-	bool addReferenceData(const Data1D &weightedData, Weights &dataWeights, double factor = 1.0);
+	bool addReferenceData(const Data1D& weightedData, NeutronWeights& dataWeights, double factor = 1.0);
 	// Add reference partial data between specified AtomTypes, applying optional factor to the weight and the data itself
 	bool addPartialReferenceData(Data1D &weightedData, AtomType *at1, AtomType *at2, double dataWeight,
 				     double factor = 1.0);

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -19,12 +19,12 @@
 	along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "classes/xrayweights.h"
 #include "base/lineparser.h"
 #include "base/processpool.h"
 #include "classes/atomtype.h"
 #include "classes/species.h"
 #include "classes/speciesinfo.h"
-#include "classes/xrayweights.h"
 #include "genericitems/array2ddouble.h"
 #include "templates/enumhelpers.h"
 
@@ -69,8 +69,9 @@ bool XRayWeights::getFormFactors()
 		// Try to retrieve form factor data for this atom type (element, formal charge [TODO])
 		auto data = XRayFormFactors::formFactorData(formFactors_, at->element());
 		if (std::get<1>(data))
-			return Messenger::error("No form factor data present for element %s (formal charge %i) in x-ray data set '%s'.\n", at->element()->symbol(), 0,
-						XRayFormFactors::xRayFormFactorData().keyword(formFactors_));
+			return Messenger::error(
+				"No form factor data present for element %s (formal charge %i) in x-ray data set '%s'.\n",
+				at->element()->symbol(), 0, XRayFormFactors::xRayFormFactorData().keyword(formFactors_));
 
 		formFactorData_.push_back(std::reference_wrapper<const FormFactorData>(std::get<0>(data)));
 	}
@@ -93,7 +94,8 @@ bool XRayWeights::setUp(List<SpeciesInfo> &speciesInfoList, XRayFormFactors::XRa
 {
 	valid_ = false;
 
-	// Fill atomTypes_ list with AtomType populations, based on Isotopologues relative populations and associated Species populations
+	// Fill atomTypes_ list with AtomType populations, based on Isotopologues relative populations and associated Species
+	// populations
 	atomTypes_.clear();
 	for (SpeciesInfo *spInfo = speciesInfoList.first(); spInfo != NULL; spInfo = spInfo->next())
 	{
@@ -185,7 +187,10 @@ void XRayWeights::setUpMatrices()
 double XRayWeights::concentration(int typeIndexI) const { return concentrations_.constAt(typeIndexI); }
 
 // Return concentration product for types i and j
-double XRayWeights::concentrationProduct(int typeIndexI, int typeIndexJ) const { return concentrationProducts_.constAt(typeIndexI, typeIndexJ); }
+double XRayWeights::concentrationProduct(int typeIndexI, int typeIndexJ) const
+{
+	return concentrationProducts_.constAt(typeIndexI, typeIndexJ);
+}
 
 // Return form factor for type i over supplied Q values
 Array<double> XRayWeights::formFactor(int typeIndexI, const Array<double> &Q) const
@@ -228,7 +233,10 @@ double XRayWeights::formFactorProduct(int typeIndexI, int typeIndexJ, double Q) 
 }
 
 // Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) at specified Q value
-double XRayWeights::weight(int typeIndexI, int typeIndexJ, double Q) const { return preFactors_.constAt(typeIndexI, typeIndexJ) * formFactorProduct(typeIndexI, typeIndexJ, Q); }
+double XRayWeights::weight(int typeIndexI, int typeIndexJ, double Q) const
+{
+	return preFactors_.constAt(typeIndexI, typeIndexJ) * formFactorProduct(typeIndexI, typeIndexJ, Q);
+}
 
 // Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) over supplied Q values
 Array<double> XRayWeights::weight(int typeIndexI, int typeIndexJ, const Array<double> &Q) const
@@ -340,7 +348,8 @@ bool XRayWeights::equality(ProcessPool &procPool)
 	if (!procPool.equality(preFactors_))
 		return Messenger::error("XRayWeights bound coherent matrix is not equivalent.\n");
 	if (!procPool.equality(valid_))
-		return Messenger::error("XRayWeights validity is not equivalent (process %i has %i).\n", procPool.poolRank(), valid_);
+		return Messenger::error("XRayWeights validity is not equivalent (process %i has %i).\n", procPool.poolRank(),
+					valid_);
 #endif
 	return true;
 }

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -28,7 +28,6 @@
 #include "genericitems/array2ddouble.h"
 #include "templates/enumhelpers.h"
 
-// Constructor
 XRayWeights::XRayWeights()
 {
 	formFactors_ = XRayFormFactors::NoFormFactorData;
@@ -37,10 +36,8 @@ XRayWeights::XRayWeights()
 	valid_ = false;
 }
 
-// Copy Constructor
 XRayWeights::XRayWeights(const XRayWeights &source) { (*this) = source; }
 
-// Assignment Operator
 void XRayWeights::operator=(const XRayWeights &source)
 {
 	formFactors_ = source.formFactors_;

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -54,8 +54,8 @@ void XRayWeights::operator=(const XRayWeights &source)
  * Source AtomTypes
  */
 
-// Retrieve form factor data for the current atom types
-bool XRayWeights::getFormFactors()
+// Initialise form factor data for the current atom types
+bool XRayWeights::initialiseFormFactors()
 {
 	formFactorData_.clear();
 
@@ -125,7 +125,7 @@ bool XRayWeights::finalise(XRayFormFactors::XRayFormFactorData formFactors)
 
 	// Retrieve form factor data for the current atom types
 	formFactors_ = formFactors;
-	if (!getFormFactors())
+	if (!initialiseFormFactors())
 		return false;
 
 	setUpMatrices();

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -182,16 +182,13 @@ void XRayWeights::setUpMatrices()
 }
 
 // Return concentration product for type i
-double XRayWeights::concentration(int typeIndexI) const
-{
-	return concentrations_.constAt(typeIndexI);
-}
+double XRayWeights::concentration(int typeIndexI) const { return concentrations_.constAt(typeIndexI); }
 
 // Return concentration product for types i and j
 double XRayWeights::concentrationProduct(int typeIndexI, int typeIndexJ) const { return concentrationProducts_.constAt(typeIndexI, typeIndexJ); }
 
 // Return form factor for type i over supplied Q values
-Array<double> XRayWeights::formFactor(int typeIndexI, const Array<double>& Q) const
+Array<double> XRayWeights::formFactor(int typeIndexI, const Array<double> &Q) const
 {
 #ifdef CHECKS
 	if ((typeIndexI < 0) || (typeIndexI >= formFactorData_.size()))
@@ -204,9 +201,10 @@ Array<double> XRayWeights::formFactor(int typeIndexI, const Array<double>& Q) co
 	// Initialise results array
 	Array<double> fiq(Q.nItems());
 
-	auto& fi = formFactorData_[typeIndexI].get();
+	auto &fi = formFactorData_[typeIndexI].get();
 
-	for (int n=0; n<Q.nItems(); ++n) fiq[n] = fi.magnitude(Q.constAt(n));
+	for (int n = 0; n < Q.nItems(); ++n)
+		fiq[n] = fi.magnitude(Q.constAt(n));
 
 	return fiq;
 }
@@ -233,7 +231,7 @@ double XRayWeights::formFactorProduct(int typeIndexI, int typeIndexJ, double Q) 
 double XRayWeights::weight(int typeIndexI, int typeIndexJ, double Q) const { return preFactors_.constAt(typeIndexI, typeIndexJ) * formFactorProduct(typeIndexI, typeIndexJ, Q); }
 
 // Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) over supplied Q values
-Array<double> XRayWeights::weight(int typeIndexI, int typeIndexJ, const Array<double>& Q) const
+Array<double> XRayWeights::weight(int typeIndexI, int typeIndexJ, const Array<double> &Q) const
 {
 	// Get form factor data for involved types
 #ifdef CHECKS
@@ -252,8 +250,8 @@ Array<double> XRayWeights::weight(int typeIndexI, int typeIndexJ, const Array<do
 	// Initialise results array
 	Array<double> fijq(Q.nItems());
 
-	auto& fi = formFactorData_[typeIndexI].get();
-	auto& fj = formFactorData_[typeIndexJ].get();
+	auto &fi = formFactorData_[typeIndexI].get();
+	auto &fj = formFactorData_[typeIndexJ].get();
 	auto preFactor = preFactors_.constAt(typeIndexI, typeIndexJ);
 
 	for (int n = 0; n < Q.nItems(); ++n)

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -29,11 +29,9 @@
 #include "templates/enumhelpers.h"
 
 XRayWeights::XRayWeights()
+	: formFactors_(XRayFormFactors::NoFormFactorData), valid_(false), boundCoherentSquareOfAverage_(0.0),
+	  boundCoherentAverageOfSquares_(0.0)
 {
-	formFactors_ = XRayFormFactors::NoFormFactorData;
-	boundCoherentSquareOfAverage_ = 0.0;
-	boundCoherentAverageOfSquares_ = 0.0;
-	valid_ = false;
 }
 
 XRayWeights::XRayWeights(const XRayWeights &source) { (*this) = source; }

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -1,0 +1,297 @@
+/*
+	*** XRay Weights Container
+	*** src/classes/xrayweights.cpp
+	Copyright T. Youngs 2012-2020
+
+	This file is part of Dissolve.
+
+	Dissolve is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Dissolve is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "base/lineparser.h"
+#include "base/processpool.h"
+#include "classes/atomtype.h"
+#include "classes/species.h"
+#include "classes/speciesinfo.h"
+#include "classes/xrayweights.h"
+#include "genericitems/array2ddouble.h"
+#include "templates/enumhelpers.h"
+
+// Constructor
+XRayWeights::XRayWeights()
+{
+	formFactors_ = XRayFormFactors::NoFormFactorData;
+	valid_ = false;
+}
+
+// Copy Constructor
+XRayWeights::XRayWeights(const XRayWeights &source) { (*this) = source; }
+
+// Assignment Operator
+void XRayWeights::operator=(const XRayWeights &source)
+{
+	formFactors_ = source.formFactors_;
+	atomTypes_ = source.atomTypes_;
+	concentrationProducts_ = source.concentrationProducts_;
+	preFactors_ = source.preFactors_;
+	valid_ = source.valid_;
+}
+
+/*
+ * Source AtomTypes
+ */
+
+// Retrieve form factor data for the current atom types
+bool XRayWeights::getFormFactors()
+{
+	formFactorData_.clear();
+
+	for (AtomTypeData *atd = atomTypes_.first(); atd != NULL; atd = atd->next())
+	{
+		auto *at = atd->atomType();
+
+		// Try to retrieve form factor data for this atom type (element, formal charge [TODO])
+		auto data = XRayFormFactors::formFactorData(formFactors_, at->element());
+		if (std::get<1>(data))
+			return Messenger::error("No form factor data present for element %s (formal charge %i) in x-ray data set '%s'.\n", at->element()->symbol(), 0,
+						XRayFormFactors::xRayFormFactorData().keyword(formFactors_));
+
+		formFactorData_.push_back(std::reference_wrapper<const FormFactorData>(std::get<0>(data)));
+	}
+
+	return true;
+}
+
+// Clear contents
+void XRayWeights::clear()
+{
+	atomTypes_.clear();
+	concentrationProducts_.clear();
+	valid_ = false;
+}
+
+// Set-up from supplied SpeciesInfo list
+bool XRayWeights::setUp(List<SpeciesInfo> &speciesInfoList, XRayFormFactors::XRayFormFactorData formFactors)
+{
+	valid_ = false;
+
+	// Fill atomTypes_ list with AtomType populations, based on Isotopologues relative populations and associated Species populations
+	atomTypes_.clear();
+	for (SpeciesInfo *spInfo = speciesInfoList.first(); spInfo != NULL; spInfo = spInfo->next())
+	{
+		const Species *sp = spInfo->species();
+
+		// Loop over Atoms in the Species
+		for (SpeciesAtom *i = sp->firstAtom(); i != NULL; i = i->next())
+			atomTypes_.add(i->atomType(), spInfo->population());
+	}
+	atomTypes_.finalise();
+
+	// Retrieve form factor data for the current atom types
+	formFactors_ = formFactors;
+	if (!getFormFactors())
+		return false;
+
+	calculateMatrices();
+
+	valid_ = true;
+
+	return true;
+}
+
+// Return AtomTypeList
+AtomTypeList &XRayWeights::atomTypes() { return atomTypes_; }
+
+// Return number of used AtomTypes
+int XRayWeights::nUsedTypes() const { return atomTypes_.nItems(); }
+
+// Print atomtype information
+void XRayWeights::print() const
+{
+	// Print atomtypes table
+	Messenger::print("\n");
+	atomTypes_.print();
+}
+
+/*
+ * Data
+ */
+
+// Calculate matrices from current AtomType information
+void XRayWeights::calculateMatrices()
+{
+	concentrationProducts_.initialise(atomTypes_.nItems(), atomTypes_.nItems(), true);
+	preFactors_.initialise(atomTypes_.nItems(), atomTypes_.nItems(), true);
+
+	double ci, cj;
+
+	// Determine atomic concentration products and full pre-factor
+	AtomTypeData *atd1 = atomTypes_.first(), *atd2;
+	for (int typeI = 0; typeI < atomTypes_.nItems(); ++typeI, atd1 = atd1->next())
+	{
+		ci = atd1->fraction();
+
+		atd2 = atd1;
+		for (int typeJ = typeI; typeJ < atomTypes_.nItems(); ++typeJ, atd2 = atd2->next())
+		{
+			cj = atd2->fraction();
+
+			concentrationProducts_.at(typeI, typeJ) = ci * cj;
+			preFactors_.at(typeI, typeJ) = ci * cj * (typeI == typeJ ? 1 : 2);
+		}
+	}
+}
+
+// Return concentration product for types i and j
+double XRayWeights::concentrationProduct(int i, int j) const { return concentrationProducts_.constAt(i, j); }
+
+// Return form factor product for types i and j at specified Q value
+double XRayWeights::formFactorProduct(int i, int j, double Q) const
+{
+#ifdef CHECKS
+	if ((i < 0) || (i >= formFactorData_.size()))
+	{
+		Messenger::error("XRayWeights::formFactorProduct() - Type i index %i is out of range.\n", i);
+		return 0.0;
+	}
+	if ((j < 0) || (j >= formFactorData_.size()))
+	{
+		Messenger::error("XRayWeights::formFactorProduct() - Type j index %i is out of range.\n", j);
+		return 0.0;
+	}
+#endif
+	return formFactorData_[i].get().magnitude(Q) * formFactorData_[j].get().magnitude(Q);
+}
+
+// Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) at specified Q value
+double XRayWeights::weight(int i, int j, double Q) const { return preFactors_.constAt(i, j) * formFactorProduct(i, j, Q); }
+
+// Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) over supplied Q values
+Array<double> XRayWeights::weight(int i, int j, const Array<double> Q) const
+{
+	// Initialise results array
+	Array<double> fijq(Q.nItems());
+
+	// Get form factor data for involved types
+#ifdef CHECKS
+	if ((i < 0) || (i >= formFactorData_.size()))
+	{
+		Messenger::error("XRayWeights::formFactorProduct() - Type i index %i is out of range.\n", i);
+		return 0.0;
+	}
+	if ((j < 0) || (j >= formFactorData_.size()))
+	{
+		Messenger::error("XRayWeights::formFactorProduct() - Type j index %i is out of range.\n", j);
+		return 0.0;
+	}
+#endif
+	auto fi = formFactorData_[i].get();
+	auto fj = formFactorData_[j].get();
+	auto preFactor = preFactors_.constAt(i, j);
+
+	for (int n = 0; n < Q.nItems(); ++n)
+		fijq[n] = fi.magnitude(Q.constAt(n)) * fj.magnitude(Q.constAt(n)) * preFactor;
+
+	return fijq;
+}
+
+// Return whether the structure is valid (i.e. has been finalised)
+bool XRayWeights::isValid() const { return valid_; }
+
+/*
+ * GenericItemBase Implementations
+ */
+
+// Return class name
+const char *XRayWeights::itemClassName() { return "XRayWeights"; }
+
+// Read data through specified LineParser
+bool XRayWeights::read(LineParser &parser, const CoreData &coreData)
+{
+	clear();
+
+	// Read form factor dataset to use
+	if (!parser.getArgsDelim())
+		return false;
+	formFactors_ = XRayFormFactors::xRayFormFactorData().enumeration(parser.argc(0));
+
+	// Read AtomTypeList
+	if (!atomTypes_.read(parser, coreData))
+		return false;
+
+	// Get form factors
+	if (!getFormFactors())
+		return false;
+
+	// Calculate matrices
+	calculateMatrices();
+
+	valid_ = true;
+
+	return true;
+}
+
+// Write data through specified LineParser
+bool XRayWeights::write(LineParser &parser)
+{
+	// Write x-ray form factor dataset
+	if (!parser.writeLineF("%s\n", XRayFormFactors::xRayFormFactorData().keyword(formFactors_)))
+		return false;
+
+	// Write AtomTypeList
+	if (!atomTypes_.write(parser))
+		return false;
+
+	return true;
+}
+
+/*
+ * Parallel Comms
+ */
+
+// Broadcast item contents
+bool XRayWeights::broadcast(ProcessPool &procPool, const int root, const CoreData &coreData)
+{
+#ifdef PARALLEL
+	if (!procPool.broadcast(EnumCast<XRayFormFactors::XRayFormFactorData>(formFactors_), root))
+		return false;
+	if (!atomTypes_.broadcast(procPool, root, coreData))
+		return false;
+	if (!procPool.broadcast(concentrationProducts_, root))
+		return false;
+	if (!procPool.broadcast(preFactors_, root))
+		return false;
+	if (!procPool.broadcast(valid_, root))
+		return false;
+#endif
+	return true;
+}
+
+// Check item equality
+bool XRayWeights::equality(ProcessPool &procPool)
+{
+#ifdef PARALLEL
+	if (!procPool.equality(EnumCast<XRayFormFactors::XRayFormFactorData>(formFactors_)))
+		return Messenger::error("XRayWeights form factor datasets are not equivalent.\n");
+	if (!atomTypes_.equality(procPool))
+		return Messenger::error("XRayWeights AtomTypes are not equivalent.\n");
+	if (!procPool.equality(concentrationProducts_))
+		return Messenger::error("XRayWeights concentration matrix is not equivalent.\n");
+	if (!procPool.equality(preFactors_))
+		return Messenger::error("XRayWeights bound coherent matrix is not equivalent.\n");
+	if (!procPool.equality(valid_))
+		return Messenger::error("XRayWeights validity is not equivalent (process %i has %i).\n", procPool.poolRank(), valid_);
+#endif
+	return true;
+}

--- a/src/classes/xrayweights.h
+++ b/src/classes/xrayweights.h
@@ -37,7 +37,7 @@ class SpeciesInfo;
 // XRay Weights Container
 class XRayWeights : public GenericItemBase
 {
-      public:
+	public:
 	// Constructor
 	XRayWeights();
 	// Copy Constructor
@@ -48,7 +48,7 @@ class XRayWeights : public GenericItemBase
 	/*
 	 * Source AtomTypes
 	 */
-      private:
+	private:
 	// X-Ray form factors to use
 	XRayFormFactors::XRayFormFactorData formFactors_;
 	// Type list derived from supplied Species
@@ -58,11 +58,11 @@ class XRayWeights : public GenericItemBase
 	// Whether the structure is valid (i.e. has been finalised)
 	bool valid_;
 
-      private:
+	private:
 	// Retrieve form factor data for the current atom types
 	bool getFormFactors();
 
-      public:
+	public:
 	// Clear contents
 	void clear();
 	// Set-up from supplied SpeciesInfo list
@@ -81,7 +81,7 @@ class XRayWeights : public GenericItemBase
 	/*
 	 * Data
 	 */
-      private:
+	private:
 	// Concentration products (ci)
 	Array<double> concentrations_;
 	// Concentration product matrix (ci * cj)
@@ -93,11 +93,11 @@ class XRayWeights : public GenericItemBase
 	// Bound coherent squared average scattering (<b**2>)
 	double boundCoherentAverageOfSquares_;
 
-      private:
+	private:
 	// Set up matrices based on current AtomType information
 	void setUpMatrices();
 
-      public:
+	public:
 	// Return concentration product for type i
 	double concentration(int typeIndexI) const;
 	// Return concentration product for types i and j
@@ -116,7 +116,7 @@ class XRayWeights : public GenericItemBase
 	/*
 	 * GenericItemBase Implementations
 	 */
-      public:
+	public:
 	// Return class name
 	static const char *itemClassName();
 	// Read data through specified LineParser
@@ -127,7 +127,7 @@ class XRayWeights : public GenericItemBase
 	/*
 	 * Parallel Comms
 	 */
-      public:
+	public:
 	// Broadcast item contents
 	bool broadcast(ProcessPool &procPool, const int root, const CoreData &coreData);
 	// Check item equality

--- a/src/classes/xrayweights.h
+++ b/src/classes/xrayweights.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 // Forward Declarations
+class Species;
 class SpeciesInfo;
 
 // XRay Weights Container
@@ -65,7 +66,15 @@ class XRayWeights : public GenericItemBase
 	// Clear contents
 	void clear();
 	// Set-up from supplied SpeciesInfo list
+<<<<<<< HEAD
 	bool setUp(List<SpeciesInfo> &speciesInfoList, XRayFormFactors::XRayFormFactorData formFactors);
+=======
+	bool setUp(List<SpeciesInfo>& speciesInfoList, XRayFormFactors::XRayFormFactorData formFactors);
+	// Add Species to weights in the specified population
+	void addSpecies(const Species* sp, int population);
+	// Finalise weights after addition of all individual Species
+	bool finalise(XRayFormFactors::XRayFormFactorData formFactors);
+>>>>>>> 42916d84... Update XRaySQ module.
 	// Return AtomTypeList
 	AtomTypeList &atomTypes();
 	// Return number of used AtomTypes
@@ -83,8 +92,8 @@ class XRayWeights : public GenericItemBase
 	Array2D<double> preFactors_;
 
       private:
-	// Calculate  matrices based on current AtomType information
-	void calculateMatrices();
+	// Set up matrices based on current AtomType information
+	void setUpMatrices();
 
       public:
 	// Return concentration product for types i and j
@@ -120,3 +129,5 @@ class XRayWeights : public GenericItemBase
 };
 
 #endif
+
+

--- a/src/classes/xrayweights.h
+++ b/src/classes/xrayweights.h
@@ -1,0 +1,122 @@
+/*
+	*** XRay Weights Container
+	*** src/classes/xrayweights.h
+	Copyright T. Youngs 2012-2020
+
+	This file is part of Dissolve.
+
+	Dissolve is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Dissolve is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DISSOLVE_XRAYWEIGHTS_H
+#define DISSOLVE_XRAYWEIGHTS_H
+
+#include "classes/atomtypelist.h"
+#include "data/formfactors.h"
+#include "genericitems/base.h"
+#include "templates/array2d.h"
+#include "templates/list.h"
+#include <functional>
+#include <vector>
+
+// Forward Declarations
+class SpeciesInfo;
+
+// XRay Weights Container
+class XRayWeights : public GenericItemBase
+{
+      public:
+	// Constructor
+	XRayWeights();
+	// Copy Constructor
+	XRayWeights(const XRayWeights &source);
+	// Assignment operator
+	void operator=(const XRayWeights &source);
+
+	/*
+	 * Source AtomTypes
+	 */
+      private:
+	// X-Ray form factors to use
+	XRayFormFactors::XRayFormFactorData formFactors_;
+	// Type list derived from supplied Species
+	AtomTypeList atomTypes_;
+	// Form factor data for atom types
+	std::vector<std::reference_wrapper<const FormFactorData>> formFactorData_;
+	// Whether the structure is valid (i.e. has been finalised)
+	bool valid_;
+
+      private:
+	// Retrieve form factor data for the current atom types
+	bool getFormFactors();
+
+      public:
+	// Clear contents
+	void clear();
+	// Set-up from supplied SpeciesInfo list
+	bool setUp(List<SpeciesInfo> &speciesInfoList, XRayFormFactors::XRayFormFactorData formFactors);
+	// Return AtomTypeList
+	AtomTypeList &atomTypes();
+	// Return number of used AtomTypes
+	int nUsedTypes() const;
+	// Print atomtype information
+	void print() const;
+
+	/*
+	 * Data
+	 */
+      private:
+	// Concentration product matrix (ci * cj)
+	Array2D<double> concentrationProducts_;
+	// Pre-factors matrix (ci * cj * [2-dij])
+	Array2D<double> preFactors_;
+
+      private:
+	// Calculate  matrices based on current AtomType information
+	void calculateMatrices();
+
+      public:
+	// Return concentration product for types i and j
+	double concentrationProduct(int i, int j) const;
+	// Return form factor product for types i and j at specified Q value
+	double formFactorProduct(int i, int j, double Q) const;
+	// Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) at specified Q value
+	double weight(int i, int j, double Q) const;
+	// Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) over supplied Q values
+	Array<double> weight(int i, int j, const Array<double> Q) const;
+	// Return whether the structure is valid (i.e. has been finalised)
+	bool isValid() const;
+
+	/*
+	 * GenericItemBase Implementations
+	 */
+      public:
+	// Return class name
+	static const char *itemClassName();
+	// Read data through specified LineParser
+	bool read(LineParser &parser, const CoreData &coreData);
+	// Write data through specified LineParser
+	bool write(LineParser &parser);
+
+	/*
+	 * Parallel Comms
+	 */
+      public:
+	// Broadcast item contents
+	bool broadcast(ProcessPool &procPool, const int root, const CoreData &coreData);
+	// Check item equality
+	bool equality(ProcessPool &procPool);
+};
+
+#endif

--- a/src/classes/xrayweights.h
+++ b/src/classes/xrayweights.h
@@ -66,15 +66,11 @@ class XRayWeights : public GenericItemBase
 	// Clear contents
 	void clear();
 	// Set-up from supplied SpeciesInfo list
-<<<<<<< HEAD
 	bool setUp(List<SpeciesInfo> &speciesInfoList, XRayFormFactors::XRayFormFactorData formFactors);
-=======
-	bool setUp(List<SpeciesInfo>& speciesInfoList, XRayFormFactors::XRayFormFactorData formFactors);
 	// Add Species to weights in the specified population
-	void addSpecies(const Species* sp, int population);
+	void addSpecies(const Species *sp, int population);
 	// Finalise weights after addition of all individual Species
 	bool finalise(XRayFormFactors::XRayFormFactorData formFactors);
->>>>>>> 42916d84... Update XRaySQ module.
 	// Return AtomTypeList
 	AtomTypeList &atomTypes();
 	// Return number of used AtomTypes
@@ -86,24 +82,34 @@ class XRayWeights : public GenericItemBase
 	 * Data
 	 */
       private:
+	// Concentration products (ci)
+	Array<double> concentrations_;
 	// Concentration product matrix (ci * cj)
 	Array2D<double> concentrationProducts_;
 	// Pre-factors matrix (ci * cj * [2-dij])
 	Array2D<double> preFactors_;
+	// Average squared scattering (<b>**2)
+	double boundCoherentSquareOfAverage_;
+	// Bound coherent squared average scattering (<b**2>)
+	double boundCoherentAverageOfSquares_;
 
       private:
 	// Set up matrices based on current AtomType information
 	void setUpMatrices();
 
       public:
+	// Return concentration product for type i
+	double concentration(int typeIndexI) const;
 	// Return concentration product for types i and j
-	double concentrationProduct(int i, int j) const;
+	double concentrationProduct(int typeIndexI, int typeIndexJ) const;
 	// Return form factor product for types i and j at specified Q value
-	double formFactorProduct(int i, int j, double Q) const;
+	double formFactorProduct(int typeIndexI, int typeIndexJ, double Q) const;
+	// Return form factor for type i over supplied Q values
+	Array<double> formFactor(int typeIndexI, const Array<double> &Q) const;
 	// Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) at specified Q value
-	double weight(int i, int j, double Q) const;
+	double weight(int typeIndexI, int typetypeIndexJ, double Q) const;
 	// Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) over supplied Q values
-	Array<double> weight(int i, int j, const Array<double> Q) const;
+	Array<double> weight(int typeIndexI, int typeIndexJ, const Array<double> &Q) const;
 	// Return whether the structure is valid (i.e. has been finalised)
 	bool isValid() const;
 
@@ -129,5 +135,3 @@ class XRayWeights : public GenericItemBase
 };
 
 #endif
-
-

--- a/src/classes/xrayweights.h
+++ b/src/classes/xrayweights.h
@@ -56,8 +56,8 @@ class XRayWeights : public GenericItemBase
 	bool valid_;
 
 	private:
-	// Retrieve form factor data for the current atom types
-	bool getFormFactors();
+	// Initialise form factor data for the current atom types
+	bool initialiseFormFactors();
 
 	public:
 	// Clear contents

--- a/src/classes/xrayweights.h
+++ b/src/classes/xrayweights.h
@@ -38,11 +38,8 @@ class SpeciesInfo;
 class XRayWeights : public GenericItemBase
 {
 	public:
-	// Constructor
 	XRayWeights();
-	// Copy Constructor
 	XRayWeights(const XRayWeights &source);
-	// Assignment operator
 	void operator=(const XRayWeights &source);
 
 	/*

--- a/src/gui/keywordwidgets/base.h
+++ b/src/gui/keywordwidgets/base.h
@@ -22,8 +22,6 @@
 #ifndef DISSOLVE_KEYWORDWIDGET_BASE_H
 #define DISSOLVE_KEYWORDWIDGET_BASE_H
 
-#include "templates/listitem.h"
-
 // Forward Declarations
 class CoreData;
 class GenericList;

--- a/src/gui/keywordwidgets/isotopologuecollection.h
+++ b/src/gui/keywordwidgets/isotopologuecollection.h
@@ -22,6 +22,7 @@
 #ifndef DISSOLVE_KEYWORDWIDGET_ISOTOPOLOGUECOLLECTION_H
 #define DISSOLVE_KEYWORDWIDGET_ISOTOPOLOGUECOLLECTION_H
 
+#include "gui/helpers/treewidgetupdater.h"
 #include "gui/keywordwidgets/base.h"
 #include "gui/keywordwidgets/dropdown.h"
 #include "gui/keywordwidgets/ui_isotopologuecollection.h"
@@ -57,7 +58,7 @@ class IsotopologueCollectionKeywordWidget : public KeywordDropDown, public Keywo
 	void autoButton_clicked(bool checked);
 	void addButton_clicked(bool checked);
 	void removeButton_clicked(bool checked);
-	void isotopologueTree_itemChanged(QTreeWidgetItem *w, int column);
+	void isotopologueTree_itemChanged(QTreeWidgetItem *item, int column);
 	void isotopologueTree_currentItemChanged(QTreeWidgetItem *currentItem, QTreeWidgetItem *previousItem);
 
 	signals:
@@ -68,15 +69,18 @@ class IsotopologueCollectionKeywordWidget : public KeywordDropDown, public Keywo
 	 * Update
 	 */
 	private:
+	// Tree widget item managers
+	TreeWidgetItemManager<IsotopologueCollectionKeywordWidget, IsotopologueSet> isotopologueSetsItemManager_;
+	TreeWidgetItemManager<IsotopologueCollectionKeywordWidget, Isotopologues> isotopologuesItemManager_;
+	TreeWidgetItemManager<IsotopologueCollectionKeywordWidget, IsotopologueWeight> isotopologueWeightItemManager_;
+
+	private:
 	// IsotopologueTree root (IsotopologueSet) item update function
-	void updateIsotopologueTreeRootItem(QTreeWidget *treeWidget, int topLevelItemIndex, IsotopologueSet *topeSet,
-					    bool createItem);
+	void updateIsotopologueTreeRootItem(QTreeWidgetItem *item, IsotopologueSet &topeSet, bool itemIsNew);
 	// IsotopologueTree child (Isotopologues) update function
-	void updateIsotopologueTreeChildItem(QTreeWidgetItem *parentItem, int childIndex, Isotopologues *topes,
-					     bool createItem);
+	void updateIsotopologueTreeChildItem(QTreeWidgetItem *item, Isotopologues &topes, bool itemIsNew);
 	// IsotopologueTree sub-child (IsotopologueWeight) update function
-	void updateIsotopologueTreeSubChildItem(QTreeWidgetItem *parentItem, int childIndex, IsotopologueWeight *isoWeight,
-						bool createItem);
+	void updateIsotopologueTreeSubChildItem(QTreeWidgetItem *item, IsotopologueWeight &isoWeight, bool itemIsNew);
 
 	public:
 	// Update value displayed in widget

--- a/src/gui/keywordwidgets/isotopologuecollection_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologuecollection_funcs.cpp
@@ -27,7 +27,6 @@
 #include "gui/delegates/exponentialspin.hui"
 #include "gui/delegates/isotopologuecombo.hui"
 #include "gui/delegates/usedspeciescombo.hui"
-#include "gui/helpers/treewidgetupdater.h"
 #include "gui/keywordwidgets/dropdown.h"
 #include "gui/keywordwidgets/isotopologuecollection.h"
 #include "module/module.h"
@@ -35,7 +34,8 @@
 
 IsotopologueCollectionKeywordWidget::IsotopologueCollectionKeywordWidget(QWidget *parent, KeywordBase *keyword,
 									 const CoreData &coreData)
-	: KeywordDropDown(this), KeywordWidgetBase(coreData)
+	: KeywordDropDown(this), KeywordWidgetBase(coreData), isotopologueSetsItemManager_(this),
+	  isotopologuesItemManager_(this), isotopologueWeightItemManager_(this)
 {
 	// Create and set up the UI for our widget in the drop-down's widget container
 	ui_.setupUi(dropWidget());
@@ -203,35 +203,66 @@ void IsotopologueCollectionKeywordWidget::removeButton_clicked(bool checked)
 		return;
 
 	// Determine what kind of data is selected
-	if (!item->text(0).isEmpty())
+	if (isotopologueSetsItemManager_.isMapped(item))
 	{
-		IsotopologueSet *set = VariantPointer<IsotopologueSet>(item->data(0, Qt::UserRole));
-		if (!set)
+		// Get IsotopologueSet reference
+		auto data = isotopologueSetsItemManager_.reference(item);
+		if (std::get<1>(data))
+		{
+			// TODO Raise Exception
+			Messenger::error("Reference for IsotopologueSet not in map.\n");
 			return;
-		keyword_->data().remove(set);
+		}
+		keyword_->data().remove(&std::get<0>(data));
 	}
-	else if (!item->text(1).isEmpty())
+	else if (isotopologuesItemManager_.isMapped(item))
 	{
-		IsotopologueSet *set = VariantPointer<IsotopologueSet>(item->data(0, Qt::UserRole));
-		if (!set)
+		// Get IsotopologueSet reference
+		auto setData = isotopologueSetsItemManager_.reference(item->parent());
+		if (std::get<1>(setData))
+		{
+			// TODO Raise Exception
+			Messenger::error("Reference for IsotopologueSet not in map.\n");
 			return;
+		}
 
-		Isotopologues *topes = VariantPointer<Isotopologues>(item->data(1, Qt::UserRole));
-		if (!topes)
+		// Get Isotopologues reference
+		auto topesData = isotopologuesItemManager_.reference(item);
+		if (std::get<1>(topesData))
+		{
+			// TODO Raise Exception
+			Messenger::error("Reference for Isotopologues not in map.\n");
 			return;
-		keyword_->data().remove(set, topes->species());
+		}
+
+		keyword_->data().remove(&std::get<0>(setData), std::get<0>(topesData).species());
 	}
-	else
+	else if (isotopologueWeightItemManager_.isMapped(item))
 	{
-		IsotopologueSet *set = VariantPointer<IsotopologueSet>(item->data(0, Qt::UserRole));
-		if (!set)
-			return;
+		// Get toplevel item parent (two levels up) so we have access to the IsotopologueSet
+		QTreeWidgetItem *topLevelItem = item->parent();
+		while (topLevelItem->parent())
+			topLevelItem = topLevelItem->parent();
 
-		IsotopologueWeight *isoWeight = VariantPointer<IsotopologueWeight>(item->data(1, Qt::UserRole));
-		if (!isoWeight)
+		// Get IsotopologueSet reference
+		auto setData = isotopologueSetsItemManager_.reference(topLevelItem);
+		if (std::get<1>(setData))
+		{
+			// TODO Raise Exception
+			Messenger::error("Reference for IsotopologueSet not in map.\n");
 			return;
+		}
 
-		keyword_->data().remove(set, isoWeight);
+		// Get IsotopologueWeight reference
+		auto weightData = isotopologueWeightItemManager_.reference(item);
+		if (std::get<1>(weightData))
+		{
+			// TODO Raise Exception
+			Messenger::error("Reference for IsotopologueWeight not in map.\n");
+			return;
+		}
+
+		keyword_->data().remove(&std::get<0>(setData), &std::get<0>(weightData));
 	}
 
 	// Manually flag that the keyword data has changed
@@ -242,55 +273,63 @@ void IsotopologueCollectionKeywordWidget::removeButton_clicked(bool checked)
 	emit(keywordValueChanged(keyword_->optionMask()));
 }
 
-void IsotopologueCollectionKeywordWidget::isotopologueTree_itemChanged(QTreeWidgetItem *w, int column)
+void IsotopologueCollectionKeywordWidget::isotopologueTree_itemChanged(QTreeWidgetItem *item, int column)
 {
 	if (refreshing_)
 		return;
 
-	// Get item parent, and retrieve the IsotopologueSet
-	if (!w->parent())
+	// Only editable items are in the IsotopologueWeight, so the item must reflect one
+	if (!isotopologueWeightItemManager_.isMapped(item))
+	{
+		Messenger::error("Item being changed doesn't appear to be an IsotopologueWeight.\n");
 		return;
-	Isotopologues *topes = VariantPointer<Isotopologues>(w->parent()->data(1, Qt::UserRole));
-	if (!topes)
-		return;
+	}
 
-	// Get the IsotopologueWeight for the current item
-	IsotopologueWeight *topeWeight = VariantPointer<IsotopologueWeight>(w->data(1, Qt::UserRole));
-	if (!topeWeight)
+	// Get IsotopologueWeight reference
+	auto weightData = isotopologueWeightItemManager_.reference(item);
+	if (std::get<1>(weightData))
+	{
+		// TODO Raise Exception
+		Messenger::error("Reference for IsotopologueWeight not in map.\n");
 		return;
+	}
+	auto &weight = std::get<0>(weightData);
 
 	// Column of passed item tells us the type of data we need to change
-	Isotopologue *iso;
-	switch (column)
+	if (column == 2)
 	{
-		// Isotopologue
-		case (2):
-			// Find the isotopologue by name in the parent species...
-			iso = topes->species()->findIsotopologue(qPrintable(w->text(column)));
-			if (!iso)
-				return;
+		// Editing the Isotopologue - need the parent item in order to validate it
+		auto topesData = isotopologuesItemManager_.reference(item->parent());
+		if (std::get<1>(topesData))
+		{
+			// TODO Raise Exception
+			Messenger::error("Reference for Isotopologues not in map.\n");
+			return;
+		}
+		auto &topes = std::get<0>(topesData);
+		auto *iso = topes.species()->findIsotopologue(qPrintable(item->text(column)));
+		if (!iso)
+			return;
 
-			// Set the new Isotopologue
-			topeWeight->setIsotopologue(iso);
+		// Set the new Isotopologue
+		weight.setIsotopologue(iso);
 
-			// Manually flag that the keyword data has changed
-			keyword_->hasBeenSet();
+		// Manually flag that the keyword data has changed
+		keyword_->hasBeenSet();
 
-			emit(keywordValueChanged(keyword_->optionMask()));
-			break;
-		// Weight
-		case (3):
-			topeWeight->setWeight(w->text(column).toDouble());
-
-			// Manually flag that the keyword data has changed
-			keyword_->hasBeenSet();
-
-			emit(keywordValueChanged(keyword_->optionMask()));
-			break;
-		default:
-			Messenger::error("Don't know what to do with data from column %i of Isotopologue table.\n", column);
-			break;
+		emit(keywordValueChanged(keyword_->optionMask()));
 	}
+	else if (column == 3)
+	{
+		weight.setWeight(item->text(column).toDouble());
+
+		// Manually flag that the keyword data has changed
+		keyword_->hasBeenSet();
+
+		emit(keywordValueChanged(keyword_->optionMask()));
+	}
+	else
+		Messenger::error("Don't know what to do with data from column %i of Isotopologue table.\n", column);
 }
 
 void IsotopologueCollectionKeywordWidget::isotopologueTree_currentItemChanged(QTreeWidgetItem *currentItem,
@@ -304,70 +343,44 @@ void IsotopologueCollectionKeywordWidget::isotopologueTree_currentItemChanged(QT
  */
 
 // IsotopologueTree parent (IsotopologueSet) item update function
-void IsotopologueCollectionKeywordWidget::updateIsotopologueTreeRootItem(QTreeWidget *treeWidget, int topLevelItemIndex,
-									 IsotopologueSet *topeSet, bool createItem)
+void IsotopologueCollectionKeywordWidget::updateIsotopologueTreeRootItem(QTreeWidgetItem *item, IsotopologueSet &topeSet,
+									 bool itemIsNew)
 {
-	QTreeWidgetItem *item;
-	if (createItem)
-	{
-		item = new QTreeWidgetItem;
-		item->setData(0, Qt::UserRole, VariantPointer<IsotopologueSet>(topeSet));
+	if (itemIsNew)
 		item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
-		treeWidget->insertTopLevelItem(topLevelItemIndex, item);
-	}
-	else
-		item = treeWidget->topLevelItem(topLevelItemIndex);
 
 	// Set item data
-	item->setText(0, topeSet->configuration()->name());
+	item->setText(0, topeSet.configuration()->name());
 
 	// Update child (Isotopologues) items
-	TreeWidgetUpdater<IsotopologueCollectionKeywordWidget, Isotopologues> treeUpdater(
-		item, topeSet->isotopologues(), this, &IsotopologueCollectionKeywordWidget::updateIsotopologueTreeChildItem);
+	isotopologuesItemManager_.updateChildren(item, topeSet.isotopologues(),
+						 &IsotopologueCollectionKeywordWidget::updateIsotopologueTreeChildItem);
 }
 
 // IsotopologueTree child (Isotopologues) update function
-void IsotopologueCollectionKeywordWidget::updateIsotopologueTreeChildItem(QTreeWidgetItem *parentItem, int childIndex,
-									  Isotopologues *topes, bool createItem)
+void IsotopologueCollectionKeywordWidget::updateIsotopologueTreeChildItem(QTreeWidgetItem *item, Isotopologues &topes,
+									  bool itemIsNew)
 {
-	QTreeWidgetItem *item;
-	if (createItem)
-	{
-		item = new QTreeWidgetItem;
-		item->setData(0, Qt::UserRole, parentItem->data(0, Qt::UserRole));
-		item->setData(1, Qt::UserRole, VariantPointer<Isotopologues>(topes));
+	if (itemIsNew)
 		item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
-		parentItem->insertChild(childIndex, item);
-	}
-	else
-		item = parentItem->child(childIndex);
 
 	// Set item data
-	item->setText(1, topes->species()->name());
+	item->setText(1, topes.species()->name());
 
-	// Update sub-child (Isotopologue/weight) items
-	TreeWidgetUpdater<IsotopologueCollectionKeywordWidget, IsotopologueWeight> subChildUpdater(
-		item, topes->mix(), this, &IsotopologueCollectionKeywordWidget::updateIsotopologueTreeSubChildItem);
+	// Update child (IsotopologueWeight) items
+	isotopologueWeightItemManager_.updateChildren(item, topes.mix(),
+						      &IsotopologueCollectionKeywordWidget::updateIsotopologueTreeSubChildItem);
 }
 
-// IsotopologueTree sub-child (Isotopologue/double) update function
-void IsotopologueCollectionKeywordWidget::updateIsotopologueTreeSubChildItem(QTreeWidgetItem *parentItem, int childIndex,
-									     IsotopologueWeight *isoWeight, bool createItem)
+// IsotopologueTree sub-child (IsotopologueWeight) update function
+void IsotopologueCollectionKeywordWidget::updateIsotopologueTreeSubChildItem(QTreeWidgetItem *item,
+									     IsotopologueWeight &isoWeight, bool itemIsNew)
 {
-	QTreeWidgetItem *item;
-	if (createItem)
-	{
-		item = new QTreeWidgetItem;
-		item->setData(0, Qt::UserRole, parentItem->data(0, Qt::UserRole));
-		item->setData(1, Qt::UserRole, VariantPointer<IsotopologueWeight>(isoWeight));
-		item->setData(2, Qt::UserRole, VariantPointer<const Isotopologue>(isoWeight->isotopologue()));
+	if (itemIsNew)
 		item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable);
-		parentItem->insertChild(childIndex, item);
-	}
-	else
-		item = parentItem->child(childIndex);
-	item->setText(2, isoWeight->isotopologue()->name());
-	item->setText(3, QString::number(isoWeight->weight()));
+
+	item->setText(2, isoWeight.isotopologue()->name());
+	item->setText(3, QString::number(isoWeight.weight()));
 }
 
 // Update value displayed in widget
@@ -379,9 +392,8 @@ void IsotopologueCollectionKeywordWidget::updateWidgetValues(const CoreData &cor
 	refreshing_ = true;
 
 	// Update the root items of the tree with the allowed Configurations list
-	TreeWidgetUpdater<IsotopologueCollectionKeywordWidget, IsotopologueSet> treeUpdater(
-		ui_.IsotopologueTree, keyword_->data().isotopologueSets(), this,
-		&IsotopologueCollectionKeywordWidget::updateIsotopologueTreeRootItem);
+	isotopologueSetsItemManager_.update(ui_.IsotopologueTree, keyword_->data().isotopologueSets(),
+					    &IsotopologueCollectionKeywordWidget::updateIsotopologueTreeRootItem);
 
 	for (int n = 0; n < 4; ++n)
 		ui_.IsotopologueTree->resizeColumnToContents(n);

--- a/src/gui/keywordwidgets/isotopologuecollection_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologuecollection_funcs.cpp
@@ -165,17 +165,20 @@ void IsotopologueCollectionKeywordWidget::addButton_clicked(bool checked)
 
 		Species *sp = isoWeight->isotopologue()->parent();
 
-		Isotopologues *topes = set->isotopologues(sp);
+		auto data = set->getIsotopologues(sp);
+
+		// TODO Raise exception if isotopologue set not found
+		auto &topes = std::get<0>(data);
 
 		// Natural first
-		if (!topes->contains(sp->naturalIsotopologue()))
+		if (!topes.contains(sp->naturalIsotopologue()))
 			set->add(sp->naturalIsotopologue(), 1.0);
 		else
 		{
 			ListIterator<Isotopologue> topeIterator(sp->isotopologues());
 			while (Isotopologue *tope = topeIterator.iterate())
 			{
-				if (topes->contains(tope))
+				if (topes.contains(tope))
 					continue;
 
 				set->add(tope, 1.0);

--- a/src/keywords/isotopologuecollection.cpp
+++ b/src/keywords/isotopologuecollection.cpp
@@ -97,12 +97,11 @@ bool IsotopologueCollectionKeyword::write(LineParser &parser, const char *keywor
 	{
 		for (auto topes : set.isotopologues())
 		{
-			ListIterator<IsotopologueWeight> weightIterator(topes.mix());
-			while (IsotopologueWeight *isoWeight = weightIterator.iterate())
+			for (auto isoWeight : topes.mix())
 			{
 				if (!parser.writeLineF("%s%s  '%s'  '%s'  '%s'  %f\n", prefix, keywordName,
 						       set.configuration()->name(), topes.species()->name(),
-						       isoWeight->isotopologue()->name(), isoWeight->weight()))
+						       isoWeight.isotopologue()->name(), isoWeight.weight()))
 					return false;
 			}
 		}

--- a/src/keywords/isotopologuecollection.cpp
+++ b/src/keywords/isotopologuecollection.cpp
@@ -93,17 +93,15 @@ bool IsotopologueCollectionKeyword::read(LineParser &parser, int startArg, const
 bool IsotopologueCollectionKeyword::write(LineParser &parser, const char *keywordName, const char *prefix)
 {
 	// Loop over list of IsotopologueReferences
-	ListIterator<IsotopologueSet> setIterator(data_.isotopologueSets());
-	while (IsotopologueSet *set = setIterator.iterate())
+	for (auto set : data_.isotopologueSets())
 	{
-		ListIterator<Isotopologues> topesIterator(set->isotopologues());
-		while (Isotopologues *topes = topesIterator.iterate())
+		for (auto topes : set.isotopologues())
 		{
-			ListIterator<IsotopologueWeight> weightIterator(topes->mix());
+			ListIterator<IsotopologueWeight> weightIterator(topes.mix());
 			while (IsotopologueWeight *isoWeight = weightIterator.iterate())
 			{
 				if (!parser.writeLineF("%s%s  '%s'  '%s'  '%s'  %f\n", prefix, keywordName,
-						       set->configuration()->name(), topes->species()->name(),
+						       set.configuration()->name(), topes.species()->name(),
 						       isoWeight->isotopologue()->name(), isoWeight->weight()))
 					return false;
 			}

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -23,9 +23,9 @@
 #include "classes/atomtype.h"
 #include "classes/braggreflection.h"
 #include "classes/kvector.h"
+#include "classes/neutronweights.h"
 #include "classes/partialset.h"
 #include "classes/species.h"
-#include "classes/weights.h"
 #include "genericitems/item.h"
 #include "genericitems/items.h"
 #include "math/histogram1d.h"
@@ -145,7 +145,7 @@ void Dissolve::registerGenericItems()
 	GenericItem::addItemClass(new GenericItemContainer<Histogram3D>(Histogram3D::itemClassName()));
 	GenericItem::addItemClass(new GenericItemContainer<Isotopologues>(Isotopologues::itemClassName()));
 	GenericItem::addItemClass(new GenericItemContainer<KVector>(KVector::itemClassName()));
+	GenericItem::addItemClass(new GenericItemContainer<NeutronWeights>(NeutronWeights::itemClassName()));
 	GenericItem::addItemClass(new GenericItemContainer<PairBroadeningFunction>(PairBroadeningFunction::itemClassName()));
 	GenericItem::addItemClass(new GenericItemContainer<PartialSet>(PartialSet::itemClassName()));
-	GenericItem::addItemClass(new GenericItemContainer<Weights>(Weights::itemClassName()));
 }

--- a/src/modules/bragg/bragg.h
+++ b/src/modules/bragg/bragg.h
@@ -29,7 +29,6 @@
 
 // Forward Declarations
 class PartialSet;
-class Weights;
 
 // Bragg Module
 class BraggModule : public Module

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -26,7 +26,6 @@
 #include "classes/configuration.h"
 #include "classes/kvector.h"
 #include "classes/species.h"
-#include "classes/weights.h"
 #include "genericitems/listhelper.h"
 #include "math/broadeningfunction.h"
 #include "math/filters.h"

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -22,7 +22,7 @@
 #include "classes/box.h"
 #include "classes/configuration.h"
 #include "classes/species.h"
-#include "classes/weights.h"
+#include "classes/neutronweights.h"
 #include "genericitems/listhelper.h"
 #include "main/dissolve.h"
 #include "math/averaging.h"

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -21,8 +21,8 @@
 
 #include "classes/box.h"
 #include "classes/configuration.h"
-#include "classes/species.h"
 #include "classes/neutronweights.h"
+#include "classes/species.h"
 #include "genericitems/listhelper.h"
 #include "main/dissolve.h"
 #include "math/averaging.h"

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -21,9 +21,9 @@
 
 #include "base/sysfunc.h"
 #include "classes/atomtype.h"
+#include "classes/neutronweights.h"
 #include "classes/partialset.h"
 #include "classes/scatteringmatrix.h"
-#include "classes/weights.h"
 #include "data/isotopes.h"
 #include "genericitems/listhelper.h"
 #include "io/export/data1d.h"
@@ -533,17 +533,18 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
 		{
 			bool found;
 
-			// Retrieve the reference data, associated Weights matrix and source unweighted and weighted partials
+			// Retrieve the reference data, associated neutron weights and source unweighted and weighted partials
 			const Data1D &referenceData = GenericListHelper<Data1D>::value(
 				dissolve.processingModuleData(), "ReferenceData", module->uniqueName(), Data1D(), &found);
 			if (!found)
 				return Messenger::error("Could not locate ReferenceData for target '%s'.\n",
 							module->uniqueName());
 
-			Weights &weights = GenericListHelper<Weights>::retrieve(dissolve.processingModuleData(), "FullWeights",
-										module->uniqueName(), Weights(), &found);
+			NeutronWeights &weights = GenericListHelper<NeutronWeights>::retrieve(
+				dissolve.processingModuleData(), "FullWeights", module->uniqueName(), NeutronWeights(), &found);
 			if (!found)
-				return Messenger::error("Could not locate Weights for target '%s'.\n", module->uniqueName());
+				return Messenger::error("Could not locate NeutronWeights for target '%s'.\n",
+							module->uniqueName());
 
 			const PartialSet &unweightedSQ = GenericListHelper<PartialSet>::value(
 				dissolve.processingModuleData(), "UnweightedSQ", module->uniqueName(), PartialSet(), &found);

--- a/src/modules/neutronsq/functions.cpp
+++ b/src/modules/neutronsq/functions.cpp
@@ -130,10 +130,9 @@ bool NeutronSQModule::calculateSummedWeights(NeutronWeights &summedWeights) cons
 				const auto &topes = std::get<0>(data);
 
 				// Add defined isotopologues, in the relative isotopic proportions defined, to the weights.
-				ListIterator<IsotopologueWeight> weightIterator(topes.mix());
-				while (IsotopologueWeight *isoWeight = weightIterator.iterate())
+				for (auto isoWeight : topes.mix())
 					summedWeights.addIsotopologue(spInfo->species(), spInfo->population(),
-								      isoWeight->isotopologue(), isoWeight->weight());
+								      isoWeight.isotopologue(), isoWeight.weight());
 			}
 		}
 	}

--- a/src/modules/neutronsq/functions.cpp
+++ b/src/modules/neutronsq/functions.cpp
@@ -130,7 +130,7 @@ bool NeutronSQModule::calculateSummedWeights(NeutronWeights &summedWeights) cons
 				const auto &topes = std::get<0>(data);
 
 				// Add defined isotopologues, in the relative isotopic proportions defined, to the weights.
-				for (auto isoWeight : topes.mix())
+				for (auto isoWeight : topes.constMix())
 					summedWeights.addIsotopologue(spInfo->species(), spInfo->population(),
 								      isoWeight.isotopologue(), isoWeight.weight());
 			}

--- a/src/modules/neutronsq/functions.cpp
+++ b/src/modules/neutronsq/functions.cpp
@@ -35,11 +35,11 @@ bool NeutronSQModule::calculateWeightedGR(PartialSet &unweightedgr, PartialSet &
 		for (typeJ = typeI; typeJ < unweightedgr.nAtomTypes(); ++typeJ)
 		{
 			double weight = weights.weight(typeI, typeJ);
-			double boundWeight = weights.boundWeight(typeI, typeJ);
+			double intraWeight = weights.intramolecularWeight(typeI, typeJ);
 
 			// Bound (intramolecular) partial (multiplied by the bound term weight)
 			weightedgr.boundPartial(typeI, typeJ).copyArrays(unweightedgr.boundPartial(typeI, typeJ));
-			weightedgr.boundPartial(typeI, typeJ).values() *= boundWeight;
+			weightedgr.boundPartial(typeI, typeJ).values() *= intraWeight;
 
 			// Unbound partial (multiplied by the full weight)
 			weightedgr.unboundPartial(typeI, typeJ).copyArrays(unweightedgr.unboundPartial(typeI, typeJ));
@@ -73,7 +73,7 @@ bool NeutronSQModule::calculateWeightedSQ(PartialSet &unweightedsq, PartialSet &
 		{
 			// Weight bound and unbound S(Q) and sum into full partial
 			double weight = weights.weight(typeI, typeJ);
-			double boundWeight = weights.boundWeight(typeI, typeJ);
+			double boundWeight = weights.intramolecularWeight(typeI, typeJ);
 
 			// Bound (intramolecular) partial (multiplied by the bound term weight)
 			weightedsq.boundPartial(typeI, typeJ).copyArrays(unweightedsq.boundPartial(typeI, typeJ));

--- a/src/modules/neutronsq/functions.cpp
+++ b/src/modules/neutronsq/functions.cpp
@@ -25,8 +25,8 @@
 #include "classes/speciesinfo.h"
 #include "modules/neutronsq/neutronsq.h"
 
-// Calculate weighted g(r) from supplied unweighted g(r) and Weights
-bool NeutronSQModule::calculateWeightedGR(PartialSet &unweightedgr, PartialSet &weightedgr, Weights &weights,
+// Calculate weighted g(r) from supplied unweighted g(r) and neutron weights
+bool NeutronSQModule::calculateWeightedGR(PartialSet &unweightedgr, PartialSet &weightedgr, NeutronWeights &weights,
 					  NeutronSQModule::NormalisationType normalisation)
 {
 	int typeI, typeJ;
@@ -62,8 +62,8 @@ bool NeutronSQModule::calculateWeightedGR(PartialSet &unweightedgr, PartialSet &
 	return true;
 }
 
-// Calculate weighted S(Q) from supplied unweighted S(Q) and Weights
-bool NeutronSQModule::calculateWeightedSQ(PartialSet &unweightedsq, PartialSet &weightedsq, Weights &weights,
+// Calculate weighted S(Q) from supplied unweighted S(Q) and neutron weights
+bool NeutronSQModule::calculateWeightedSQ(PartialSet &unweightedsq, PartialSet &weightedsq, NeutronWeights &weights,
 					  NeutronSQModule::NormalisationType normalisation)
 {
 	int typeI, typeJ;
@@ -99,8 +99,8 @@ bool NeutronSQModule::calculateWeightedSQ(PartialSet &unweightedsq, PartialSet &
 	return true;
 }
 
-// Calculate Weights matrix summed over target Configurations
-bool NeutronSQModule::calculateSummedWeights(Weights &summedWeights) const
+// Calculate nwutron weights summed over target Configurations
+bool NeutronSQModule::calculateSummedWeights(NeutronWeights &summedWeights) const
 {
 	summedWeights.clear();
 

--- a/src/modules/neutronsq/functions.cpp
+++ b/src/modules/neutronsq/functions.cpp
@@ -112,11 +112,11 @@ bool NeutronSQModule::calculateSummedWeights(NeutronWeights &summedWeights) cons
 		while (SpeciesInfo *spInfo = speciesInfoIterator.iterate())
 		{
 			// Find the Isotopologues for the Configuration/Species, if they have been defined
-			const Isotopologues *topes = isotopologues_.isotopologues(cfg, spInfo->species());
+			auto data = isotopologues_.getIsotopologues(cfg, spInfo->species());
 
 			// Use the natural isotopologue if a species in the Configuration is not covered by at least one
 			// explicit Isotopologue definition
-			if (!topes)
+			if (std::get<1>(data))
 			{
 				Messenger::print("Isotopologue specification for Species '%s' in Configuration '%s' is "
 						 "missing, so the natural isotopologue will be used.\n",
@@ -127,8 +127,10 @@ bool NeutronSQModule::calculateSummedWeights(NeutronWeights &summedWeights) cons
 			}
 			else
 			{
+				const auto &topes = std::get<0>(data);
+
 				// Add defined isotopologues, in the relative isotopic proportions defined, to the weights.
-				ListIterator<IsotopologueWeight> weightIterator(topes->mix());
+				ListIterator<IsotopologueWeight> weightIterator(topes.mix());
 				while (IsotopologueWeight *isoWeight = weightIterator.iterate())
 					summedWeights.addIsotopologue(spInfo->species(), spInfo->population(),
 								      isoWeight->isotopologue(), isoWeight->weight());

--- a/src/modules/neutronsq/neutronsq.h
+++ b/src/modules/neutronsq/neutronsq.h
@@ -106,14 +106,14 @@ class NeutronSQModule : public Module
 	Data1DStore testData_;
 
 	public:
-	// Calculate weighted g(r) from supplied unweighted g(r) and Weights
-	bool calculateWeightedGR(PartialSet &unweightedgr, PartialSet &weightedgr, Weights &weights,
+	// Calculate weighted g(r) from supplied unweighted g(r) and neutron weights
+	bool calculateWeightedGR(PartialSet &unweightedgr, PartialSet &weightedgr, NeutronWeights &weights,
 				 NeutronSQModule::NormalisationType normalisation);
-	// Calculate weighted S(Q) from supplied unweighted S(Q) and Weights
-	bool calculateWeightedSQ(PartialSet &unweightedsq, PartialSet &weightedsq, Weights &weights,
+	// Calculate weighted S(Q) from supplied unweighted S(Q) and neutron weights
+	bool calculateWeightedSQ(PartialSet &unweightedsq, PartialSet &weightedsq, NeutronWeights &weights,
 				 NeutronSQModule::NormalisationType normalisation);
-	// Calculate Weights matrix summed over target Configurations
-	bool calculateSummedWeights(Weights &summedWeights) const;
+	// Calculate neutron weights summed over target Configurations
+	bool calculateSummedWeights(NeutronWeights &summedWeights) const;
 
 	/*
 	 * GUI Widget

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -391,7 +391,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
 			auto &topeSet = std::get<0>(data);
 
 			// Iterate over Species present in the set
-			for (auto topes : topeSet.isotopologues())
+			for (auto topes : topeSet.constIsotopologues())
 			{
 				// Find the referenced Species in our SpeciesInfo list
 				SpeciesInfo *spInfo = cfg->usedSpeciesInfo(topes.species());

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -156,7 +156,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
 	/*
 	 * Calculate neutron structure factors from existing g(r) data
-	 * 
+	 *
 	 * This is a serial routine, with each process constructing its own copy of the data.
 	 * Partial calculation routines called by this routine are parallel.
 	 */

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -22,8 +22,8 @@
 #include "classes/atomtype.h"
 #include "classes/box.h"
 #include "classes/configuration.h"
+#include "classes/neutronweights.h"
 #include "classes/species.h"
-#include "classes/weights.h"
 #include "genericitems/listhelper.h"
 #include "io/export/data1d.h"
 #include "main/dissolve.h"
@@ -75,7 +75,7 @@ bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
 		if (normType != NeutronSQModule::NoNormalisation)
 		{
 			// We need the summed Weights in order to do the normalisation
-			Weights summedWeights;
+			NeutronWeights summedWeights;
 			if (!calculateSummedWeights(summedWeights))
 			{
 				Messenger::error("Couldn't get summed Weights for reference data in NeutronSQ module '%s', and "
@@ -381,7 +381,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
 		// Construct weights matrix based on Isotopologue specifications and the populations of AtomTypes in the
 		// Configuration
-		Weights weights;
+		NeutronWeights weights;
 		if (isotopologues_.contains(cfg))
 		{
 			// Get the set...
@@ -468,12 +468,12 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
 	// Calculate weighted S(Q)
 	Messenger::print("Isotopologue and isotope composition over all Configurations used in '%s':\n\n", uniqueName_.get());
-	Weights summedWeights;
+	NeutronWeights summedWeights;
 	if (!calculateSummedWeights(summedWeights))
 		return false;
 	summedWeights.print();
-	GenericListHelper<Weights>::realise(dissolve.processingModuleData(), "FullWeights", uniqueName_,
-					    GenericItem::InRestartFileFlag) = summedWeights;
+	GenericListHelper<NeutronWeights>::realise(dissolve.processingModuleData(), "FullWeights", uniqueName_,
+						   GenericItem::InRestartFileFlag) = summedWeights;
 	calculateWeightedSQ(summedUnweightedSQ, summedWeightedSQ, summedWeights, normalisation);
 
 	// Create/retrieve PartialSet for summed unweighted g(r)

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -410,7 +410,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
 		// one Isotopologue definition
 		ListIterator<SpeciesInfo> speciesInfoIterator(cfg->usedSpecies());
 		while (SpeciesInfo *spInfo = speciesInfoIterator.iterate())
-			if (!weights.hasIsotopologues(spInfo->species()))
+			if (!weights.containsIsotopologues(spInfo->species()))
 			{
 				Messenger::print("Isotopologue specification for Species '%s' in Configuration '%s' is missing "
 						 "- natural isotopologue will be used.\n",

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -401,10 +401,9 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
 						topes.species()->name(), cfg->niceName());
 
 				// Add defined isotopologues, in the relative isotopic proportions defined, to the weights.
-				ListIterator<IsotopologueWeight> weightIterator(topes.mix());
-				while (IsotopologueWeight *isoWeight = weightIterator.iterate())
+				for (auto isoWeight : topes.mix())
 					weights.addIsotopologue(spInfo->species(), spInfo->population(),
-								isoWeight->isotopologue(), isoWeight->weight());
+								isoWeight.isotopologue(), isoWeight.weight());
 			}
 		}
 

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -155,8 +155,8 @@ bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
 bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
 	/*
-	 * Calculate weighted or unweighted partials and total g(r)/G(r) or S(Q)/F(Q)
-	 *
+	 * Calculate neutron structure factors from existing g(r) data
+	 * 
 	 * This is a serial routine, with each process constructing its own copy of the data.
 	 * Partial calculation routines called by this routine are parallel.
 	 */

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -385,21 +385,23 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
 		if (isotopologues_.contains(cfg))
 		{
 			// Get the set...
-			const IsotopologueSet *topeSet = isotopologues_.isotopologueSet(cfg);
+			const auto data = isotopologues_.getIsotopologueSet(cfg);
+
+			// TODO Raise exception if no isotopologue set found
+			auto &topeSet = std::get<0>(data);
 
 			// Iterate over Species present in the set
-			ListIterator<Isotopologues> topeIterator(topeSet->isotopologues());
-			while (Isotopologues *topes = topeIterator.iterate())
+			for (auto topes : topeSet.isotopologues())
 			{
 				// Find the referenced Species in our SpeciesInfo list
-				SpeciesInfo *spInfo = cfg->usedSpeciesInfo(topes->species());
+				SpeciesInfo *spInfo = cfg->usedSpeciesInfo(topes.species());
 				if (!spInfo)
 					return Messenger::error(
 						"Couldn't locate SpeciesInfo for '%s' in the Configuration '%s'.\n",
-						topes->species()->name(), cfg->niceName());
+						topes.species()->name(), cfg->niceName());
 
 				// Add defined isotopologues, in the relative isotopic proportions defined, to the weights.
-				ListIterator<IsotopologueWeight> weightIterator(topes->mix());
+				ListIterator<IsotopologueWeight> weightIterator(topes.mix());
 				while (IsotopologueWeight *isoWeight = weightIterator.iterate())
 					weights.addIsotopologue(spInfo->species(), spInfo->population(),
 								isoWeight->isotopologue(), isoWeight->weight());

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -22,7 +22,7 @@
 #include "classes/box.h"
 #include "classes/configuration.h"
 #include "classes/species.h"
-#include "classes/weights.h"
+#include "classes/neutronweights.h"
 #include "genericitems/listhelper.h"
 #include "main/dissolve.h"
 #include "math/averaging.h"

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -21,8 +21,8 @@
 
 #include "classes/box.h"
 #include "classes/configuration.h"
-#include "classes/species.h"
 #include "classes/neutronweights.h"
+#include "classes/species.h"
 #include "genericitems/listhelper.h"
 #include "main/dissolve.h"
 #include "math/averaging.h"

--- a/src/modules/rdf/rdf.h
+++ b/src/modules/rdf/rdf.h
@@ -31,7 +31,6 @@
 class Dissolve;
 class ModuleGroup;
 class PartialSet;
-class Weights;
 
 // RDF Module
 class RDFModule : public Module

--- a/src/modules/refine/process.cpp
+++ b/src/modules/refine/process.cpp
@@ -21,9 +21,9 @@
 
 #include "base/sysfunc.h"
 #include "classes/atomtype.h"
+#include "classes/neutronweights.h"
 #include "classes/partialset.h"
 #include "classes/scatteringmatrix.h"
-#include "classes/weights.h"
 #include "data/isotopes.h"
 #include "genericitems/listhelper.h"
 #include "main/dissolve.h"
@@ -304,10 +304,11 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
 			if (!found)
 				return Messenger::error("Could not locate ReferenceData for target '%s'.\n",
 							module->uniqueName());
-			Weights &weights = GenericListHelper<Weights>::retrieve(dissolve.processingModuleData(), "FullWeights",
-										module->uniqueName(), Weights(), &found);
+			NeutronWeights &weights = GenericListHelper<NeutronWeights>::retrieve(
+				dissolve.processingModuleData(), "FullWeights", module->uniqueName(), NeutronWeights(), &found);
 			if (!found)
-				return Messenger::error("Could not locate Weights for target '%s'.\n", module->uniqueName());
+				return Messenger::error("Could not locate NeutronWeights for target '%s'.\n",
+							module->uniqueName());
 			const PartialSet &unweightedSQ = GenericListHelper<PartialSet>::value(
 				dissolve.processingModuleData(), "UnweightedSQ", module->uniqueName(), PartialSet(), &found);
 			if (!found)

--- a/src/modules/sq/sq.h
+++ b/src/modules/sq/sq.h
@@ -30,7 +30,6 @@
 
 // Forward Declarations
 class PartialSet;
-class Weights;
 
 // SQ Module
 class SQModule : public Module

--- a/src/templates/broadcastvector.h
+++ b/src/templates/broadcastvector.h
@@ -1,0 +1,79 @@
+/*
+	*** std::vector Broadcaster
+	*** src/templates/broadcastvector.h
+	Copyright T. Youngs 2012-2020
+
+	This file is part of Dissolve.
+
+	Dissolve is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Dissolve is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DISSOLVE_BROADCASTVECTOR_H
+#define DISSOLVE_BROADCASTVECTOR_H
+
+#include "base/processpool.h"
+
+// Broadcast Vector
+template <class T> class BroadcastVector
+{
+	/*
+	 * Constructor-only template class which iterates over a supplied sstd::vector, broadcasting the object from master
+	 * to slave processes. The items must provide the 'broadcast()' virtual.
+	 */
+	private:
+	// Result of broadcast
+	bool result_;
+
+	public:
+	BroadcastVector(ProcessPool &procPool, int root, std::vector<T> &items, const CoreData &coreData)
+	{
+		result_ = false;
+		int count;
+		if (procPool.isMaster())
+		{
+			// Broadcast number of items in list, then list items...
+			count = items.size();
+			if (!procPool.broadcast(count, root))
+				return;
+			for (auto item : items)
+				if (!item.broadcast(procPool, root, coreData))
+					return;
+		}
+		else
+		{
+			// Get number of list items to expect
+			if (!procPool.broadcast(count, root))
+				return;
+
+			// Clear list and reconstruct
+			items.clear();
+			for (int n = 0; n < count; ++n)
+			{
+				// Slaves must create a suitable structure first, and then join the broadcast
+				items.emplace_back();
+				if (!items.back().broadcast(procPool, root, coreData))
+					return;
+			}
+		}
+
+		// All OK - success!
+		result_ = true;
+	}
+	// Return whether broadcast was successful
+	bool success() { return result_; }
+	// Return whether broadcast failed
+	bool failed() { return (!result_); }
+};
+
+#endif


### PR DESCRIPTION
Slight digression from (but related to) addition of XRay structure factor calculation, this PR will:

- Replace custom List<T> class with standard containers in Isotopologues, IsotopologueSet, and IsotopologueCollection
- Remove ListItem<T> dependence from IsotopologueWeight, Isotopologues, and IsotopologueSet

Partial work towards #257.

~One point for discussion - to overcome the inability of QVariant to store references I have just taken pointers to the objects as per the original implementation where necessary. Adam had already encountered this, but I don't recall the exact solution (if indeed one had been decided).~

The present changes are an example of where classes can straightforwardly use std::vector to manage objects over my old List class - IsotopologueCollection and its related classes are used as storage for keyword-based data, and are not referenced as pointers. Instead, the data is retrieved when needed. So, strictly we don't need the ability to use make_shared and refer to it with a weak_ptr. The GUI, however, allows the data within IsotopologueCollection to be edited, and so this is where using weak_ptr would be useful to ensure object validity. So, the choices as I see it are:
1. Keep the neatness of a std::vector of objects, and worry about how to refer to those objects by pointer in the GUI classes.
2. Move to a vector of shared_ptr, and use weak_ptr in the GUI classes.

A third option is implemented in 5c00c3c which introduces a manager class to maintain items in a QTreeWIdget as well as associate those items with references to the underlying data.

To be merged after #279.