### PR TITLE
Move code to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ set(CMAKE_AUTOMOC OFF)
 # Set policy for automatic linkage of Qt libs to project
 CMAKE_POLICY(SET CMP0020 NEW)
 
-# Request C++11 Standard Support (Required for Qt 5.7 and certain other parts of the code)
-set(CMAKE_CXX_STANDARD 11)
+# Request C++17 Standard Support (Required for std::optional and auto types in lambda parameters)
+set(CMAKE_CXX_STANDARD 17)
 
 # Catch defines
 if(PARALLEL)

--- a/src/base/lineparser.cpp
+++ b/src/base/lineparser.cpp
@@ -50,7 +50,7 @@ LineParser::~LineParser()
 }
 
 // Return current stream for input
-istream *LineParser::inputStream() const
+std::istream *LineParser::inputStream() const
 {
     if (fileInput_)
         return inputFile_;
@@ -123,7 +123,7 @@ bool LineParser::openInput(const char *filename)
     bool result = true;
     if ((!processPool_) || processPool_->isMaster())
     {
-        inputFile_ = new ifstream(filename, ios::in | ios::binary);
+        inputFile_ = new std::ifstream(filename, std::ios::in | std::ios::binary);
         if (!inputFile_->is_open())
         {
             closeFiles();
@@ -162,9 +162,9 @@ bool LineParser::openInputString(const char *string)
     fileInput_ = false;
 
     // Create a new stringstream and copy the input string to it
-    inputStrings_ = new stringstream;
+    inputStrings_ = new std::stringstream;
     (*inputStrings_) << string;
-    inputStrings_->seekg(ios_base::beg);
+    inputStrings_->seekg(std::ios_base::beg);
 
     lastLineNo_ = 0;
 
@@ -200,7 +200,7 @@ bool LineParser::openOutput(const char *filename, bool directOutput)
         directOutput_ = directOutput;
         if (directOutput_)
         {
-            outputFile_ = new ofstream(filename, ios::out);
+            outputFile_ = new std::ofstream(filename, std::ios::out);
             if (!outputFile_->is_open())
             {
                 closeFiles();
@@ -209,7 +209,7 @@ bool LineParser::openOutput(const char *filename, bool directOutput)
             }
         }
         else
-            cachedFile_ = new stringstream;
+            cachedFile_ = new std::stringstream;
     }
 
     // Broadcast result of open
@@ -248,7 +248,7 @@ bool LineParser::appendOutput(const char *filename)
 
         // Open file for appending
         directOutput_ = true;
-        outputFile_ = new ofstream(filename, ios::app);
+        outputFile_ = new std::ofstream(filename, std::ios::app);
         if (!outputFile_->is_open())
         {
             closeFiles();
@@ -343,9 +343,9 @@ char LineParser::peek() const
 }
 
 // Tell current position of input stream
-streampos LineParser::tellg() const
+std::streampos LineParser::tellg() const
 {
-    streampos result = 0;
+    std::streampos result = 0;
     if (inputStream() != NULL)
         result = inputStream()->tellg();
     else
@@ -354,7 +354,7 @@ streampos LineParser::tellg() const
 }
 
 // Seek position in input stream
-void LineParser::seekg(streampos pos)
+void LineParser::seekg(std::streampos pos)
 {
     if (inputFile_ != NULL)
     {
@@ -367,7 +367,7 @@ void LineParser::seekg(streampos pos)
 }
 
 // Seek n bytes in specified direction in input stream
-void LineParser::seekg(streamoff off, ios_base::seekdir dir)
+void LineParser::seekg(std::streamoff off, std::ios_base::seekdir dir)
 {
     if (inputStream() != NULL)
         inputFile_->seekg(off, dir);
@@ -379,7 +379,7 @@ void LineParser::seekg(streamoff off, ios_base::seekdir dir)
 void LineParser::rewind()
 {
     if (inputStream() != NULL)
-        inputFile_->seekg(0, ios::beg);
+        inputFile_->seekg(0, std::ios::beg);
     else
         Messenger::print("No file currently open to rewind.\n");
 }
@@ -410,7 +410,7 @@ bool LineParser::eofOrBlank() const
         }
 
         // Otherwise, store the current file position and search for a non-whitespace character (or end of file)
-        streampos pos = inputStream()->tellg();
+        std::streampos pos = inputStream()->tellg();
 
         // Skip through whitespace, searching for 'hard' character
         char c;
@@ -1212,7 +1212,7 @@ bool LineParser::commitCache()
             return false;
         }
 
-        ofstream outputFile(outputFilename_);
+        std::ofstream outputFile(outputFilename_);
         if (outputFile.is_open())
         {
             outputFile << cachedFile_->str();

--- a/src/base/lineparser.h
+++ b/src/base/lineparser.h
@@ -29,8 +29,6 @@
 #include <iostream>
 #include <sstream>
 
-using namespace std;
-
 #define MAXLINELENGTH 8092
 
 // Forward Declarations
@@ -83,17 +81,17 @@ class LineParser
     // Integer line number of last read line
     int lastLineNo_;
     // Source stream for reading
-    ifstream *inputFile_;
+    std::ifstream *inputFile_;
     // Source string stream for reading
-    stringstream *inputStrings_;
+    std::stringstream *inputStrings_;
     // Target stream for writing
-    ofstream *outputFile_;
+    std::ofstream *outputFile_;
     // Target stream for cached writing
-    stringstream *cachedFile_;
+    std::stringstream *cachedFile_;
 
     private:
     // Return current stream for input
-    istream *inputStream() const;
+    std::istream *inputStream() const;
 
     public:
     // Reset data
@@ -127,13 +125,13 @@ class LineParser
     // Return whether current file source is good for writing
     bool isFileGoodForWriting() const;
     // Tell current position of input stream
-    streampos tellg() const;
+    std::streampos tellg() const;
     // Peek next character in input stream
     char peek() const;
     // Seek position in input stream
-    void seekg(streampos pos);
+    void seekg(std::streampos pos);
     // Seek n bytes in specified direction in input stream
-    void seekg(streamoff off, ios_base::seekdir dir);
+    void seekg(std::streamoff off, std::ios_base::seekdir dir);
     // Rewind input stream to start
     void rewind();
     // Return whether the end of the input stream has been reached (or only whitespace remains)

--- a/src/classes/atomtypelist.cpp
+++ b/src/classes/atomtypelist.cpp
@@ -70,8 +70,8 @@ void AtomTypeList::zero()
 AtomTypeData &AtomTypeList::add(AtomType &atomType, double population)
 {
     // Search the list for the AtomType provided.
-    auto atd = std::find_if(types_.begin(), types_.end(),
-                            [&atomType](const AtomTypeData &data) { return &data.atomType() == &atomType; });
+    auto atd =
+        std::find_if(types_.begin(), types_.end(), [&atomType](const auto &data) { return &data.atomType() == &atomType; });
 
     // Return the entry if we found it
     if (atd != types_.end())
@@ -102,8 +102,8 @@ void AtomTypeList::add(const AtomTypeList &source)
 // Remove specified AtomType from the list
 void AtomTypeList::remove(AtomType &atomType)
 {
-    types_.erase(std::remove_if(types_.begin(), types_.end(),
-                                [&atomType](const AtomTypeData &atd) { return &atd.atomType() == &atomType; }));
+    types_.erase(
+        std::remove_if(types_.begin(), types_.end(), [&atomType](const auto &atd) { return &atd.atomType() == &atomType; }));
 }
 
 // Add/increase this AtomType/Isotope pair
@@ -255,8 +255,7 @@ AtomType &AtomTypeList::atomType(int n)
 // Return AtomTypeData for specified AtomType
 std::optional<std::reference_wrapper<const AtomTypeData>> AtomTypeList::atomTypeData(AtomType &atomType)
 {
-    auto it = std::find_if(types_.begin(), types_.end(),
-                           [&atomType](const AtomTypeData &atd) { return &atomType == &atd.atomType(); });
+    auto it = std::find_if(types_.begin(), types_.end(), [&atomType](const auto &atd) { return &atomType == &atd.atomType(); });
     if (it == types_.end())
         return {};
     return *it;

--- a/src/classes/atomtypelist.cpp
+++ b/src/classes/atomtypelist.cpp
@@ -253,14 +253,13 @@ AtomType &AtomTypeList::atomType(int n)
 }
 
 // Return AtomTypeData for specified AtomType
-optional<const AtomTypeData &> AtomTypeList::atomTypeData(AtomType &atomType)
+std::optional<std::reference_wrapper<const AtomTypeData>> AtomTypeList::atomTypeData(AtomType &atomType)
 {
     auto it = std::find_if(types_.begin(), types_.end(),
                            [&atomType](const AtomTypeData &atd) { return &atomType == &atd.atomType(); });
-    bool found = false;
-    if (it != types_.end())
-        found = true;
-    return std::make_tuple(*it, found);
+    if (it == types_.end())
+        return {};
+    return *it;
 }
 
 // Print AtomType populations

--- a/src/classes/atomtypelist.h
+++ b/src/classes/atomtypelist.h
@@ -89,7 +89,7 @@ class AtomTypeList : public GenericItemBase
     // Return nth referenced AtomType
     AtomType &atomType(int n);
     // Return AtomTypeData for specified AtomType
-    optional<std::reference_wrapper<const AtomTypeData>> atomTypeData(AtomType &atomType);
+    std::optional<std::reference_wrapper<const AtomTypeData>> atomTypeData(AtomType &atomType);
     // Print AtomType populations
     void print() const;
 

--- a/src/classes/atomtypelist.h
+++ b/src/classes/atomtypelist.h
@@ -24,14 +24,13 @@
 #include "classes/atomtypedata.h"
 #include "classes/coredata.h"
 #include "genericitems/base.h"
+#include <optional>
 #include <tuple>
 #include <vector>
 
 // Forward Declarations
 class AtomType;
 class Isotope;
-
-template <class T> using optional = std::tuple<T, bool>;
 
 // AtomTypeList
 class AtomTypeList : public GenericItemBase
@@ -90,7 +89,7 @@ class AtomTypeList : public GenericItemBase
     // Return nth referenced AtomType
     AtomType &atomType(int n);
     // Return AtomTypeData for specified AtomType
-    optional<const AtomTypeData &> atomTypeData(AtomType &atomType);
+    optional<std::reference_wrapper<const AtomTypeData>> atomTypeData(AtomType &atomType);
     // Print AtomType populations
     void print() const;
 

--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -126,12 +126,14 @@ bool IsotopologueCollection::contains(const Configuration *cfg) const
 }
 
 // Return IsotopologueSet for the specified Configuration
-optional<const IsotopologueSet> IsotopologueCollection::getIsotopologueSet(const Configuration *cfg) const
+std::optional<const IsotopologueSet> IsotopologueCollection::getIsotopologueSet(const Configuration *cfg) const
 {
     auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
                            [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
+    if (it == isotopologueSets_.end())
+        return {};
 
-    return std::make_tuple(*it, it == isotopologueSets_.end());
+    return *it;
 }
 
 // Return whether the Species has a defined set of isotopologues in the specified Configuration
@@ -144,7 +146,7 @@ bool IsotopologueCollection::contains(const Configuration *cfg, const Species *s
 }
 
 // Return Isotopologues for the Species in the specified Configuration
-optional<const Isotopologues> IsotopologueCollection::getIsotopologues(const Configuration *cfg, const Species *sp) const
+std::optional<const Isotopologues> IsotopologueCollection::getIsotopologues(const Configuration *cfg, const Species *sp) const
 {
     auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
                            [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
@@ -152,8 +154,7 @@ optional<const Isotopologues> IsotopologueCollection::getIsotopologues(const Con
     if (it != isotopologueSets_.end())
         return it->getIsotopologues(sp);
 
-    static const Isotopologues dummyTopes;
-    return std::make_tuple(dummyTopes, true);
+    return {};
 }
 
 // Complete the collection by making sure it contains every Species in every Configuration in the supplied list

--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -39,7 +39,7 @@ IsotopologueCollection::~IsotopologueCollection() {}
 void IsotopologueCollection::pruneEmptySets()
 {
     isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-                                           [](IsotopologueSet &set) { return set.nIsotopologues() == 0; }),
+                                           [](const auto &set) { return set.nIsotopologues() == 0; }),
                             isotopologueSets_.end());
 }
 
@@ -51,7 +51,7 @@ void IsotopologueCollection::add(Configuration *cfg, Isotopologue *iso, double r
 {
     // Check if a set already exists for this Configuration
     auto it = std::find_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-                           [cfg](IsotopologueSet &set) { return set.configuration() == cfg; });
+                           [cfg](const auto &set) { return set.configuration() == cfg; });
 
     if (it == isotopologueSets_.end())
     {
@@ -65,16 +65,16 @@ void IsotopologueCollection::add(Configuration *cfg, Isotopologue *iso, double r
 // Remove the specified set from the collection
 void IsotopologueCollection::remove(IsotopologueSet *set)
 {
-    isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-                                           [set](IsotopologueSet &data) { return &data == set; }),
-                            isotopologueSets_.end());
+    isotopologueSets_.erase(
+        std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(), [set](const auto &data) { return &data == set; }),
+        isotopologueSets_.end());
 }
 
 // Remove the Configuration from the collection
 void IsotopologueCollection::remove(Configuration *cfg)
 {
     isotopologueSets_.erase(std::remove_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-                                           [cfg](IsotopologueSet &set) { return set.configuration() == cfg; }),
+                                           [cfg](const auto &set) { return set.configuration() == cfg; }),
                             isotopologueSets_.end());
 }
 
