### PR TITLE
No list atomtypedata

### DIFF
--- a/src/classes/atomtypedata.cpp
+++ b/src/classes/atomtypedata.cpp
@@ -32,42 +32,42 @@
 #include <string.h>
 
 AtomTypeData::AtomTypeData(AtomType &type, double population, double fraction, double boundCoherent, int nIso)
-	: atomType_(type), exchangeable_(false), population_(population), fraction_(fraction), boundCoherent_(boundCoherent)
+    : atomType_(type), exchangeable_(false), population_(population), fraction_(fraction), boundCoherent_(boundCoherent)
 {
-	isotopes_.clear();
-	for (int n = 0; n < nIso; ++n)
-	{
-		isotopes_.add();
-	}
+    isotopes_.clear();
+    for (int n = 0; n < nIso; ++n)
+    {
+        isotopes_.add();
+    }
 }
 
 AtomTypeData::AtomTypeData(const AtomTypeData &source) : atomType_(source.atomType_), listIndex_(source.listIndex())
 {
-	(*this) = source;
+    (*this) = source;
 }
 
 // Read data through specified LineParser
 AtomTypeData::AtomTypeData(LineParser &parser, const CoreData &coreData, int listIndex)
-	: atomType_(*coreData.findAtomType(parser.argc(0))), listIndex_(listIndex)
+    : atomType_(*coreData.findAtomType(parser.argc(0))), listIndex_(listIndex)
 {
-	population_ = parser.argd(1);
-	fraction_ = parser.argd(2);
-	boundCoherent_ = parser.argd(3);
-	isotopes_.clear();
-	int nIso = parser.argi(4);
-	for (int n = 0; n < nIso; ++n)
-	{
-		IsotopeData *tope = isotopes_.add();
-	}
+    population_ = parser.argd(1);
+    fraction_ = parser.argd(2);
+    boundCoherent_ = parser.argd(3);
+    isotopes_.clear();
+    int nIso = parser.argi(4);
+    for (int n = 0; n < nIso; ++n)
+    {
+        IsotopeData *tope = isotopes_.add();
+    }
 }
 
 // Initialise Constructor
 AtomTypeData::AtomTypeData(int listIndex, AtomType &type, double population)
-	: atomType_(type), listIndex_(listIndex), population_(population)
+    : atomType_(type), listIndex_(listIndex), population_(population)
 {
-	exchangeable_ = false;
-	fraction_ = 0.0;
-	boundCoherent_ = 0.0;
+    exchangeable_ = false;
+    fraction_ = 0.0;
+    boundCoherent_ = 0.0;
 }
 
 void AtomTypeData::operator=(const AtomTypeData &source)
@@ -151,13 +151,13 @@ void AtomTypeData::finalise(double totalAtoms)
 // Remove any existing isotopes, and add only the natural isotope
 void AtomTypeData::naturalise()
 {
-	// Clear the isotopes list and add on the natural isotope, keeping the current population
-	isotopes_.clear();
-	IsotopeData *topeData = isotopes_.add();
-	topeData->initialise(Isotopes::naturalIsotope(atomType_.element()));
-	topeData->add(population_);
-	topeData->finalise(population_);
-	boundCoherent_ = topeData->isotope()->boundCoherent();
+    // Clear the isotopes list and add on the natural isotope, keeping the current population
+    isotopes_.clear();
+    IsotopeData *topeData = isotopes_.add();
+    topeData->initialise(Isotopes::naturalIsotope(atomType_.element()));
+    topeData->add(population_);
+    topeData->finalise(population_);
+    boundCoherent_ = topeData->isotope()->boundCoherent();
 }
 
 // Return if specified Isotope is already in the list