@@ -129,7 +129,7 @@ bool IsotopologueCollection::contains(const Configuration *cfg) const
 std::optional<const IsotopologueSet> IsotopologueCollection::getIsotopologueSet(const Configuration *cfg) const
 {
     auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
-                           [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
+                           [cfg](const auto &set) { return set.configuration() == cfg; });
     if (it == isotopologueSets_.end())
         return {};
 
@@ -140,7 +140,7 @@ std::optional<const IsotopologueSet> IsotopologueCollection::getIsotopologueSet(
 bool IsotopologueCollection::contains(const Configuration *cfg, const Species *sp) const
 {
     auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
-                           [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
+                           [cfg](const auto &set) { return set.configuration() == cfg; });
 
     return (it != isotopologueSets_.end() ? it->contains(sp) : false);
 }
@@ -149,7 +149,7 @@ bool IsotopologueCollection::contains(const Configuration *cfg, const Species *s
 std::optional<const Isotopologues> IsotopologueCollection::getIsotopologues(const Configuration *cfg, const Species *sp) const
 {
     auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
-                           [cfg](const IsotopologueSet &set) { return set.configuration() == cfg; });
+                           [cfg](const auto &set) { return set.configuration() == cfg; });
 
     if (it != isotopologueSets_.end())
         return it->getIsotopologues(sp);
@@ -164,7 +164,7 @@ void IsotopologueCollection::complete(const RefList<Configuration> &configuratio
     {
         // Retrieve / create a set for this Configuration
         auto it = std::find_if(isotopologueSets_.begin(), isotopologueSets_.end(),
-                               [cfg](IsotopologueSet &set) { return set.configuration() == cfg; });
+                               [cfg](const auto &set) { return set.configuration() == cfg; });
 
         IsotopologueSet *setForCfg = nullptr;
         if (it == isotopologueSets_.end())

--- a/src/classes/isotopologuecollection.h
+++ b/src/classes/isotopologuecollection.h
@@ -24,6 +24,7 @@
 #include "classes/isotopologueset.h"
 #include "genericitems/base.h"
 #include "templates/reflist.h"
+#include <optional>
 
 // Forward Declarations
 class Configuration;
@@ -74,11 +75,11 @@ class IsotopologueCollection : public GenericItemBase
     // Return whether a set exists for the supplied Configuration
     bool contains(const Configuration *cfg) const;
     // Return IsotopologueSet for the specified Configuration
-    optional<const IsotopologueSet> getIsotopologueSet(const Configuration *cfg) const;
+    std::optional<const IsotopologueSet> getIsotopologueSet(const Configuration *cfg) const;
     // Return whether the Species has a defined set of isotopologues in the specified Configuration
     bool contains(const Configuration *cfg, const Species *sp) const;
     // Return Isotopologues for the Species in the specified Configuration
-    optional<const Isotopologues> getIsotopologues(const Configuration *cfg, const Species *sp) const;
+    std::optional<const Isotopologues> getIsotopologues(const Configuration *cfg, const Species *sp) const;
     // Complete the collection by making sure it contains every Species in every Configuration in the supplied list
     void complete(const RefList<Configuration> &configurations);
 

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -54,10 +54,9 @@ int Isotopologues::speciesPopulation() const { return speciesPopulation_; }
 void Isotopologues::pruneMissing()
 {
     // Go through list of Isotopologues present in this mix, removing any that no longer exist
-    mix_.erase(
-        std::remove_if(mix_.begin(), mix_.end(),
-                       [&](IsotopologueWeight &isoWeight) { return !species_->hasIsotopologue(isoWeight.isotopologue()); }),
-        mix_.end());
+    mix_.erase(std::remove_if(mix_.begin(), mix_.end(),
+                              [&](const auto &isoWeight) { return !species_->hasIsotopologue(isoWeight.isotopologue()); }),
+               mix_.end());
 }
 
 // Add next available Isotopologue to list
@@ -117,8 +116,7 @@ bool Isotopologues::set(const Isotopologue *iso, double relativeWeight)
     }
 
     // Find the specified Isotopologue
-    auto it = std::find_if(mix_.begin(), mix_.end(),
-                           [iso](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; });
+    auto it = std::find_if(mix_.begin(), mix_.end(), [iso](auto &isoWeight) { return isoWeight.isotopologue() == iso; });
 
     if (it == mix_.end())
     {
@@ -137,15 +135,15 @@ bool Isotopologues::set(const Isotopologue *iso, double relativeWeight)
 // Remove references to the specified Isotopologue
 void Isotopologues::remove(const Isotopologue *iso)
 {
-    mix_.erase(std::remove_if(mix_.begin(), mix_.end(),
-                              [iso](IsotopologueWeight &isoWeight) { return isoWeight.isotopologue() == iso; }),
-               mix_.end());
+    mix_.erase(
+        std::remove_if(mix_.begin(), mix_.end(), [iso](const auto &isoWeight) { return isoWeight.isotopologue() == iso; }),
+        mix_.end());
 }
 
 // Remove the specified IsotopologueWeight
 void Isotopologues::remove(IsotopologueWeight *isoWeight)
 {
-    mix_.erase(std::remove_if(mix_.begin(), mix_.end(), [isoWeight](IsotopologueWeight &data) { return isoWeight == &data; }),
+    mix_.erase(std::remove_if(mix_.begin(), mix_.end(), [isoWeight](const auto &data) { return isoWeight == &data; }),
                mix_.end());
 }
 

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -129,8 +129,10 @@ optional<const Isotopologues> IsotopologueSet::getIsotopologues(const Species *s
 {
     auto it = std::find_if(isotopologues_.cbegin(), isotopologues_.cend(),
                            [sp](const Isotopologues &data) { return data.species() == sp; });
+    if (it == isotopologues_.end())
+        return {};
 
-    return std::make_tuple(*it, it == isotopologues_.end());
+    return *it;
 }
 
 // Return number of Isotopologues defined

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -125,7 +125,7 @@ bool IsotopologueSet::contains(const Species *sp) const
 }
 
 // Return IsotopologueSet for the specified Species
-optional<const Isotopologues> IsotopologueSet::getIsotopologues(const Species *sp) const
+std::optional<const Isotopologues> IsotopologueSet::getIsotopologues(const Species *sp) const
 {
     auto it =
         std::find_if(isotopologues_.cbegin(), isotopologues_.cend(), [sp](const auto &data) { return data.species() == sp; });

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -65,7 +65,7 @@ Configuration *IsotopologueSet::configuration() const { return configuration_; }
 void IsotopologueSet::add(Isotopologue *iso, double relativeWeight)
 {
     auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(),
-                           [iso](Isotopologues &data) { return data.species() == iso->parent(); });
+                           [iso](auto &data) { return data.species() == iso->parent(); });
     if (it != isotopologues_.end())
         it->add(iso, relativeWeight);
     else
@@ -78,9 +78,9 @@ void IsotopologueSet::add(Isotopologue *iso, double relativeWeight)
 // Remove specified Species from the list (if it exists)
 void IsotopologueSet::remove(Species *sp)
 {
-    isotopologues_.erase(std::remove_if(isotopologues_.begin(), isotopologues_.end(),
-                                        [sp](Isotopologues &data) { return data.species() == sp; }),
-                         isotopologues_.end());
+    isotopologues_.erase(
+        std::remove_if(isotopologues_.begin(), isotopologues_.end(), [sp](const auto &data) { return data.species() == sp; }),
+        isotopologues_.end());
 }
 
 // Remove any occurrences of the specified Isotopologue
@@ -88,7 +88,7 @@ void IsotopologueSet::remove(Isotopologue *iso)
 {
     // Get parent Isotopologues from the contained Species pointer
     auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(),
-                           [iso](Isotopologues &data) { return data.species() == iso->parent(); });
+                           [iso](auto &data) { return data.species() == iso->parent(); });
 
     if (it != isotopologues_.end())
     {
@@ -105,7 +105,7 @@ void IsotopologueSet::remove(IsotopologueWeight *isoWeight)
 {
     // Get Isotopologues related to the IsotopologueWeight's Species pointer
     auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(),
-                           [isoWeight](Isotopologues &data) { return data.species() == isoWeight->isotopologue()->parent(); });
+                           [isoWeight](auto &data) { return data.species() == isoWeight->isotopologue()->parent(); });
 
     if (it != isotopologues_.end())
     {
@@ -127,8 +127,8 @@ bool IsotopologueSet::contains(const Species *sp) const
 // Return IsotopologueSet for the specified Species
 optional<const Isotopologues> IsotopologueSet::getIsotopologues(const Species *sp) const
 {
-    auto it = std::find_if(isotopologues_.cbegin(), isotopologues_.cend(),
-                           [sp](const Isotopologues &data) { return data.species() == sp; });
+    auto it =
+        std::find_if(isotopologues_.cbegin(), isotopologues_.cend(), [sp](const auto &data) { return data.species() == sp; });
     if (it == isotopologues_.end())
         return {};
 

--- a/src/classes/isotopologueset.h
+++ b/src/classes/isotopologueset.h
@@ -23,9 +23,8 @@
 
 #include "classes/isotopologues.h"
 #include "genericitems/base.h"
+#include <optional>
 #include <vector>
-
-template <class T> using optional = std::tuple<T, bool>;
 
 // Forward Declarations
 class Configuration;
@@ -81,7 +80,7 @@ class IsotopologueSet : public GenericItemBase
     // Return whether Isotopologues for the specified Species exists
     bool contains(const Species *sp) const;
     // Return Isotopologues for the specified Species
-    optional<const Isotopologues> getIsotopologues(const Species *sp) const;
+    std::optional<const Isotopologues> getIsotopologues(const Species *sp) const;
     // Return number of Isotopologues defined
     int nIsotopologues() const;
     // Return vector of all Isotopologues

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -77,7 +77,7 @@ void NeutronWeights::addIsotopologue(Species *sp, int speciesPopulation, const I
 {
     // Does an Isotopologues definition already exist for the supplied Species?
     auto it = std::find_if(isotopologueMixtures_.begin(), isotopologueMixtures_.end(),
-                           [sp](Isotopologues &data) { return data.species() == sp; });
+                           [sp](auto &data) { return data.species() == sp; });
 
     if (it == isotopologueMixtures_.end())
     {

--- a/src/classes/speciesatom.cpp
+++ b/src/classes/speciesatom.cpp
@@ -141,8 +141,7 @@ const std::vector<SpeciesBond *> &SpeciesAtom::bonds() const { return bonds_; }
 // Return whether Bond to specified Atom exists
 SpeciesBond *SpeciesAtom::hasBond(SpeciesAtom *partner)
 {
-    auto result =
-        find_if(bonds_.begin(), bonds_.end(), [&](const SpeciesBond *bond) { return bond->partner(this) == partner; });
+    auto result = find_if(bonds_.begin(), bonds_.end(), [&](const auto *bond) { return bond->partner(this) == partner; });
     return result == bonds_.end() ? nullptr : *result;
 }
 

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -64,11 +64,11 @@ bool XRayWeights::initialiseFormFactors()
 
         // Try to retrieve form factor data for this atom type (element, formal charge [TODO])
         auto data = XRayFormFactors::formFactorData(formFactors_, at.element());
-        if (std::get<1>(data))
+        if (!data)
             return Messenger::error("No form factor data present for element %s (formal charge %i) in x-ray data set '%s'.\n",
                                     at.element()->symbol(), 0, XRayFormFactors::xRayFormFactorData().keyword(formFactors_));
 
-        formFactorData_.push_back(std::reference_wrapper<const FormFactorData>(std::get<0>(data)));
+        formFactorData_.push_back(*data);
     }
 
     return true;

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -117,9 +117,8 @@ void Forcefield::addParameters(const char *name, double data0, double data1, dou
 // Return named short-range parameters (if they exist)
 const ForcefieldParameters *Forcefield::shortRangeParameters(const char *name) const
 {
-    auto it =
-        std::find_if(shortRangeParameters_.begin(), shortRangeParameters_.end(),
-                     [&name](const ForcefieldParameters &params) { return DissolveSys::sameString(name, params.name()); });
+    auto it = std::find_if(shortRangeParameters_.begin(), shortRangeParameters_.end(),
+                           [&name](const auto &params) { return DissolveSys::sameString(name, params.name()); });
     if (it != shortRangeParameters_.end())
         return &*it;
 

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -195,30 +195,32 @@ void Forcefield::addImproperTerm(const char *typeI, const char *typeJ, const cha
 }
 
 // Return bond term for the supplied atom type pair (if it exists)
-optional<const ForcefieldBondTerm &> Forcefield::getBondTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j) const
+std::optional<std::reference_wrapper<const ForcefieldBondTerm>> Forcefield::getBondTerm(const ForcefieldAtomType *i,
+                                                                                        const ForcefieldAtomType *j) const
 {
     return termMatch_(bondTerms_, i, j);
 }
 
 // Return angle term for the supplied atom type trio (if it exists)
-optional<const ForcefieldAngleTerm &> Forcefield::getAngleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
-                                                               const ForcefieldAtomType *k) const
+std::optional<std::reference_wrapper<const ForcefieldAngleTerm>>
+Forcefield::getAngleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k) const
 {
     return termMatch_(angleTerms_, i, j, k);
 }
 
 // Return torsion term for the supplied atom type quartet (if it exists)
-optional<const ForcefieldTorsionTerm &> Forcefield::getTorsionTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
-                                                                   const ForcefieldAtomType *k,
-                                                                   const ForcefieldAtomType *l) const
+std::optional<std::reference_wrapper<const ForcefieldTorsionTerm>> Forcefield::getTorsionTerm(const ForcefieldAtomType *i,
+                                                                                              const ForcefieldAtomType *j,
+                                                                                              const ForcefieldAtomType *k,
+                                                                                              const ForcefieldAtomType *l) const
 {
     return termMatch_(torsionTerms_, i, j, k, l);
 }
 
 // Return improper term for the supplied atom type quartet (if it exists)
-optional<const ForcefieldImproperTerm &> Forcefield::getImproperTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
-                                                                     const ForcefieldAtomType *k,
-                                                                     const ForcefieldAtomType *l) const
+std::optional<std::reference_wrapper<const ForcefieldImproperTerm>>
+Forcefield::getImproperTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k,
+                            const ForcefieldAtomType *l) const
 {
     return termMatch_(improperTerms_, i, j, k, l);
 }
@@ -333,12 +335,12 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
             return Messenger::error("Couldn't locate object for atom type named '%s'.\n", j->atomType()->name());
 
         auto opt_term = getBondTerm(typeI, typeJ);
-        if (std::get<1>(opt_term))
+        if (!opt_term)
         {
             return Messenger::error("Failed to locate parameters for bond %i-%i (%s-%s).\n", i->userIndex(), j->userIndex(),
                                     typeI->equivalentName(), typeJ->equivalentName());
         }
-        const ForcefieldBondTerm &term = std::get<0>(opt_term);
+        const ForcefieldBondTerm &term = *opt_term;
         bond->setForm(term.form());
         bond->setParameters(term.parameters());
     }
@@ -365,12 +367,12 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
             return Messenger::error("Couldn't locate object for atom type named '%s'.\n", k->atomType()->name());
 
         auto opt_term = getAngleTerm(typeI, typeJ, typeK);
-        if (std::get<1>(opt_term))
+        if (!opt_term)
             return Messenger::error("Failed to locate parameters for angle %i-%i-%i (%s-%s-%s).\n", i->userIndex(),
                                     j->userIndex(), k->userIndex(), typeI->equivalentName(), typeJ->equivalentName(),
                                     typeK->equivalentName());
 
-        const auto &term = std::get<0>(opt_term);
+        const ForcefieldAngleTerm &term = *opt_term;
         angle->setForm(term.form());
         angle->setParameters(term.parameters());
     }
@@ -401,12 +403,12 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
             return Messenger::error("Couldn't locate object for atom type named '%s'.\n", l->atomType()->name());
 
         auto opt_term = getTorsionTerm(typeI, typeJ, typeK, typeL);
-        if (std::get<1>(opt_term))
+        if (!opt_term)
             return Messenger::error("Failed to locate parameters for torsion %i-%i-%i-%i (%s-%s-%s-%s).\n", i->userIndex(),
                                     j->userIndex(), k->userIndex(), l->userIndex(), typeI->equivalentName(),
                                     typeJ->equivalentName(), typeK->equivalentName(), typeL->equivalentName());
 
-        const auto &term = std::get<0>(opt_term);
+        const ForcefieldTorsionTerm &term = *opt_term;
         torsion->setForm(term.form());
         torsion->setParameters(term.parameters());
     }
@@ -463,9 +465,9 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
                             continue;
 
                         auto opt_term = getImproperTerm(typeI, typeJ, typeK, typeL);
-                        if (!std::get<1>(opt_term))
+                        if (opt_term)
                         {
-                            const auto &term = std::get<0>(opt_term);
+                            const ForcefieldImproperTerm &term = *opt_term;
                             // Check to see if the Species already has an improper definition - if
                             // not create one
                             SpeciesImproper *improper = sp->improper(i, j, k, l);

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -34,10 +34,9 @@
 #include "data/fftorsionterm.h"
 #include <algorithm>
 #include <functional>
+#include <optional>
 #include <tuple>
 #include <vector>
-
-template <class T> using optional = std::tuple<T, bool>;
 
 // Forward Declarations
 class CoreData;
@@ -139,22 +138,24 @@ class Forcefield : public Elements
                          SpeciesImproper::ImproperFunction form, double data0 = 0.0, double data1 = 0.0, double data2 = 0.0,
                          double data3 = 0.0);
     // Match any kind of term