@@ -206,15 +206,14 @@ const char *AtomTypeData::atomTypeName() const { return atomType_.name(); }
 // Write data through specified LineParser
 bool AtomTypeData::write(LineParser &parser)
 {
-	// Line Contains: AtomType name, exchangeable flag, population, fraction, boundCoherent, and nIsotopes
-	if (!parser.writeLineF("%s %f %f %f %i\n", atomType_.name(), population_, fraction_, boundCoherent_,
-			       isotopes_.nItems()))
-		return false;
-	ListIterator<IsotopeData> isotopeIterator(isotopes_);
-	while (IsotopeData *topeData = isotopeIterator.iterate())
-		if (!topeData->write(parser))
-			return false;
-	return true;
+    // Line Contains: AtomType name, exchangeable flag, population, fraction, boundCoherent, and nIsotopes
+    if (!parser.writeLineF("%s %f %f %f %i\n", atomType_.name(), population_, fraction_, boundCoherent_, isotopes_.nItems()))
+        return false;
+    ListIterator<IsotopeData> isotopeIterator(isotopes_);
+    while (IsotopeData *topeData = isotopeIterator.iterate())
+        if (!topeData->write(parser))
+            return false;
+    return true;
 }
 
 /*
@@ -225,21 +224,21 @@ bool AtomTypeData::write(LineParser &parser)
 // Broadcast data from Master to all Slaves
 bool AtomTypeData::broadcast(ProcessPool &procPool, const int root, const CoreData &coreData)
 {
-	// For the atomType_, use the fact that the AtomType names are unique...
-	CharString typeName;
-	if (procPool.poolRank() == root)
-		typeName = atomType_.name();
-	procPool.broadcast(typeName, root);
-	atomType_ = *coreData.findAtomType(typeName);
+    // For the atomType_, use the fact that the AtomType names are unique...
+    CharString typeName;
+    if (procPool.poolRank() == root)
+        typeName = atomType_.name();
+    procPool.broadcast(typeName, root);
+    atomType_ = *coreData.findAtomType(typeName);
 
-	// Broadcast the IsotopeData list
-	BroadcastList<IsotopeData> topeBroadcaster(procPool, root, isotopes_, coreData);
-	// if (topeBroadcaster.failed())
-	//   Messenger("Broadcase of AtomTypeData failed");
+    // Broadcast the IsotopeData list
+    BroadcastList<IsotopeData> topeBroadcaster(procPool, root, isotopes_, coreData);
+    // if (topeBroadcaster.failed())
+    //   Messenger("Broadcase of AtomTypeData failed");
 
-	procPool.broadcast(population_, root);
-	procPool.broadcast(fraction_, root);
-	procPool.broadcast(boundCoherent_, root);
+    procPool.broadcast(population_, root);
+    procPool.broadcast(fraction_, root);
+    procPool.broadcast(boundCoherent_, root);
 }
 #endif
 

--- a/src/classes/atomtypedata.cpp
+++ b/src/classes/atomtypedata.cpp
@@ -31,16 +31,44 @@
 #include "templates/broadcastlist.h"
 #include <string.h>
 
-AtomTypeData::AtomTypeData() : ListItem<AtomTypeData>()
+AtomTypeData::AtomTypeData(AtomType &type, double population, double fraction, double boundCoherent, int nIso)
+	: atomType_(type), exchangeable_(false), population_(population), fraction_(fraction), boundCoherent_(boundCoherent)
 {
-    atomType_ = NULL;
-    exchangeable_ = false;
-    population_ = 0;
-    fraction_ = 0.0;
-    boundCoherent_ = 0.0;
+	isotopes_.clear();
+	for (int n = 0; n < nIso; ++n)
+	{
+		isotopes_.add();
+	}
 }
 
-AtomTypeData::AtomTypeData(const AtomTypeData &source) { (*this) = source; }
+AtomTypeData::AtomTypeData(const AtomTypeData &source) : atomType_(source.atomType_), listIndex_(source.listIndex())
+{
+	(*this) = source;
+}
+
+// Read data through specified LineParser
+AtomTypeData::AtomTypeData(LineParser &parser, const CoreData &coreData, int listIndex)
+	: atomType_(*coreData.findAtomType(parser.argc(0))), listIndex_(listIndex)
+{
+	population_ = parser.argd(1);
+	fraction_ = parser.argd(2);
+	boundCoherent_ = parser.argd(3);
+	isotopes_.clear();
+	int nIso = parser.argi(4);
+	for (int n = 0; n < nIso; ++n)
+	{
+		IsotopeData *tope = isotopes_.add();
+	}
+}
+
+// Initialise Constructor
+AtomTypeData::AtomTypeData(int listIndex, AtomType &type, double population)
+	: atomType_(type), listIndex_(listIndex), population_(population)
+{
+	exchangeable_ = false;
+	fraction_ = 0.0;
+	boundCoherent_ = 0.0;
+}
 
 void AtomTypeData::operator=(const AtomTypeData &source)
 {
@@ -55,23 +83,6 @@ void AtomTypeData::operator=(const AtomTypeData &source)
 /*
  * Properties
  */
-
-// Initialise
-bool AtomTypeData::initialise(int listIndex, AtomType *atomType, double population)
-{
-    listIndex_ = listIndex;
-    atomType_ = atomType;
-    if (atomType == NULL)
-        return Messenger::error("NULL_POINTER - NULL AtomType pointer passed to AtomTypeData::initialise().\n");
-
-    population_ = population;
-    fraction_ = 0.0;
-    boundCoherent_ = 0.0;
-
-    // 	Messenger::print("Initialised AtomType index entry with AtomType '%s', Isotope %i (bc = %7.3f)\n",
-    // atomType->name(), tope->A(), tope->boundCoherent());
-    return true;
-}
 
 // Add to population
 void AtomTypeData::add(double nAdd) { population_ += nAdd; }
@@ -113,7 +124,7 @@ void AtomTypeData::zeroPopulations()
 int AtomTypeData::listIndex() const { return listIndex_; }
 
 // Return reference AtomType
-AtomType *AtomTypeData::atomType() const { return atomType_; }
+AtomType &AtomTypeData::atomType() const { return atomType_; }
 
 // Set exchangeable flag
 void AtomTypeData::setAsExchangeable() { exchangeable_ = true; }
@@ -140,13 +151,13 @@ void AtomTypeData::finalise(double totalAtoms)
 // Remove any existing isotopes, and add only the natural isotope
 void AtomTypeData::naturalise()
 {
-    // Clear the isotopes list and add on the natural isotope, keeping the current population
-    isotopes_.clear();
-    IsotopeData *topeData = isotopes_.add();
-    topeData->initialise(Isotopes::naturalIsotope(atomType_->element()));
-    topeData->add(population_);
-    topeData->finalise(population_);
-    boundCoherent_ = topeData->isotope()->boundCoherent();
+	// Clear the isotopes list and add on the natural isotope, keeping the current population
+	isotopes_.clear();
+	IsotopeData *topeData = isotopes_.add();
+	topeData->initialise(Isotopes::naturalIsotope(atomType_.element()));
+	topeData->add(population_);
+	topeData->finalise(population_);
+	boundCoherent_ = topeData->isotope()->boundCoherent();
 }
 
 // Return if specified Isotope is already in the list
@@ -171,7 +182,7 @@ void AtomTypeData::setSingleIsotope(Isotope *tope)
 }
 
 // Return Isotope
-IsotopeData *AtomTypeData::isotopeData() { return isotopes_.first(); }
+IsotopeData *AtomTypeData::isotopeData() const { return isotopes_.first(); }
 
 // Return total population over all isotopes
 int AtomTypeData::population() const { return population_; }
@@ -186,73 +197,51 @@ void AtomTypeData::setBoundCoherent(double d) { boundCoherent_ = d; }
 double AtomTypeData::boundCoherent() const { return boundCoherent_; }
 
 // Return referenced AtomType name
-const char *AtomTypeData::atomTypeName() const { return atomType_->name(); }
+const char *AtomTypeData::atomTypeName() const { return atomType_.name(); }
 
 /*
  * I/O
  */
 
-// Read data through specified LineParser
-bool AtomTypeData::read(LineParser &parser, const CoreData &coreData)
-{
-    if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-        return false;
-    atomType_ = coreData.findAtomType(parser.argc(0));
-    if (!atomType_)
-        return false;
-    population_ = parser.argd(1);
-    fraction_ = parser.argd(2);
-    boundCoherent_ = parser.argd(3);
-    isotopes_.clear();
-    int nIso = parser.argi(4);
-    for (int n = 0; n < nIso; ++n)
-    {
-        IsotopeData *tope = isotopes_.add();
-        if (!tope->read(parser, coreData))
-            return false;
-    }
-    return true;
-}
-
 // Write data through specified LineParser
 bool AtomTypeData::write(LineParser &parser)
 {
-    // Line Contains: AtomType name, exchangeable flag, population, fraction, boundCoherent, and nIsotopes
-    if (!parser.writeLineF("%s %f %f %f %i\n", atomType_->name(), population_, fraction_, boundCoherent_, isotopes_.nItems()))
-        return false;
-    ListIterator<IsotopeData> isotopeIterator(isotopes_);
-    while (IsotopeData *topeData = isotopeIterator.iterate())
-        if (!topeData->write(parser))
-            return false;
-    return true;
+	// Line Contains: AtomType name, exchangeable flag, population, fraction, boundCoherent, and nIsotopes
+	if (!parser.writeLineF("%s %f %f %f %i\n", atomType_.name(), population_, fraction_, boundCoherent_,
+			       isotopes_.nItems()))
+		return false;
+	ListIterator<IsotopeData> isotopeIterator(isotopes_);
+	while (IsotopeData *topeData = isotopeIterator.iterate())
+		if (!topeData->write(parser))
+			return false;
+	return true;
 }
 
 /*
  * Parallel Comms
  */
 
+#ifdef PARALLEL
 // Broadcast data from Master to all Slaves
 bool AtomTypeData::broadcast(ProcessPool &procPool, const int root, const CoreData &coreData)
 {
-#ifdef PARALLEL
-    // For the atomType_, use the fact that the AtomType names are unique...
-    CharString typeName;
-    if (procPool.poolRank() == root)
-        typeName = atomType_->name();
-    procPool.broadcast(typeName, root);
-    atomType_ = coreData.findAtomType(typeName);
+	// For the atomType_, use the fact that the AtomType names are unique...
+	CharString typeName;
+	if (procPool.poolRank() == root)
+		typeName = atomType_.name();
+	procPool.broadcast(typeName, root);
+	atomType_ = *coreData.findAtomType(typeName);
 
-    // Broadcast the IsotopeData list
-    BroadcastList<IsotopeData> topeBroadcaster(procPool, root, isotopes_, coreData);
-    if (topeBroadcaster.failed())
-        return false;
+	// Broadcast the IsotopeData list
+	BroadcastList<IsotopeData> topeBroadcaster(procPool, root, isotopes_, coreData);
+	// if (topeBroadcaster.failed())
+	//   Messenger("Broadcase of AtomTypeData failed");
 
-    procPool.broadcast(population_, root);
-    procPool.broadcast(fraction_, root);
-    procPool.broadcast(boundCoherent_, root);
-#endif
-    return true;
+	procPool.broadcast(population_, root);
+	procPool.broadcast(fraction_, root);
+	procPool.broadcast(boundCoherent_, root);
 }
+#endif
 
 // Check item equality
 bool AtomTypeData::equality(ProcessPool &procPool)

--- a/src/classes/atomtypedata.h
+++ b/src/classes/atomtypedata.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include "templates/list.h"
-#include "templates/listitem.h"
 
 // Forward Declarations
 class AtomType;
@@ -34,11 +33,16 @@ class ProcessPool;
 /*
  * AtomTypeData Definition
  */