-    template <class T, typename... Args> static optional<const T &> termMatch_(std::vector<T>, Args...);
+    template <class T, typename... Args>
+    static std::optional<std::reference_wrapper<const T>> termMatch_(std::vector<T>, Args...);
 
     public:
     // Return bond term for the supplied atom type pair (if it exists)
-    virtual optional<const ForcefieldBondTerm &> getBondTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j) const;
+    virtual std::optional<std::reference_wrapper<const ForcefieldBondTerm>> getBondTerm(const ForcefieldAtomType *i,
+                                                                                        const ForcefieldAtomType *j) const;
     // Return angle term for the supplied atom type trio (if it exists)
-    virtual optional<const ForcefieldAngleTerm &> getAngleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
-                                                               const ForcefieldAtomType *k) const;
+    virtual std::optional<std::reference_wrapper<const ForcefieldAngleTerm>>
+    getAngleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k) const;
     // Return torsion term for the supplied atom type quartet (if it exists)
-    virtual optional<const ForcefieldTorsionTerm &> getTorsionTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
-                                                                   const ForcefieldAtomType *k,
-                                                                   const ForcefieldAtomType *l) const;
+    virtual std::optional<std::reference_wrapper<const ForcefieldTorsionTerm>>
+    getTorsionTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k,
+                   const ForcefieldAtomType *l) const;
     // Return improper term for the supplied atom type quartet (if it exists)