-class AtomTypeData : public ListItem<AtomTypeData>
+class AtomTypeData
 {
     public:
-    AtomTypeData();
+    AtomTypeData(AtomType &type, double population = 0, double fraction = 0, double boundCoherent = 0, int nIso = 0);
     AtomTypeData(const AtomTypeData &source);
+    // Read data through specified LineParser
+    AtomTypeData(LineParser &parser, const CoreData &coreData, int listIndex);
+    // Old Initialise
+    AtomTypeData(int listIndex, AtomType &atomType, double population);
+    // Assignment Operator
     void operator=(const AtomTypeData &source);
 
     /*
@@ -48,7 +52,7 @@ class AtomTypeData : public ListItem<AtomTypeData>
     // List index of AtomTypeData in AtomTypeList
     int listIndex_;
     // Reference AtomType
-    AtomType *atomType_;
+    AtomType &atomType_;
     // Whether the AtomType has been marked as exchangeable
     bool exchangeable_;
     // Isotopes information (if any)
@@ -61,8 +65,6 @@ class AtomTypeData : public ListItem<AtomTypeData>
     double boundCoherent_;
 
     public:
-    // Initialise
-    bool initialise(int listIndex, AtomType *atomType, double population = 0);
     // Add to population
     void add(double nAdd);
     // Add to population of Isotope
@@ -72,7 +74,7 @@ class AtomTypeData : public ListItem<AtomTypeData>
     // Return list index of AtomTypeData in AtomTypeList
     int listIndex() const;
     // Return reference AtomType
-    AtomType *atomType() const;
+    AtomType &atomType() const;
     // Set exchangeable flag
     void setAsExchangeable();
     // Return whether the associated AtomType is exchangeable
@@ -86,7 +88,7 @@ class AtomTypeData : public ListItem<AtomTypeData>
     // Set this AtomType to have only the single Isotope provided
     void setSingleIsotope(Isotope *tope);
     // Return first IsotopeData
-    IsotopeData *isotopeData();
+    IsotopeData *isotopeData() const;
     // Return total population over all isotopes
     int population() const;
     // Return total fractional population including all isotopes
@@ -102,8 +104,6 @@ class AtomTypeData : public ListItem<AtomTypeData>
      * I/O
      */
     public:
-    // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/classes/atomtypelist.h
+++ b/src/classes/atomtypelist.h
@@ -22,13 +22,16 @@
 #pragma once
 
 #include "classes/atomtypedata.h"
+#include "classes/coredata.h"
 #include "genericitems/base.h"
-#include "templates/list.h"
+#include <tuple>
+#include <vector>
 
 // Forward Declarations
 class AtomType;
-class CoreData;
 class Isotope;
+
+template <class T> using optional = std::tuple<T, bool>;
 
 // AtomTypeList
 class AtomTypeList : public GenericItemBase
@@ -38,15 +41,14 @@ class AtomTypeList : public GenericItemBase
     ~AtomTypeList();
     AtomTypeList(const AtomTypeList &source);
     void operator=(const AtomTypeList &source);
-    // Array access operator
-    AtomTypeData *operator[](int n);
+    AtomTypeData &operator[](unsigned int n);
 
     /*
      * Type List
      */
     private:
     // List of AtomTypeData
-    List<AtomTypeData> types_;
+    std::vector<AtomTypeData> types_;
 
     public:
     // Clear all data
@@ -54,13 +56,13 @@ class AtomTypeList : public GenericItemBase
     // Zero populations of all types in the list
     void zero();
     // Add the specified AtomType to the list, returning the AtomTypeData
-    AtomTypeData *add(AtomType *atomType, double popAdd = 0);
+    AtomTypeData &add(AtomType &atomType, double popAdd = 0);
     // Add the AtomTypes in the supplied list into this one, increasing populations etc.
     void add(const AtomTypeList &source);
     // Remove specified AtomType from the list
-    void remove(AtomType *atomType);
+    void remove(AtomType &atomType);
     // Add/increase this AtomType/Isotope pair, returning the index of the AtomType in the list
-    void addIsotope(AtomType *atomType, Isotope *tope = NULL, double popAdd = 0);
+    void addIsotope(AtomType &atomType, Isotope *tope = NULL, double popAdd = 0);
     // Finalise list, calculating fractional populations etc.
     void finalise();
     // Finalise list, calculating fractional populations etc., and accounting for exchangeable sites in boundCoherent values
@@ -68,25 +70,27 @@ class AtomTypeList : public GenericItemBase
     // Make all AtomTypeData in the list reference only their natural isotope
     void naturalise();
     // Check for presence of AtomType in list
-    bool contains(AtomType *atomType) const;
+    bool contains(AtomType &atomType) const;
     // Check for presence of AtomType/Isotope pair in list
-    bool contains(AtomType *atomType, Isotope *tope);
+    bool contains(AtomType &atomType, Isotope *tope);
     // Return number of AtomType/Isotopes in list
     int nItems() const;
     // Return first item in list
-    AtomTypeData *first() const;
-    // Return types list
-    const List<AtomTypeData> &types() const;
+    const AtomTypeData &first() const;
+    // Return opening iterator
+    std::vector<AtomTypeData>::const_iterator begin() const;
+    // Return opening iterator
+    std::vector<AtomTypeData>::const_iterator end() const;
     // Return index of AtomType in list
-    int indexOf(AtomType *atomtype) const;
+    int indexOf(AtomType &atomtype) const;
     // Return index of names AtomType in list
     int indexOf(const char *name) const;
     // Return total population of all types in list
     double totalPopulation() const;
     // Return nth referenced AtomType
-    AtomType *atomType(int n);
+    AtomType &atomType(int n);
     // Return AtomTypeData for specified AtomType
-    AtomTypeData *atomTypeData(AtomType *atomType);
+    optional<const AtomTypeData &> atomTypeData(AtomType &atomType);
     // Print AtomType populations
     void print() const;
 

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -119,11 +119,11 @@ class Configuration : public ListItem<Configuration>, public ObjectStore<Configu
     // Initialise content array
     void initialiseArrays(int nMolecules);
     // Return specified used type
-    AtomType *usedAtomType(int index);
+    AtomType &usedAtomType(int index);
     // Return specified used type data
-    AtomTypeData *usedAtomTypeData(int index);
+    AtomTypeData &usedAtomTypeData(int index);
     // Return first AtomTypeData for this Configuration
-    AtomTypeData *usedAtomTypes();
+    const AtomTypeData &usedAtomTypes() const;
     // Return AtomTypeList for this Configuration
     const AtomTypeList &usedAtomTypesList() const;
     // Return number of atom types used in this Configuration

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -53,13 +53,13 @@ void Configuration::initialiseArrays(int nMolecules)
 }
 
 // Return specified used type