-    virtual optional<const ForcefieldImproperTerm &> getImproperTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
-                                                                     const ForcefieldAtomType *k,
-                                                                     const ForcefieldAtomType *l) const;
+    virtual std::optional<std::reference_wrapper<const ForcefieldImproperTerm>>
+    getImproperTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k,
+                    const ForcefieldAtomType *l) const;
 
     /*
      * Term Assignment
@@ -217,8 +218,11 @@ class Forcefield : public Elements
     int guessOxidationState(const SpeciesAtom *i) const;
 };
 
-template <class T, typename... Args> optional<const T &> Forcefield::termMatch_(std::vector<T> container, Args... args)
+template <class T, typename... Args>
+optional<std::reference_wrapper<const T>> Forcefield::termMatch_(std::vector<T> container, Args... args)
 {
     auto it = std::find_if(container.begin(), container.end(), [&](const T &item) { return item.isMatch(args...); });
-    return std::make_tuple(*it, it == container.end());
+    if (it == container.end())
+        return {};
+    return *it;
 }

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -219,7 +219,7 @@ class Forcefield : public Elements
 };
 
 template <class T, typename... Args>
-optional<std::reference_wrapper<const T>> Forcefield::termMatch_(std::vector<T> container, Args... args)
+std::optional<std::reference_wrapper<const T>> Forcefield::termMatch_(std::vector<T> container, Args... args)
 {
     auto it = std::find_if(container.begin(), container.end(), [&](const T &item) { return item.isMatch(args...); });
     if (it == container.end())

--- a/src/data/ff/oplsaa2005/base.h
+++ b/src/data/ff/oplsaa2005/base.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "data/ff.h"
+#include <optional>
 
 // Forward Declarations
 /* none */
@@ -54,14 +55,19 @@ class OPLSAA2005BaseForcefield : public Forcefield
      */
     public:
     // Return bond term for the supplied atom type pair (if it exists)
-    optional<const ForcefieldBondTerm &> bondTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j) const;
+    std::optional<std::reference_wrapper<const ForcefieldBondTerm>> bondTerm(const ForcefieldAtomType *i,
+                                                                             const ForcefieldAtomType *j) const;
     // Return angle term for the supplied atom type trio (if it exists)
-    optional<const ForcefieldAngleTerm &> angleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
-                                                    const ForcefieldAtomType *k) const;
+    std::optional<std::reference_wrapper<const ForcefieldAngleTerm>>
+    angleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k) const;
     // Return torsion term for the supplied atom type quartet (if it exists)
-    optional<const ForcefieldTorsionTerm &> torsionTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
-                                                        const ForcefieldAtomType *k, const ForcefieldAtomType *l) const;
+    std::optional<std::reference_wrapper<const ForcefieldTorsionTerm>> torsionTerm(const ForcefieldAtomType *i,
+                                                                                   const ForcefieldAtomType *j,
+                                                                                   const ForcefieldAtomType *k,
+                                                                                   const ForcefieldAtomType *l) const;
     // Return improper term for the supplied atom type quartet (if it exists)
-    optional<const ForcefieldImproperTerm &> improperTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
-                                                          const ForcefieldAtomType *k, const ForcefieldAtomType *l) const;
+    std::optional<std::reference_wrapper<const ForcefieldImproperTerm>> improperTerm(const ForcefieldAtomType *i,
+                                                                                     const ForcefieldAtomType *j,
+                                                                                     const ForcefieldAtomType *k,
+                                                                                     const ForcefieldAtomType *l) const;
 };

--- a/src/data/ff/oplsaa2005/intramolecular.cpp
+++ b/src/data/ff/oplsaa2005/intramolecular.cpp
@@ -26,6 +26,7 @@
 #include "data/fftorsionterm.h"
 #include <algorithm>
 #include <functional>
+#include <optional>
 #include <vector>
 
 /*
@@ -33,8 +34,8 @@
  */
 
 // Return bond term for the supplied atom type pair (if it exists)
-optional<const ForcefieldBondTerm &> OPLSAA2005BaseForcefield::bondTerm(const ForcefieldAtomType *i,
-                                                                        const ForcefieldAtomType *j) const
+std::optional<std::reference_wrapper<const ForcefieldBondTerm>>
+OPLSAA2005BaseForcefield::bondTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j) const
 {
     static std::vector<ForcefieldBondTerm> bondTerms = {
         //	i	j	Type (Harmonic)			k	eq
@@ -397,7 +398,7 @@ optional<const ForcefieldBondTerm &> OPLSAA2005BaseForcefield::bondTerm(const Fo
 }
 
 // Return angle term for the supplied atom type trio (if it exists)
-optional<const ForcefieldAngleTerm &>
+std::optional<std::reference_wrapper<const ForcefieldAngleTerm>>
 OPLSAA2005BaseForcefield::angleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k) const
 {
     static std::vector<ForcefieldAngleTerm> angleTerms = {
@@ -1412,10 +1413,9 @@ OPLSAA2005BaseForcefield::angleTerm(const ForcefieldAtomType *i, const Forcefiel
 }
 
 // Return torsion term for the supplied atom type quartet (if it exists)
-optional<const ForcefieldTorsionTerm &> OPLSAA2005BaseForcefield::torsionTerm(const ForcefieldAtomType *i,
-                                                                              const ForcefieldAtomType *j,
-                                                                              const ForcefieldAtomType *k,
-                                                                              const ForcefieldAtomType *l) const
+std::optional<std::reference_wrapper<const ForcefieldTorsionTerm>>
+OPLSAA2005BaseForcefield::torsionTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k,
+                                      const ForcefieldAtomType *l) const
 {
     static std::vector<ForcefieldTorsionTerm> torsionTerms = {
         //	i	j	k	l	Type (CosineForm)		k		n	eq	s
@@ -2171,10 +2171,9 @@ optional<const ForcefieldTorsionTerm &> OPLSAA2005BaseForcefield::torsionTerm(co
 }
 
 // Return improper term for the supplied atom type quartet (if it exists)
-optional<const ForcefieldImproperTerm &> OPLSAA2005BaseForcefield::improperTerm(const ForcefieldAtomType *i,
-                                                                                const ForcefieldAtomType *j,
-                                                                                const ForcefieldAtomType *k,
-                                                                                const ForcefieldAtomType *l) const
+std::optional<std::reference_wrapper<const ForcefieldImproperTerm>>
+OPLSAA2005BaseForcefield::improperTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k,
+                                       const ForcefieldAtomType *l) const
 {
     static std::vector<ForcefieldImproperTerm> improperTerms = {};
     return Forcefield::termMatch_(improperTerms, i, j, k, l);

--- a/src/data/fflibrary.cpp
+++ b/src/data/fflibrary.cpp
@@ -73,7 +73,7 @@ std::vector<std::shared_ptr<Forcefield>> &ForcefieldLibrary::forcefields()
 }
 
 // Return named Forcefield, if it exists
-std::shared_ptr<Forcefield> ForcefieldLibrary::forcefield(const string name)
+std::shared_ptr<Forcefield> ForcefieldLibrary::forcefield(const std::string name)
 {
     for (auto &ff : forcefields())
     {

--- a/src/data/fflibrary.h
+++ b/src/data/fflibrary.h
@@ -43,5 +43,5 @@ class ForcefieldLibrary
     // Return list of available Forcefields
     static std::vector<std::shared_ptr<Forcefield>> &forcefields();
     // Return named Forcefield, if it exists
-    static std::shared_ptr<Forcefield> forcefield(const string name);
+    static std::shared_ptr<Forcefield> forcefield(const std::string name);
 };

--- a/src/data/formfactors.cpp
+++ b/src/data/formfactors.cpp
@@ -21,6 +21,8 @@
 
 #include "data/formfactors.h"
 #include "data/formfactors_dummy.h"
+#include <functional>
+#include <optional>
 
 namespace XRayFormFactors
 {
@@ -38,7 +40,7 @@ EnumOptions<XRayFormFactors::XRayFormFactorData> xRayFormFactorData()
 }
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-optional<const FormFactorData &> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge)
+std::optional<std::reference_wrapper<const FormFactorData>> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge)
 {
     switch (dataSet)
     {
@@ -48,12 +50,12 @@ optional<const FormFactorData &> formFactorData(XRayFormFactorData dataSet, int 
             Messenger::error("Form factor data set type %i not recognised.\n");
     }
 
-    static const FormFactorData_Dummy dummyData;
-    return std::make_tuple(dummyData, true);
+    return {};
 }
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-optional<const FormFactorData &> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge)
+std::optional<std::reference_wrapper<const FormFactorData>> formFactorData(XRayFormFactorData dataSet, Element *el,
+                                                                           int formalCharge)
 {
     return formFactorData(dataSet, el->Z(), formalCharge);
 }

--- a/src/data/formfactors.cpp
+++ b/src/data/formfactors.cpp
@@ -40,7 +40,7 @@ EnumOptions<XRayFormFactors::XRayFormFactorData> xRayFormFactorData()
 }
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-opt<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge)
+optional_reference_wrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge)
 {
     switch (dataSet)
     {
@@ -54,7 +54,7 @@ opt<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int 
 }
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-opt<const FormFactorData> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge)
+optional_reference_wrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge)
 {
     return formFactorData(dataSet, el->Z(), formalCharge);
 }

--- a/src/data/formfactors.cpp
+++ b/src/data/formfactors.cpp
@@ -40,7 +40,7 @@ EnumOptions<XRayFormFactors::XRayFormFactorData> xRayFormFactorData()
 }
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-std::optional<std::reference_wrapper<const FormFactorData>> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge)
+opt<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge)
 {
     switch (dataSet)
     {
@@ -54,8 +54,7 @@ std::optional<std::reference_wrapper<const FormFactorData>> formFactorData(XRayF
 }
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-std::optional<std::reference_wrapper<const FormFactorData>> formFactorData(XRayFormFactorData dataSet, Element *el,
-                                                                           int formalCharge)
+opt<const FormFactorData> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge)
 {
     return formFactorData(dataSet, el->Z(), formalCharge);
 }

--- a/src/data/formfactors.h
+++ b/src/data/formfactors.h
@@ -27,7 +27,7 @@
 #include <optional>
 #include <tuple>
 
-template <class T> using opt = std::optional<std::reference_wrapper<T>>;
+template <class T> using optional_reference_wrapper = std::optional<std::reference_wrapper<T>>;
 
 // X-Ray Form Factors
 namespace XRayFormFactors
@@ -44,11 +44,11 @@ enum XRayFormFactorData
 EnumOptions<XRayFormFactorData> xRayFormFactorData();
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-opt<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge = 0);
+optional_reference_wrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge = 0);
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-opt<const FormFactorData> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge = 0);
+optional_reference_wrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge = 0);
 
 // Return Waasmaier & Kirfel (1995) form factor data for given element and formal charge (if it exists)
-opt<const FormFactorData> wk1995Data(int Z, int formalCharge = 0);
+optional_reference_wrapper<const FormFactorData> wk1995Data(int Z, int formalCharge = 0);
 }; // namespace XRayFormFactors

--- a/src/data/formfactors.h
+++ b/src/data/formfactors.h
@@ -27,6 +27,8 @@
 #include <optional>
 #include <tuple>
 
+template <class T> using opt = std::optional<std::reference_wrapper<T>>;
+
 // X-Ray Form Factors
 namespace XRayFormFactors
 {
@@ -42,13 +44,11 @@ enum XRayFormFactorData
 EnumOptions<XRayFormFactorData> xRayFormFactorData();
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-std::optional<std::reference_wrapper<const FormFactorData>> formFactorData(XRayFormFactorData dataSet, int Z,
-									   int formalCharge = 0);
+opt<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge = 0);
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-std::optional<std::reference_wrapper<const FormFactorData>> formFactorData(XRayFormFactorData dataSet, Element *el,
-									   int formalCharge = 0);
+opt<const FormFactorData> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge = 0);
 
 // Return Waasmaier & Kirfel (1995) form factor data for given element and formal charge (if it exists)
-std::optional<std::reference_wrapper<const FormFactorData>> wk1995Data(int Z, int formalCharge = 0);
+opt<const FormFactorData> wk1995Data(int Z, int formalCharge = 0);
 }; // namespace XRayFormFactors

--- a/src/data/formfactors.h
+++ b/src/data/formfactors.h
@@ -24,9 +24,8 @@
 #include "base/enumoptions.h"
 #include "data/elements.h"
 #include "data/formfactordata.h"
+#include <optional>
 #include <tuple>
-
-template <class T> using optional = std::tuple<T, bool>;
 
 // X-Ray Form Factors
 namespace XRayFormFactors
@@ -43,11 +42,13 @@ enum XRayFormFactorData
 EnumOptions<XRayFormFactorData> xRayFormFactorData();
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-optional<const FormFactorData &> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge = 0);
+std::optional<std::reference_wrapper<const FormFactorData>> formFactorData(XRayFormFactorData dataSet, int Z,
+									   int formalCharge = 0);
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-optional<const FormFactorData &> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge = 0);
+std::optional<std::reference_wrapper<const FormFactorData>> formFactorData(XRayFormFactorData dataSet, Element *el,
+									   int formalCharge = 0);
 
 // Return Waasmaier & Kirfel (1995) form factor data for given element and formal charge (if it exists)
-optional<const FormFactorData &> wk1995Data(int Z, int formalCharge = 0);
+std::optional<std::reference_wrapper<const FormFactorData>> wk1995Data(int Z, int formalCharge = 0);
 }; // namespace XRayFormFactors