-AtomType *Configuration::usedAtomType(int index) { return usedAtomTypes_.atomType(index); }
+AtomType &Configuration::usedAtomType(int index) { return usedAtomTypes_.atomType(index); }
 
 // Return specified used type data
-AtomTypeData *Configuration::usedAtomTypeData(int index) { return usedAtomTypes_[index]; }
+AtomTypeData &Configuration::usedAtomTypeData(int index) { return usedAtomTypes_[index]; }
 
 // Return first AtomTypeData for this Configuration
-AtomTypeData *Configuration::usedAtomTypes() { return usedAtomTypes_.first(); }
+const AtomTypeData &Configuration::usedAtomTypes() const { return usedAtomTypes_.first(); }
 
 // Return AtomTypeList for this Configuration
 const AtomTypeList &Configuration::usedAtomTypesList() const { return usedAtomTypes_; }
@@ -180,8 +180,8 @@ Atom *Configuration::addAtom(const SpeciesAtom *sourceAtom, std::shared_ptr<Mole
     newAtom->setCoordinates(r);
 
     // Update our typeIndex (non-isotopic) and set local and master type indices
-    AtomTypeData *atd = usedAtomTypes_.add(sourceAtom->atomType(), 1);
-    newAtom->setLocalTypeIndex(atd->listIndex());
+    AtomTypeData &atd = usedAtomTypes_.add(*sourceAtom->atomType(), 1);
+    newAtom->setLocalTypeIndex(atd.listIndex());
     newAtom->setMasterTypeIndex(sourceAtom->atomType()->index());
 
     return newAtom;

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -280,12 +280,12 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, NeutronWeigh
     {
         for (int m = n; m < nUsedTypes; ++m)
         {
-            int colIndex = pairIndex(usedTypes.atomType(n), usedTypes.atomType(m));
+            int colIndex = pairIndex(&usedTypes.atomType(n), &usedTypes.atomType(m));
             if (colIndex == -1)
             {
                 Messenger::error("Weights associated to reference data contain one or more unknown AtomTypes "
                                  "('%s' and/or '%s').\n",
-                                 usedTypes.atomType(n)->name(), usedTypes.atomType(m)->name());
+                                 usedTypes.atomType(n).name(), usedTypes.atomType(m).name());
                 return false;
             }
 

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -226,7 +226,7 @@ const AtomTypeList &Species::usedAtomTypes()
         usedAtomTypes_.clear();
         for (SpeciesAtom *i = atoms_.first(); i != NULL; i = i->next())
             if (i->atomType())
-                usedAtomTypes_.add(i->atomType(), 1);
+                usedAtomTypes_.add(*i->atomType(), 1);
 
         usedAtomTypesPoint_ = atomTypesVersion_;
     }

--- a/src/gui/helpers/listwidgetupdater.h
+++ b/src/gui/helpers/listwidgetupdater.h
@@ -32,6 +32,7 @@ template <class T, class I> class ListWidgetUpdater
 {
     // Typedefs for passed functions
     typedef void (T::*ListWidgetRowUpdateFunction)(int row, I *item, bool createItem);
+    typedef void (T::*ListWidgetRowUpdateRefFunction)(int row, I &item, bool createItem);
 
     public:
     // Update widget from supplied List, calling supplied function to create / modify data
@@ -73,6 +74,59 @@ template <class T, class I> class ListWidgetUpdater
             {
                 // Create new items
                 (functionParent->*updateRow)(currentRow, dataItem, true);
+            }
+
+            ++currentRow;
+        }
+
+        // If there are still rows remaining in the widget, delete them now
+        while (currentRow < listWidget->count())
+        {
+            QListWidgetItem *oldItem = listWidget->takeItem(currentRow);
+            if (oldItem)
+                delete oldItem;
+        }
+    }
+
+    // Update widget from supplied List, calling supplied function to create / modify data
+    ListWidgetUpdater(QListWidget *listWidget, const List<I> &data, T *functionParent, ListWidgetRowUpdateRefFunction updateRow)
+    {
+        QListWidgetItem *listWidgetItem;
+
+        int currentRow = 0;
+
+        ListIterator<I> dataIterator(data);
+        while (I *dataItem = dataIterator.iterate())
+        {
+            // Our table may or may not be populated, and with different items to those in the list.
+
+            // If there is an item already on this row, check it
+            // If it represents the current pointer data, just update it and move on. Otherwise, delete it and check
+            // again
+            while (currentRow < listWidget->count())
+            {
+                listWidgetItem = listWidget->item(currentRow);
+                I *rowData = (listWidgetItem ? VariantPointer<I>(listWidgetItem->data(Qt::UserRole)) : NULL);
+                if (rowData == dataItem)
+                {
+                    // Update the current row and quit the loop
+                    (functionParent->*updateRow)(currentRow, *dataItem, false);
+
+                    break;
+                }
+                else
+                {
+                    QListWidgetItem *oldItem = listWidget->takeItem(currentRow);
+                    if (oldItem)
+                        delete oldItem;
+                }
+            }
+
+            // If the current row index is (now) out of range, add a new row to the list
+            if (currentRow == listWidget->count())
+            {
+                // Create new items
+                (functionParent->*updateRow)(currentRow, *dataItem, true);
             }
 
             ++currentRow;

--- a/src/gui/keywordwidgets/atomtypeselection.h
+++ b/src/gui/keywordwidgets/atomtypeselection.h
@@ -26,6 +26,7 @@
 #include "gui/keywordwidgets/ui_atomtypeselection.h"
 #include "keywords/atomtypeselection.h"
 #include <QWidget>
+#include <vector>
 
 // Forward Declarations
 class AtomType;
@@ -46,13 +47,14 @@ class AtomTypeSelectionKeywordWidget : public KeywordDropDown, public KeywordWid
     private:
     // Associated keyword
     AtomTypeSelectionKeyword *keyword_;
+    std::vector<std::reference_wrapper<AtomType>> atomTypes_;
 
     /*
      * Signals / Slots
      */
     private:
     // Selection list update function
-    void updateSelectionRow(int row, AtomType *atomType, bool createItem);
+    void updateSelectionRow(int row, AtomType &atomType, bool createItem);
 
     private slots:
     // List item changed

--- a/src/io/export/coordinates.cpp
+++ b/src/io/export/coordinates.cpp
@@ -135,8 +135,8 @@ bool CoordinateExportFileFormat::exportDLPOLY(LineParser &parser, Configuration 
     for (int n = 0; n < cfg->nAtoms(); ++n)
     {
         Atom *i = cfg->atom(n);
-        if (!parser.writeLineF("%-6s%10i%20.10f\n%20.12f%20.12f%20.12f\n", cfg->usedAtomType(i->localTypeIndex())->name(),
-                               n + 1, AtomicMass::mass(i->speciesAtom()->element()), i->r().x, i->r().y, i->r().z))
+        if (!parser.writeLineF("%-6s%10i%20.10f\n%20.12f%20.12f%20.12f\n", cfg->usedAtomType(i->localTypeIndex()).name(), n + 1,
+                               AtomicMass::mass(i->speciesAtom()->element()), i->r().x, i->r().y, i->r().z))
             return false;
     }
 

--- a/src/keywords/atomtypeselection.cpp
+++ b/src/keywords/atomtypeselection.cpp
@@ -46,13 +46,12 @@ void AtomTypeSelectionKeyword::checkSelection()
     AtomTypeList newSelection;
 
     // Loop over existing selection, checking for each AtomType existing in any source Configuration
-    ListIterator<AtomTypeData> typeIterator(data_.types());
-    while (AtomTypeData *atd = typeIterator.iterate())
+    for (const AtomTypeData &atd : data_)
     {
         bool found = false;
         for (auto cfg : sourceConfigurations_)
         {
-            if (cfg->usedAtomTypesList().contains(atd->atomType()))
+            if (cfg->usedAtomTypesList().contains(atd.atomType()))
             {
                 found = true;
                 break;
@@ -60,7 +59,7 @@ void AtomTypeSelectionKeyword::checkSelection()
         }
 
         if (found)
-            newSelection.add(atd->atomType());
+            newSelection.add(atd.atomType());
     }
 
     // Copy the new list over the old one
@@ -105,11 +104,11 @@ bool AtomTypeSelectionKeyword::read(LineParser &parser, int startArg, const Core
             return Messenger::error("Unrecognised AtomType '%s' found in list.\n", parser.argc(n));
 
         // If the AtomType is in the list already, complain
-        if (data_.contains(atomType))
+        if (data_.contains(*atomType))
             return Messenger::error("AtomType '%s' specified in selection list twice.\n", parser.argc(n));
 
         // All OK - add it to our selection list
-        data_.add(atomType);
+        data_.add(*atomType);
     }
 
     set_ = true;
@@ -122,9 +121,8 @@ bool AtomTypeSelectionKeyword::write(LineParser &parser, const char *keywordName
 {
     // Loop over the AtomType selection list
     CharString selection;
-    ListIterator<AtomTypeData> typeIterator(data_.types());
-    while (AtomTypeData *atd = typeIterator.iterate())
-        selection.strcatf("  %s", atd->atomTypeName());
+    for (auto &atd : data_)
+        selection.strcatf("  %s", atd.atomTypeName());
 
     if (!parser.writeLineF("%s%s%s\n", prefix, keywordName, selection.get()))
         return false;
@@ -137,4 +135,4 @@ bool AtomTypeSelectionKeyword::write(LineParser &parser, const char *keywordName
  */
 
 // Prune any references to the supplied AtomType in the contained data
-void AtomTypeSelectionKeyword::removeReferencesTo(AtomType *at) { data_.remove(at); }
+void AtomTypeSelectionKeyword::removeReferencesTo(AtomType &at) { data_.remove(at); }

--- a/src/keywords/atomtypeselection.h
+++ b/src/keywords/atomtypeselection.h
@@ -68,5 +68,5 @@ class AtomTypeSelectionKeyword : public KeywordData<AtomTypeList &>
      */
     protected:
     // Prune any references to the supplied AtomType in the contained data
-    void removeReferencesTo(AtomType *at);
+    void removeReferencesTo(AtomType &at);
 };

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -27,6 +27,7 @@
 #include "genericitems/listhelper.h"
 #include "main/dissolve.h"
 #include <cstdio>
+#include <numeric>
 
 // Set random seed
 void Dissolve::setSeed(int seed) { seed_ = seed; }
@@ -77,9 +78,10 @@ bool Dissolve::prepare()
         double totalQ = 0.0;
         if (pairPotentialsIncludeCoulomb_)
         {
-            ListIterator<AtomTypeData> atdIterator(cfg->usedAtomTypesList().types());
-            while (AtomTypeData *atd = atdIterator.iterate())
-                totalQ += atd->population() * atd->atomType()->parameters().charge();
+            auto &types = cfg->usedAtomTypesList();
+            totalQ = std::accumulate(types.begin(), types.end(), totalQ, [](double acc, const AtomTypeData &atd) {
+                return acc + atd.population() * atd.atomType().parameters().charge();
+            });
         }
         else
         {

--- a/src/math/pairbroadeningfunction.cpp
+++ b/src/math/pairbroadeningfunction.cpp
@@ -276,7 +276,7 @@ CharString PairBroadeningFunction::summary() const
 }
 
 // Return a BroadeningFunction tailored to the specified AtomType pair, using intramolecular data if required
-BroadeningFunction PairBroadeningFunction::broadeningFunction(AtomType *at1, AtomType *at2, SpeciesIntra *intra)
+BroadeningFunction PairBroadeningFunction::broadeningFunction(AtomType &at1, AtomType &at2, SpeciesIntra *intra)
 {
     BroadeningFunction result;
 
@@ -290,10 +290,10 @@ BroadeningFunction PairBroadeningFunction::broadeningFunction(AtomType *at1, Ato
             break;
         case (PairBroadeningFunction::GaussianElementPairFunction):
             // If this matrix value has never been used/read, set the flag now
-            if (!elementPairGaussianFlags_.at(at1->element()->Z(), at2->element()->Z()))
-                elementPairGaussianFlags_.at(at1->element()->Z(), at2->element()->Z()) = true;
+            if (!elementPairGaussianFlags_.at(at1.element()->Z(), at2.element()->Z()))
+                elementPairGaussianFlags_.at(at1.element()->Z(), at2.element()->Z()) = true;
             result.set(BroadeningFunction::GaussianFunction,
-                       elementPairGaussianFWHM_.at(at1->element()->Z(), at2->element()->Z()));
+                       elementPairGaussianFWHM_.at(at1.element()->Z(), at2.element()->Z()));
             break;
         case (PairBroadeningFunction::FrequencyFunction):
             // Broadening based on fundamental frequency of interaction - requires SpeciesIntra
@@ -311,8 +311,8 @@ BroadeningFunction PairBroadeningFunction::broadeningFunction(AtomType *at1, Ato
                 else
                 {
                     // Bond or an angle, so calculate the fundamental frequency
-                    printf("NEWBROAD : %s %s\n", at1->name(), at2->name());
-                    double v = intra->fundamentalFrequency(AtomicMass::reducedMass(at1->element(), at2->element()));
+                    printf("NEWBROAD : %s %s\n", at1.name(), at2.name());
+                    double v = intra->fundamentalFrequency(AtomicMass::reducedMass(at1.element(), at2.element()));
 
                     // Convert to cm-1?
                     double wno = v / (SPEEDOFLIGHT * 100.0);
@@ -328,9 +328,9 @@ BroadeningFunction PairBroadeningFunction::broadeningFunction(AtomType *at1, Ato
             // POSSIBLE USE AS FUNCTION FOR ELEMENT/ATOMTYPE-DEPENDENT BROADENING?
             // 		case (PairBroadeningFunction::GaussianElementFunction):
             // 			// Calculate reduced mass (store in parameters_[1])
-            // 			parameters_[1] = sqrt((AtomicMass::mass(at1->element()) *
-            // AtomicMass::mass(at2->element())) / (AtomicMass::mass(at1->element()) +
-            // AtomicMass::mass(at2->element())));
+            // 			parameters_[1] = sqrt((AtomicMass::mass(at1.element()) *
+            // AtomicMass::mass(at2.element())) / (AtomicMass::mass(at1.element()) +
+            // AtomicMass::mass(at2.element())));
             //
             // 			// Calculate final broadening
             // 			parameters_[0] = 1.0 / (2.0 * sqrt(2.0) * parameters_[1]);

--- a/src/math/pairbroadeningfunction.h
+++ b/src/math/pairbroadeningfunction.h
@@ -102,7 +102,7 @@ class PairBroadeningFunction : public GenericItemBase
     // Return short summary of function and its parameters
     CharString summary() const;
     // Return a BroadeningFunction tailored to the specified AtomType pair
-    BroadeningFunction broadeningFunction(AtomType *at1, AtomType *at2, SpeciesIntra *intra = NULL);
+    BroadeningFunction broadeningFunction(AtomType &at1, AtomType &at2, SpeciesIntra *intra = NULL);
 
     /*
      * GenericItemBase Implementations

--- a/src/modules/bragg/gui/modulewidget_funcs.cpp
+++ b/src/modules/bragg/gui/modulewidget_funcs.cpp
@@ -26,6 +26,7 @@
 #include "main/dissolve.h"
 #include "modules/bragg/bragg.h"
 #include "modules/bragg/gui/modulewidget.h"
+#include "templates/algorithms.h"
 #include "templates/variantpointer.h"
 
 BraggModuleWidget::BraggModuleWidget(QWidget *parent, BraggModule *module) : ModuleWidget(parent), module_(module)
@@ -148,20 +149,14 @@ void BraggModuleWidget::on_TargetCombo_currentIndexChanged(int index)
         return;
 
     CharString blockData;
-    const AtomTypeList cfgTypes = currentConfiguration_->usedAtomTypesList();
-    int n = 0;
-    for (AtomTypeData *atd1 = cfgTypes.first(); atd1 != NULL; atd1 = atd1->next(), ++n)
-    {
-        int m = n;
-        for (AtomTypeData *atd2 = atd1; atd2 != NULL; atd2 = atd2->next(), ++m)
-        {
-            CharString id("%s-%s", atd1->atomTypeName(), atd2->atomTypeName());
+    auto &types = currentConfiguration_->usedAtomTypesList();
+    for_each_pair(types.begin(), types.end(), [&](int n, const AtomTypeData &atd1, int m, const AtomTypeData &atd2) {
+        CharString id("%s-%s", atd1.atomTypeName(), atd2.atomTypeName());
 
-            // Original S(Q)
-            Renderable *originalSQ = reflectionsGraph_->createRenderable(
-                Renderable::Data1DRenderable, CharString("%s//OriginalBragg//%s", currentConfiguration_->niceName(), id.get()),
-                CharString("Full//%s", id.get()), "Full");
-        }
-    }
+        // Original S(Q)
+        Renderable *originalSQ = reflectionsGraph_->createRenderable(
+            Renderable::Data1DRenderable, CharString("%s//OriginalBragg//%s", currentConfiguration_->niceName(), id.get()),
+            CharString("Full//%s", id.get()), "Full");
+    });
     reflectionsGraph_->groupManager().setGroupColouring("Full", RenderableGroup::AutomaticIndividualColouring);
 }

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -1,0 +1,36 @@
+/*
+	*** Generic Algorithms
+	*** src/templates/algorithms.h
+	Copyright T. Youngs 2012-2020
+
+	This file is part of Dissolve.
+
+	Dissolve is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Dissolve is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+// Perform an operation on every pair of elements in a container
+template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, Lam lambda)
+{
+	int i = 0;
+	for (auto elem1 = begin; elem1 != end; ++elem1, ++i)
+	{
+		int j = i;
+		for (auto elem2 = elem1; elem2 != end; ++elem2, ++j)
+		{
+			lambda(i, *elem1, j, *elem2);
+		}
+	}
+}

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -1,22 +1,22 @@
 /*
-	*** Generic Algorithms
-	*** src/templates/algorithms.h
-	Copyright T. Youngs 2012-2020
+    *** Generic Algorithms
+    *** src/templates/algorithms.h
+    Copyright T. Youngs 2012-2020
 
-	This file is part of Dissolve.
+    This file is part of Dissolve.
 
-	Dissolve is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    Dissolve is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	Dissolve is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    Dissolve is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #pragma once
@@ -24,13 +24,13 @@
 // Perform an operation on every pair of elements in a container
 template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, Lam lambda)
 {
-	int i = 0;
-	for (auto elem1 = begin; elem1 != end; ++elem1, ++i)
-	{
-		int j = i;
-		for (auto elem2 = elem1; elem2 != end; ++elem2, ++j)
-		{
-			lambda(i, *elem1, j, *elem2);
-		}
-	}
+    int i = 0;
+    for (auto elem1 = begin; elem1 != end; ++elem1, ++i)
+    {
+        int j = i;
+        for (auto elem2 = elem1; elem2 != end; ++elem2, ++j)
+        {
+            lambda(i, *elem1, j, *elem2);
+        }
+    }
 }


### PR DESCRIPTION
This PR removes the ListItem dependency from the AtomTypeData class and the AtomTypeList class.  Both are now handled by references instead of pointers.

As part of this process, the `for_pairs` algorithm has been added, which simplifies handling loops which go through each combination of elements in a container.