--- a/src/data/formfactors_wk1995.cpp
+++ b/src/data/formfactors_wk1995.cpp
@@ -66,7 +66,7 @@ namespace XRayFormFactors
 {
 
 // Return Waasmaier & Kirfel (1995) form factor data for given element and formal charge (if it exists)
-optional<const FormFactorData &> wk1995Data(int Z, int formalCharge)
+std::optional<std::reference_wrapper<const FormFactorData>> wk1995Data(int Z, int formalCharge)
 {
     /*
      * New Analytical Scattering Factor Functions for Free Atoms and Ions
@@ -1149,7 +1149,9 @@ optional<const FormFactorData &> wk1995Data(int Z, int formalCharge)
     auto it = std::find_if(wk1995.cbegin(), wk1995.cend(), [&](const FormFactorData_WK1995 &data) {
         return data.Z() == Z && data.formalCharge() == formalCharge;
     });
-    return std::make_tuple(std::ref(*it), it == wk1995.end());
+    if (it == wk1995.end())
+        return {};
+    return *it;
 }
 
 } // namespace XRayFormFactors

--- a/src/expression/expression.cpp
+++ b/src/expression/expression.cpp
@@ -58,8 +58,7 @@ void Expression::clear()
     statements_.clear();
 
     // Clear variables and constants, except those that are in the persistent nodes list
-    std::remove_if(variables_.begin(), variables_.end(),
-                   [&](const ExpressionNode *x) { return !persistentNodes_.contains(x); });
+    std::remove_if(variables_.begin(), variables_.end(), [&](const auto *x) { return !persistentNodes_.contains(x); });
 
     for (auto varRef : variables_)
     {

--- a/src/genericitems/streampos.h
+++ b/src/genericitems/streampos.h
@@ -25,21 +25,21 @@
 #include <ios>
 
 // GenericItemContainer<streampos>
-template <> class GenericItemContainer<streampos> : public GenericItem
+template <> class GenericItemContainer<std::streampos> : public GenericItem
 {
     public:
-    GenericItemContainer<streampos>(const char *name, int flags = 0) : GenericItem(name, flags) {}
+    GenericItemContainer<std::streampos>(const char *name, int flags = 0) : GenericItem(name, flags) {}
 
     /*
      * Data
      */
     private:
     // Data item
-    streampos data_;
+    std::streampos data_;
 
     public:
     // Return data item
-    streampos &data() { return data_; }
+    std::streampos &data() { return data_; }
 
     /*
      * Item Class
@@ -49,7 +49,7 @@ template <> class GenericItemContainer<streampos> : public GenericItem
     GenericItem *createItem(const char *className, const char *name, int flags = 0)
     {
         if (DissolveSys::sameString(className, itemClassName()))
-            return new GenericItemContainer<streampos>(name, flags);
+            return new GenericItemContainer<std::streampos>(name, flags);
         return NULL;
     }
 
@@ -84,7 +84,7 @@ template <> class GenericItemContainer<streampos> : public GenericItem
     {
         long int pos = (long int)data_;
         return procPool.broadcast(pos, root);
-        data_ = (streampos)pos;
+        data_ = (std::streampos)pos;
     }
     // Check item equality
     bool equality(ProcessPool &procPool) { return procPool.equality((long int)data_); }

--- a/src/gui/keywordwidgets/atomtypeselection_funcs.cpp
+++ b/src/gui/keywordwidgets/atomtypeselection_funcs.cpp
@@ -139,12 +139,11 @@ void AtomTypeSelectionKeywordWidget::updateSummaryText()
         setSummaryText("<None>");
     else
     {
-        CharString summaryText =
-            std::accumulate(std::next(selection.begin()), selection.end(), CharString(selection.first().atomTypeName()),
-                            [](CharString &acc, const AtomTypeData &atd) {
-                                acc.strcatf(", %s", atd.atomTypeName());
-                                return acc;
-                            });
+        CharString summaryText = std::accumulate(std::next(selection.begin()), selection.end(),
+                                                 CharString(selection.first().atomTypeName()), [](auto &acc, const auto &atd) {
+                                                     acc.strcatf(", %s", atd.atomTypeName());
+                                                     return acc;
+                                                 });
         setSummaryText(summaryText);
     }
 }

--- a/src/gui/keywordwidgets/isotopologuecollection_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologuecollection_funcs.cpp
@@ -168,7 +168,11 @@ void IsotopologueCollectionKeywordWidget::addButton_clicked(bool checked)
         auto data = set->getIsotopologues(sp);
 
         // TODO Raise exception if isotopologue set not found
-        auto &topes = std::get<0>(data);
+        if (!data)
+        {
+            Messenger::error("IsotopologueSet does not contain Species.\n");
+        }
+        auto &topes = *data;
 
         // Natural first
         if (!topes.contains(sp->naturalIsotopologue()))

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -120,7 +120,7 @@ void Dissolve::registerGenericItems()
     GenericItem::addItemClass(new GenericItemContainer<int>("int"));
     GenericItem::addItemClass(new GenericItemContainer<double>("double"));
     GenericItem::addItemClass(new GenericItemContainer<CharString>("CharString"));
-    GenericItem::addItemClass(new GenericItemContainer<streampos>("StreamPos"));
+    GenericItem::addItemClass(new GenericItemContainer<std::streampos>("StreamPos"));
 
     GenericItem::addItemClass(new GenericItemContainer<Vec3<int>>("Vec3<int>"));
     GenericItem::addItemClass(new GenericItemContainer<Vec3<double>>("Vec3<double>"));

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -79,7 +79,7 @@ bool Dissolve::prepare()
         if (pairPotentialsIncludeCoulomb_)
         {
             auto &types = cfg->usedAtomTypesList();
-            totalQ = std::accumulate(types.begin(), types.end(), totalQ, [](double acc, const AtomTypeData &atd) {
+            totalQ = std::accumulate(types.begin(), types.end(), totalQ, [](auto acc, const auto &atd) {
                 return acc + atd.population() * atd.atomType().parameters().charge();
             });
         }

--- a/src/math/praxis.h
+++ b/src/math/praxis.h
@@ -407,7 +407,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
 
             y = fabs(q[i - 1]) + fabs(e[i - 1]);
 
-            x = max(x, y);
+            x = std::max(x, y);
         }
         //
         //  Accumulation of right-hand transformations.
@@ -781,8 +781,8 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
             t2 = s;
         }
 
-        t2 = max(t2, small);
-        t2 = min(t2, 0.01 * h);
+        t2 = std::max(t2, small);
+        t2 = std::min(t2, 0.01 * h);
 
         if (fk && f1 <= fm)
         {
@@ -928,7 +928,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
             }
         }
 
-        d2 = max(d2, small);
+        d2 = std::max(d2, small);
 
         x1 = x2;
         fx = fm;
@@ -2058,7 +2058,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
         t2 = t;
         dmin = small;
         h = h0;
-        h = max(h, 100.0 * t);
+        h = std::max(h, 100.0 * t);
         ldt = h;
         //
         //  The initial set of search directions V is the identity matrix.
@@ -2290,7 +2290,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
                 }
 
                 ldt = ldfac * ldt;
-                ldt = max(ldt, lds);
+                ldt = std::max(ldt, lds);
 
                 if (0 < prin)
                 {
@@ -2367,7 +2367,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
                         s = s + v[i + j * nAlpha] * v[i + j * nAlpha];
                     }
                     s = sqrt(s);
-                    z[i] = max(m4, s);
+                    z[i] = std::max(m4, s);
                 }
 
                 s = r8vec_min(nAlpha, z);
@@ -2456,7 +2456,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
             //
             //  Determine the smallest eigenvalue.
             //
-            dmin = max(d[nAlpha - 1], small);
+            dmin = std::max(d[nAlpha - 1], small);
             //
             //  The ratio of the smallest to largest eigenvalue determines whether
             //  the system is ill conditioned.

--- a/src/math/svd.cpp
+++ b/src/math/svd.cpp
@@ -137,7 +137,7 @@ bool SVD::decompose(const Array2D<double> &A, Array2D<double> &U, Array2D<double
                     U.at(i, k) *= scale;
             }
         }
-        anorm = max(anorm, (fabs(S.constAt(i, i)) + fabs(rv1[i])));
+        anorm = std::max(anorm, (fabs(S.constAt(i, i)) + fabs(rv1[i])));
     }
 
     // Accumulate right-hand transformation

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -240,9 +240,9 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
             // Determine overlapping Q range between the two datasets
             double FQMin = qMin, FQMax = qMax;
             if ((FQMin < differenceData.xAxis().firstValue()) || (FQMin < calcSQTotal.xAxis().firstValue()))
-                FQMin = max(differenceData.xAxis().firstValue(), calcSQTotal.xAxis().firstValue());
+                FQMin = std::max(differenceData.xAxis().firstValue(), calcSQTotal.xAxis().firstValue());
             if ((FQMax > differenceData.xAxis().lastValue()) || (FQMax > calcSQTotal.xAxis().lastValue()))
-                FQMax = min(differenceData.xAxis().lastValue(), calcSQTotal.xAxis().lastValue());
+                FQMax = std::min(differenceData.xAxis().lastValue(), calcSQTotal.xAxis().lastValue());
 
             // Trim both datasets to the common range
             Filters::trim(calcSQTotal, FQMin, FQMax, true);
@@ -344,9 +344,9 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // Determine allowable range for fit, based on requested values and limits of generated / simulated datasets.
         double deltaSQMin = qMin, deltaSQMax = (qMax < 0.0 ? x1.lastValue() : qMax);
         if ((deltaSQMin < x1.firstValue()) || (deltaSQMin < simulatedFQ.xAxis().firstValue()))
-            deltaSQMin = max(x1.firstValue(), simulatedFQ.xAxis().firstValue());
+            deltaSQMin = std::max(x1.firstValue(), simulatedFQ.xAxis().firstValue());
         if ((deltaSQMax > x1.lastValue()) || (deltaSQMax > simulatedFQ.xAxis().lastValue()))
-            deltaSQMax = min(x1.lastValue(), simulatedFQ.xAxis().lastValue());
+            deltaSQMax = std::min(x1.lastValue(), simulatedFQ.xAxis().lastValue());
 
         double x;
         for (int n = 0; n < x1.nItems(); ++n)

--- a/src/modules/import/process.cpp
+++ b/src/modules/import/process.cpp
@@ -67,8 +67,8 @@ bool ImportModule::process(Dissolve &dissolve, ProcessPool &procPool)
             if (dissolve.processingModuleData().contains(streamPosName, uniqueName()))
             {
                 // Retrieve the streampos and go to it in the file
-                streampos trajPos =
-                    GenericListHelper<streampos>::retrieve(dissolve.processingModuleData(), streamPosName, uniqueName());
+                std::streampos trajPos =
+                    GenericListHelper<std::streampos>::retrieve(dissolve.processingModuleData(), streamPosName, uniqueName());
                 parser.seekg(trajPos);
             }
 
@@ -87,8 +87,8 @@ bool ImportModule::process(Dissolve &dissolve, ProcessPool &procPool)
             }
 
             // Set the trajectory file position in the restart file
-            GenericListHelper<streampos>::realise(dissolve.processingModuleData(), streamPosName, uniqueName(),
-                                                  GenericItem::InRestartFileFlag) = parser.tellg();
+            GenericListHelper<std::streampos>::realise(dissolve.processingModuleData(), streamPosName, uniqueName(),
+                                                       GenericItem::InRestartFileFlag) = parser.tellg();
         }
     }
 

--- a/src/modules/neutronsq/functions.cpp
+++ b/src/modules/neutronsq/functions.cpp
@@ -116,7 +116,7 @@ bool NeutronSQModule::calculateSummedWeights(NeutronWeights &summedWeights) cons
 
             // Use the natural isotopologue if a species in the Configuration is not covered by at least one
             // explicit Isotopologue definition
-            if (std::get<1>(data))
+            if (!data)
             {
                 Messenger::print("Isotopologue specification for Species '%s' in Configuration '%s' is "
                                  "missing, so the natural isotopologue will be used.\n",
@@ -127,7 +127,7 @@ bool NeutronSQModule::calculateSummedWeights(NeutronWeights &summedWeights) cons
             }
             else
             {
-                const auto &topes = std::get<0>(data);
+                const Isotopologues &topes = *data;
 
                 // Add defined isotopologues, in the relative isotopic proportions defined, to the weights.
                 for (auto isoWeight : topes.constMix())

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -378,14 +378,14 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (isotopologues_.contains(cfg))
         {
             // Get the set...
-            optional<IsotopologueSet> topeSet = isotopologues_.getIsotopologueSet(cfg);
-            if (std::get<1>(topeSet))
+            auto topeSet = isotopologues_.getIsotopologueSet(cfg);
+            if (!topeSet)
             {
                 return Messenger::error("Could not locate IsotopologueSet");
             }
 
             // Iterate over Species present in the set
-            for (Isotopologues &topes : std::get<0>(topeSet).isotopologues())
+            for (auto &topes : (*topeSet).constIsotopologues())
             {
                 // Find the referenced Species in our SpeciesInfo list
                 SpeciesInfo *spInfo = cfg->usedSpeciesInfo(topes.species());
@@ -394,7 +394,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
                                             topes.species()->name(), cfg->niceName());
 
                 // Add defined isotopologues, in the relative isotopic proportions defined, to the weights.
-                for (IsotopologueWeight &isoWeight : topes.mix())
+                for (const auto &isoWeight : topes.constMix())
                     weights.addIsotopologue(spInfo->species(), spInfo->population(), isoWeight.isotopologue(),
                                             isoWeight.weight());
             }

--- a/src/modules/refine/process.cpp
+++ b/src/modules/refine/process.cpp
@@ -461,9 +461,9 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 // simulated datasets
                 double deltaSQMin = qMin, deltaSQMax = (qMax < 0.0 ? x1.lastValue() : qMax);
                 if ((deltaSQMin < x1.firstValue()) || (deltaSQMin < simulatedSQ.xAxis().firstValue()))
-                    deltaSQMin = max(x1.firstValue(), simulatedSQ.xAxis().firstValue());
+                    deltaSQMin = std::max(x1.firstValue(), simulatedSQ.xAxis().firstValue());
                 if ((deltaSQMax > x1.lastValue()) || (deltaSQMax > simulatedSQ.xAxis().lastValue()))
-                    deltaSQMax = min(x1.lastValue(), simulatedSQ.xAxis().lastValue());
+                    deltaSQMax = std::min(x1.lastValue(), simulatedSQ.xAxis().lastValue());
 
                 Data1D refSQTrimmed;
                 double x;

--- a/src/templates/array.h
+++ b/src/templates/array.h
@@ -26,8 +26,6 @@
 #include "templates/vector3.h"
 #include <new>
 
-using namespace std;
-
 // Array
 template <class A> class Array : public ListItem<Array<A>>
 {
@@ -113,7 +111,7 @@ template <class A> class Array : public ListItem<Array<A>>
         {
             array_ = new A[size_];
         }
-        catch (bad_alloc &alloc)
+        catch (std::bad_alloc &alloc)
         {
             Messenger::error("Array<T>() - Failed to allocate sufficient memory for array_. Exception was : %s\n",
                              alloc.what());

--- a/src/templates/dynamicarray.h
+++ b/src/templates/dynamicarray.h
@@ -26,8 +26,6 @@
 #include <new>
 #include <stdint.h>
 
-using namespace std;
-
 // Array Chunk
 template <class T> class ArrayChunk : public ListItem<ArrayChunk<T>>
 {
@@ -91,7 +89,7 @@ template <class T> class ArrayChunk : public ListItem<ArrayChunk<T>>
         {
             objectArray_ = new T[nObjects_];
         }
-        catch (bad_alloc &alloc)
+        catch (std::bad_alloc &alloc)
         {
             Messenger::error("ArrayChunk<T>() - Failed to allocate sufficient memory for objectArray_. Exception was : %s\n",
                              alloc.what());
@@ -103,7 +101,7 @@ template <class T> class ArrayChunk : public ListItem<ArrayChunk<T>>
         {
             objectUsed_ = new bool[nObjects_];
         }
-        catch (bad_alloc &alloc)
+        catch (std::bad_alloc &alloc)
         {
             Messenger::error("ArrayChunk<T>() - Failed to allocate sufficient memory for objectUsed_. Exception was : %s\n",
                              alloc.what());


### PR DESCRIPTION
This moves us to C++17.  Besides the basic build switch, I've also gone through and moved us onto the official std::optional (which turned out to be a mandatory move) and also switch lambda function params to auto where possible.