### PR TITLE
Move to mutable CoreData in read and parse

### DIFF
--- a/src/classes/atomtypelist.cpp
+++ b/src/classes/atomtypelist.cpp
@@ -300,7 +300,7 @@ void AtomTypeList::print() const
 const char *AtomTypeList::itemClassName() { return "AtomTypeList"; }
 
 // Read data through specified LineParser
-bool AtomTypeList::read(LineParser &parser, const CoreData &coreData)
+bool AtomTypeList::read(LineParser &parser, CoreData &coreData)
 {
     types_.clear();
 

--- a/src/classes/atomtypelist.h
+++ b/src/classes/atomtypelist.h
@@ -101,7 +101,7 @@ class AtomTypeList : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/classes/braggreflection.cpp
+++ b/src/classes/braggreflection.cpp
@@ -136,7 +136,7 @@ int BraggReflection::nKVectors() const { return nKVectors_; }
 const char *BraggReflection::itemClassName() { return "BraggReflection"; }
 
 // Read data through specified parser
-bool BraggReflection::read(LineParser &parser, const CoreData &coreData)
+bool BraggReflection::read(LineParser &parser, CoreData &coreData)
 {
     // Read index, Q centre, and number of contributing K-vectors
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)

--- a/src/classes/braggreflection.h
+++ b/src/classes/braggreflection.h
@@ -91,7 +91,7 @@ class BraggReflection : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified parser
     bool write(LineParser &parser);
 

--- a/src/classes/data1dstore.cpp
+++ b/src/classes/data1dstore.cpp
@@ -33,7 +33,7 @@ Data1DStore::~Data1DStore() {}
 
 // Add named data reference to store, reading file and format from specified parser / starting argument
 bool Data1DStore::addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword,
-                          const CoreData &coreData)
+                          CoreData &coreData)
 {
     // Create new data
     Data1D *data = data_.add();

--- a/src/classes/data1dstore.cpp
+++ b/src/classes/data1dstore.cpp
@@ -32,8 +32,7 @@ Data1DStore::~Data1DStore() {}
  */
 
 // Add named data reference to store, reading file and format from specified parser / starting argument
-bool Data1DStore::addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword,
-                          CoreData &coreData)
+bool Data1DStore::addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword, CoreData &coreData)
 {
     // Create new data
     Data1D *data = data_.add();

--- a/src/classes/data1dstore.h
+++ b/src/classes/data1dstore.h
@@ -47,7 +47,7 @@ class Data1DStore
 
     public:
     // Add named data reference to store, reading file and format from specified parser / starting argument
-    bool addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword, const CoreData &coreData);
+    bool addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword, CoreData &coreData);
     // Check to see if the named data is present in the store
     bool containsData(const char *name) const;
     // Return named data

--- a/src/classes/data2dstore.cpp
+++ b/src/classes/data2dstore.cpp
@@ -32,8 +32,7 @@ Data2DStore::~Data2DStore() {}
  */
 
 // Add named data reference to store, reading file and format from specified parser / starting argument
-bool Data2DStore::addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword,
-                          CoreData &coreData)
+bool Data2DStore::addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword, CoreData &coreData)
 {
     // Create new data
     Data2D *data = data_.add();

--- a/src/classes/data2dstore.cpp
+++ b/src/classes/data2dstore.cpp
@@ -33,7 +33,7 @@ Data2DStore::~Data2DStore() {}
 
 // Add named data reference to store, reading file and format from specified parser / starting argument
 bool Data2DStore::addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword,
-                          const CoreData &coreData)
+                          CoreData &coreData)
 {
     // Create new data
     Data2D *data = data_.add();

--- a/src/classes/data2dstore.h
+++ b/src/classes/data2dstore.h
@@ -47,7 +47,7 @@ class Data2DStore
 
     public:
     // Add named data reference to store, reading file and format from specified parser / starting argument
-    bool addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword, const CoreData &coreData);
+    bool addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword, CoreData &coreData);
     // Check to see if the named data is present in the store
     bool containsData(const char *name) const;
     // Return named data

--- a/src/classes/data3dstore.cpp
+++ b/src/classes/data3dstore.cpp
@@ -33,7 +33,7 @@ Data3DStore::~Data3DStore() {}
 
 // Add named data reference to store, reading file and format from specified parser / starting argument
 bool Data3DStore::addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword,
-                          const CoreData &coreData)
+                          CoreData &coreData)
 {
     // Create new data
     Data3D *data = data_.add();

--- a/src/classes/data3dstore.cpp
+++ b/src/classes/data3dstore.cpp
@@ -32,8 +32,7 @@ Data3DStore::~Data3DStore() {}
  */
 
 // Add named data reference to store, reading file and format from specified parser / starting argument
-bool Data3DStore::addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword,
-                          CoreData &coreData)
+bool Data3DStore::addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword, CoreData &coreData)
 {
     // Create new data
     Data3D *data = data_.add();

--- a/src/classes/data3dstore.h
+++ b/src/classes/data3dstore.h
@@ -47,7 +47,7 @@ class Data3DStore
 
     public:
     // Add named data reference to store, reading file and format from specified parser / starting argument
-    bool addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword, const CoreData &coreData);
+    bool addData(const char *dataName, LineParser &parser, int startArg, const char *endKeyword, CoreData &coreData);
     // Check to see if the named data is present in the store
     bool containsData(const char *name) const;
     // Return named data

--- a/src/classes/isotopedata.cpp
+++ b/src/classes/isotopedata.cpp
@@ -95,7 +95,7 @@ bool IsotopeData::write(LineParser &parser)
 }
 
 // Read data through specified LineParser
-bool IsotopeData::read(LineParser &parser, const CoreData &coreData)
+bool IsotopeData::read(LineParser &parser, CoreData &coreData)
 {
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;

--- a/src/classes/isotopedata.h
+++ b/src/classes/isotopedata.h
@@ -73,7 +73,7 @@ class IsotopeData : public ListItem<IsotopeData>
     // Write data through specified LineParser
     bool write(LineParser &parser);
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
 
     /*
      * Parallel Comms

--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -196,7 +196,7 @@ void IsotopologueCollection::complete(const RefList<Configuration> &configuratio
 const char *IsotopologueCollection::itemClassName() { return "IsotopologueCollection"; }
 
 // Read data through specified LineParser
-bool IsotopologueCollection::read(LineParser &parser, const CoreData &coreData)
+bool IsotopologueCollection::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/classes/isotopologuecollection.h
+++ b/src/classes/isotopologuecollection.h
@@ -89,7 +89,7 @@ class IsotopologueCollection : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 };

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -193,7 +193,7 @@ void Isotopologues::normalise()
 const char *Isotopologues::itemClassName() { return "Isotopologues"; }
 
 // Read data through specified LineParser
-bool Isotopologues::read(LineParser &parser, const CoreData &coreData)
+bool Isotopologues::read(LineParser &parser, CoreData &coreData)
 {
     // Read Species name
     if (parser.getArgsDelim() != LineParser::Success)

--- a/src/classes/isotopologues.h
+++ b/src/classes/isotopologues.h
@@ -88,7 +88,7 @@ class Isotopologues : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -150,7 +150,7 @@ const std::vector<Isotopologues> &IsotopologueSet::constIsotopologues() const { 
 const char *IsotopologueSet::itemClassName() { return "IsotopologueSet"; }
 
 // Read data through specified LineParser
-bool IsotopologueSet::read(LineParser &parser, const CoreData &coreData)
+bool IsotopologueSet::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/classes/isotopologueset.h
+++ b/src/classes/isotopologueset.h
@@ -96,7 +96,7 @@ class IsotopologueSet : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 };

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -352,7 +352,7 @@ bool NeutronWeights::isValid() const { return valid_; }
 const char *NeutronWeights::itemClassName() { return "NeutronWeights"; }
 
 // Read data through specified LineParser
-bool NeutronWeights::read(LineParser &parser, const CoreData &coreData)
+bool NeutronWeights::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/classes/neutronweights.h
+++ b/src/classes/neutronweights.h
@@ -116,7 +116,7 @@ class NeutronWeights : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/classes/partialset.cpp
+++ b/src/classes/partialset.cpp
@@ -559,7 +559,7 @@ void PartialSet::operator*=(const double factor)
 const char *PartialSet::itemClassName() { return "PartialSet"; }
 
 // Read data through specified LineParser
-bool PartialSet::read(LineParser &parser, const CoreData &coreData)
+bool PartialSet::read(LineParser &parser, CoreData &coreData)
 {
     if (parser.readNextLine(LineParser::Defaults, objectNamePrefix_) != LineParser::Success)
         return false;

--- a/src/classes/partialset.h
+++ b/src/classes/partialset.h
@@ -166,7 +166,7 @@ class PartialSet : public ListItem<PartialSet>, public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -267,7 +267,7 @@ bool XRayWeights::isValid() const { return valid_; }
 const char *XRayWeights::itemClassName() { return "XRayWeights"; }
 
 // Read data through specified LineParser
-bool XRayWeights::read(LineParser &parser, const CoreData &coreData)
+bool XRayWeights::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/classes/xrayweights.h
+++ b/src/classes/xrayweights.h
@@ -116,7 +116,7 @@ class XRayWeights : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/genericitems/array.h
+++ b/src/genericitems/array.h
@@ -78,7 +78,7 @@ template <class T> class GenericItemContainer<Array<T>> : public GenericItem
         return true;
     }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;

--- a/src/genericitems/array2d.h
+++ b/src/genericitems/array2d.h
@@ -74,7 +74,7 @@ template <class T> class GenericItemContainer<Array2D<T>> : public GenericItem
         return true;
     }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;

--- a/src/genericitems/array2darraydouble.h
+++ b/src/genericitems/array2darraydouble.h
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<Array2D<Array<double>>> : public GenericI
     // Write data through specified parser
     bool write(LineParser &parser) { return write(data_, parser); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData) { return read(data_, parser); }
+    bool read(LineParser &parser, CoreData &coreData) { return read(data_, parser); }
     // Write specified data through specified parser
     static bool write(const Array2D<Array<double>> &thisData, LineParser &parser)
     {

--- a/src/genericitems/array2dbool.h
+++ b/src/genericitems/array2dbool.h
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<Array2D<bool>> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return write(data_, parser); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData) { return read(data_, parser); }
+    bool read(LineParser &parser, CoreData &coreData) { return read(data_, parser); }
     // Write specified data through specified parser
     static bool write(const Array2D<bool> &thisData, LineParser &parser)
     {

--- a/src/genericitems/array2ddouble.h
+++ b/src/genericitems/array2ddouble.h
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<Array2D<double>> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return write(data_, parser); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData) { return read(data_, parser); }
+    bool read(LineParser &parser, CoreData &coreData) { return read(data_, parser); }
     // Write specified data through specified parser
     static bool write(const Array2D<double> &thisData, LineParser &parser)
     {

--- a/src/genericitems/array2ddummy.h
+++ b/src/genericitems/array2ddummy.h
@@ -54,7 +54,7 @@ template <> class GenericItemContainer<Array2D<DummyClass>> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return false; }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData) { return false; }
+    bool read(LineParser &parser, CoreData &coreData) { return false; }
 
     /*
      * Parallel Comms

--- a/src/genericitems/arraydouble.h
+++ b/src/genericitems/arraydouble.h
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<Array<double>> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return write(data_, parser); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData) { return read(data_, parser); }
+    bool read(LineParser &parser, CoreData &coreData) { return read(data_, parser); }
     // Write specified data through specified parser
     static bool write(const Array<double> &thisData, LineParser &parser)
     {

--- a/src/genericitems/arraydummy.h
+++ b/src/genericitems/arraydummy.h
@@ -53,7 +53,7 @@ template <> class GenericItemContainer<Array<DummyClass>> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return false; }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData) { return false; }
+    bool read(LineParser &parser, CoreData &coreData) { return false; }
 
     /*
      * Parallel Comms

--- a/src/genericitems/arrayint.h
+++ b/src/genericitems/arrayint.h
@@ -72,7 +72,7 @@ template <> class GenericItemContainer<Array<int>> : public GenericItem
         return true;
     }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;

--- a/src/genericitems/arrayvec3double.h
+++ b/src/genericitems/arrayvec3double.h
@@ -73,7 +73,7 @@ template <> class GenericItemContainer<Array<Vec3<double>>> : public GenericItem
         return true;
     }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;

--- a/src/genericitems/arrayvec3int.h
+++ b/src/genericitems/arrayvec3int.h
@@ -73,7 +73,7 @@ template <> class GenericItemContainer<Array<Vec3<int>>> : public GenericItem
         return true;
     }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;

--- a/src/genericitems/base.cpp
+++ b/src/genericitems/base.cpp
@@ -32,7 +32,7 @@ bool GenericItemBase::write(LineParser &parser)
 }
 
 // Read data through specified parser
-bool GenericItemBase::read(LineParser &parser, const CoreData &coreData)
+bool GenericItemBase::read(LineParser &parser, CoreData &coreData)
 {
     return Messenger::error("Tried to read() a class that doesn't support it.\n");
 }

--- a/src/genericitems/base.h
+++ b/src/genericitems/base.h
@@ -42,7 +42,7 @@ class GenericItemBase
      */
     public:
     // Read data through specified parser
-    virtual bool read(LineParser &parser, const CoreData &coreData);
+    virtual bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified parser
     virtual bool write(LineParser &parser);
 

--- a/src/genericitems/bool.h
+++ b/src/genericitems/bool.h
@@ -64,7 +64,7 @@ template <> class GenericItemContainer<bool> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return parser.writeLineF("%s\n", DissolveSys::btoa(data_)); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;

--- a/src/genericitems/charstring.h
+++ b/src/genericitems/charstring.h
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<CharString> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return parser.writeLineF("%s\n", data_.get()); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.readNextLine(LineParser::Defaults) == LineParser::Success)
             return false;

--- a/src/genericitems/container.h
+++ b/src/genericitems/container.h
@@ -64,7 +64,7 @@ template <class T> class GenericItemContainer : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return data_.write(parser); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData) { return data_.read(parser, coreData); }
+    bool read(LineParser &parser, CoreData &coreData) { return data_.read(parser, coreData); }
 
     /*
      * Parallel Comms

--- a/src/genericitems/double.h
+++ b/src/genericitems/double.h
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<double> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return parser.writeLineF("%16.9e\n", data_); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;

--- a/src/genericitems/int.h
+++ b/src/genericitems/int.h
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<int> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return parser.writeLineF("%i\n", data_); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;

--- a/src/genericitems/item.h
+++ b/src/genericitems/item.h
@@ -103,7 +103,7 @@ class GenericItem : public ListItem<GenericItem>
     // Write data through specified parser
     virtual bool write(LineParser &parser) = 0;
     // Read data through specified parser
-    virtual bool read(LineParser &parser, const CoreData &coreData) = 0;
+    virtual bool read(LineParser &parser, CoreData &coreData) = 0;
 
     /*
      * Parallel Comms

--- a/src/genericitems/streampos.h
+++ b/src/genericitems/streampos.h
@@ -64,7 +64,7 @@ template <> class GenericItemContainer<streampos> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return parser.writeArg(data_); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         // NOTE Can't implicit cast streampos into the arg for readArg(), so assume long long int for now.
         long long int pos;

--- a/src/genericitems/vec3double.h
+++ b/src/genericitems/vec3double.h
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<Vec3<double>> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return parser.writeLineF("%16.9e %16.9e %16.9e\n", data_.x, data_.y, data_.z); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;

--- a/src/genericitems/vec3int.h
+++ b/src/genericitems/vec3int.h
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<Vec3<int>> : public GenericItem
     // Write data through specified parser
     bool write(LineParser &parser) { return parser.writeLineF("%i  %i  %i\n", data_.x, data_.y, data_.z); }
     // Read data through specified parser
-    bool read(LineParser &parser, const CoreData &coreData)
+    bool read(LineParser &parser, CoreData &coreData)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;

--- a/src/io/fileandformat.cpp
+++ b/src/io/fileandformat.cpp
@@ -127,7 +127,7 @@ KeywordList &FileAndFormat::keywords() { return keywords_; }
  */
 
 // Read format / filename from specified parser
-bool FileAndFormat::read(LineParser &parser, int startArg, const char *endKeyword, const CoreData &coreData)
+bool FileAndFormat::read(LineParser &parser, int startArg, const char *endKeyword, CoreData &coreData)
 {
     // Convert first argument to format type
     format_ = format(parser.argc(startArg));

--- a/src/io/fileandformat.h
+++ b/src/io/fileandformat.h
@@ -108,7 +108,7 @@ class FileAndFormat
      */
     public:
     // Read format / filename from specified parser
-    bool read(LineParser &parser, int startArg, const char *endKeyword, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const char *endKeyword, CoreData &coreData);
     // Write format / filename to specified parser
     bool writeFilenameAndFormat(LineParser &parser, const char *prefix);
     // Write options and end block

--- a/src/keywords/atomtypereflist.cpp
+++ b/src/keywords/atomtypereflist.cpp
@@ -42,7 +42,7 @@ int AtomTypeRefListKeyword::minArguments() const { return 1; }
 int AtomTypeRefListKeyword::maxArguments() const { return 999; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool AtomTypeRefListKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool AtomTypeRefListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Loop over arguments (which are AtomType names) and add them to our list
     for (int n = startArg; n < parser.nArgs(); ++n)

--- a/src/keywords/atomtypereflist.h
+++ b/src/keywords/atomtypereflist.h
@@ -44,7 +44,7 @@ class AtomTypeRefListKeyword : public KeywordData<RefList<AtomType> &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/atomtypeselection.cpp
+++ b/src/keywords/atomtypeselection.cpp
@@ -86,7 +86,7 @@ int AtomTypeSelectionKeyword::minArguments() const { return 1; }
 int AtomTypeSelectionKeyword::maxArguments() const { return 999; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool AtomTypeSelectionKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool AtomTypeSelectionKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Make sure our list is up-to-date
     checkSelection();

--- a/src/keywords/atomtypeselection.h
+++ b/src/keywords/atomtypeselection.h
@@ -59,7 +59,7 @@ class AtomTypeSelectionKeyword : public KeywordData<AtomTypeList &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -163,7 +163,7 @@ class KeywordBase : public ListItem<KeywordBase>
     // Check number of arguments provided to keyword
     bool validNArgs(int nArgsProvided) const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    virtual bool read(LineParser &parser, int startArg, const CoreData &coreData) = 0;
+    virtual bool read(LineParser &parser, int startArg, CoreData &coreData) = 0;
     // Write keyword data to specified LineParser
     virtual bool write(LineParser &parser, const char *keywordName, const char *prefix = "") = 0;
 

--- a/src/keywords/bool.cpp
+++ b/src/keywords/bool.cpp
@@ -38,7 +38,7 @@ int BoolKeyword::minArguments() const { return 1; }
 int BoolKeyword::maxArguments() const { return 1; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool BoolKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool BoolKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (parser.hasArg(startArg))
     {

--- a/src/keywords/bool.h
+++ b/src/keywords/bool.h
@@ -42,7 +42,7 @@ class BoolKeyword : public KeywordData<bool>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/broadeningfunction.cpp
+++ b/src/keywords/broadeningfunction.cpp
@@ -40,7 +40,7 @@ int BroadeningFunctionKeyword::minArguments() const { return 1; }
 int BroadeningFunctionKeyword::maxArguments() const { return MAXBROADENINGFUNCTIONPARAMS; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool BroadeningFunctionKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool BroadeningFunctionKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     bool result = data_.set(parser, startArg);
     if (result)

--- a/src/keywords/broadeningfunction.h
+++ b/src/keywords/broadeningfunction.h
@@ -43,7 +43,7 @@ class BroadeningFunctionKeyword : public KeywordData<BroadeningFunction>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/charstring.cpp
+++ b/src/keywords/charstring.cpp
@@ -38,7 +38,7 @@ int CharStringKeyword::minArguments() const { return 1; }
 int CharStringKeyword::maxArguments() const { return 1; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool CharStringKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool CharStringKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (parser.hasArg(startArg))
     {

--- a/src/keywords/charstring.h
+++ b/src/keywords/charstring.h
@@ -42,7 +42,7 @@ class CharStringKeyword : public KeywordData<CharString>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/data1dstore.cpp
+++ b/src/keywords/data1dstore.cpp
@@ -50,7 +50,7 @@ int Data1DStoreKeyword::maxArguments() const
 }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool Data1DStoreKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool Data1DStoreKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     Messenger::print("Reading test data '%s' from file '%s' (format=%s)...\n", parser.argc(startArg), parser.argc(startArg + 2),
                      parser.argc(startArg + 1));

--- a/src/keywords/data1dstore.h
+++ b/src/keywords/data1dstore.h
@@ -42,7 +42,7 @@ class Data1DStoreKeyword : public KeywordData<Data1DStore &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/data2dstore.cpp
+++ b/src/keywords/data2dstore.cpp
@@ -48,7 +48,7 @@ int Data2DStoreKeyword::maxArguments() const
 }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool Data2DStoreKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool Data2DStoreKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     Messenger::print("Reading test data '%s' from file '%s' (format=%s)...\n", parser.argc(startArg), parser.argc(startArg + 2),
                      parser.argc(startArg + 1));

--- a/src/keywords/data2dstore.h
+++ b/src/keywords/data2dstore.h
@@ -43,7 +43,7 @@ class Data2DStoreKeyword : public KeywordData<Data2DStore &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/data3dstore.cpp
+++ b/src/keywords/data3dstore.cpp
@@ -48,7 +48,7 @@ int Data3DStoreKeyword::maxArguments() const
 }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool Data3DStoreKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool Data3DStoreKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     Messenger::print("Reading test data '%s' from file '%s' (format=%s)...\n", parser.argc(startArg), parser.argc(startArg + 2),
                      parser.argc(startArg + 1));

--- a/src/keywords/data3dstore.h
+++ b/src/keywords/data3dstore.h
@@ -43,7 +43,7 @@ class Data3DStoreKeyword : public KeywordData<Data3DStore &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/double.cpp
+++ b/src/keywords/double.cpp
@@ -94,7 +94,7 @@ int DoubleKeyword::minArguments() const { return 1; }
 int DoubleKeyword::maxArguments() const { return 1; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool DoubleKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool DoubleKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (parser.hasArg(startArg))
     {

--- a/src/keywords/double.h
+++ b/src/keywords/double.h
@@ -65,7 +65,7 @@ class DoubleKeyword : public KeywordData<double>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/dynamicsitenodes.cpp
+++ b/src/keywords/dynamicsitenodes.cpp
@@ -60,7 +60,7 @@ int DynamicSiteNodesKeyword::minArguments() const { return 0; }
 int DynamicSiteNodesKeyword::maxArguments() const { return 0; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool DynamicSiteNodesKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool DynamicSiteNodesKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (!parentNode_)
         return Messenger::error("Parent ProcedureNode not set, so can't read DynamicSiteNode data.\n");

--- a/src/keywords/dynamicsitenodes.h
+++ b/src/keywords/dynamicsitenodes.h
@@ -71,7 +71,7 @@ class DynamicSiteNodesKeyword : public KeywordData<RefList<DynamicSiteProcedureN
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/elementreflist.cpp
+++ b/src/keywords/elementreflist.cpp
@@ -41,7 +41,7 @@ int ElementRefListKeyword::minArguments() const { return 1; }
 int ElementRefListKeyword::maxArguments() const { return 999; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool ElementRefListKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool ElementRefListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Loop over arguments (which are Element names) and add them to our list
     for (int n = startArg; n < parser.nArgs(); ++n)

--- a/src/keywords/elementreflist.h
+++ b/src/keywords/elementreflist.h
@@ -44,7 +44,7 @@ class ElementRefListKeyword : public KeywordData<RefList<Element> &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/enumoptions.h
+++ b/src/keywords/enumoptions.h
@@ -96,7 +96,7 @@ template <class E> class EnumOptionsKeyword : public EnumOptionsBaseKeyword, pub
     // Return maximum number of arguments accepted
     int maxArguments() const { return 1; }
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData)
+    bool read(LineParser &parser, int startArg, CoreData &coreData)
     {
         if (parser.hasArg(startArg))
         {

--- a/src/keywords/expression.cpp
+++ b/src/keywords/expression.cpp
@@ -41,7 +41,7 @@ int ExpressionKeyword::minArguments() const { return 1; }
 int ExpressionKeyword::maxArguments() const { return 1; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool ExpressionKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool ExpressionKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     return setValue(parser.argc(startArg));
 }

--- a/src/keywords/expression.cpp
+++ b/src/keywords/expression.cpp
@@ -41,10 +41,7 @@ int ExpressionKeyword::minArguments() const { return 1; }
 int ExpressionKeyword::maxArguments() const { return 1; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool ExpressionKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
-{
-    return setValue(parser.argc(startArg));
-}
+bool ExpressionKeyword::read(LineParser &parser, int startArg, CoreData &coreData) { return setValue(parser.argc(startArg)); }
 
 // Write keyword data to specified LineParser
 bool ExpressionKeyword::write(LineParser &parser, const char *keywordName, const char *prefix)

--- a/src/keywords/expression.h
+++ b/src/keywords/expression.h
@@ -43,7 +43,7 @@ class ExpressionKeyword : public KeywordData<Expression &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/expressionvariablelist.cpp
+++ b/src/keywords/expressionvariablelist.cpp
@@ -67,7 +67,7 @@ int ExpressionVariableListKeyword::minArguments() const { return 2; }
 int ExpressionVariableListKeyword::maxArguments() const { return 2; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool ExpressionVariableListKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool ExpressionVariableListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (!parentNode_)
         return Messenger::error("Parent ProcedureNode not set, so can't read ExpressionVariableList data.\n");

--- a/src/keywords/expressionvariablelist.h
+++ b/src/keywords/expressionvariablelist.h
@@ -74,7 +74,7 @@ class ExpressionVariableListKeyword : public KeywordData<List<ExpressionNode> &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/fileandformat.cpp
+++ b/src/keywords/fileandformat.cpp
@@ -57,7 +57,7 @@ int FileAndFormatKeyword::maxArguments() const
 }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool FileAndFormatKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool FileAndFormatKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (!data_.read(parser, startArg, endKeyword_, coreData))
         return Messenger::error("Failed to read file/format.\n");

--- a/src/keywords/fileandformat.h
+++ b/src/keywords/fileandformat.h
@@ -56,7 +56,7 @@ class FileAndFormatKeyword : public KeywordData<FileAndFormat &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/geometrylist.cpp
+++ b/src/keywords/geometrylist.cpp
@@ -53,7 +53,7 @@ int GeometryListKeyword::maxArguments() const
 }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool GeometryListKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool GeometryListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     Geometry *g = data_.add();
     for (int i = startArg; i <= (startArg + maxArguments() - 1); i++)

--- a/src/keywords/geometrylist.h
+++ b/src/keywords/geometrylist.h
@@ -52,7 +52,7 @@ class GeometryListKeyword : public KeywordData<List<Geometry> &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/integer.cpp
+++ b/src/keywords/integer.cpp
@@ -93,7 +93,7 @@ int IntegerKeyword::minArguments() const { return 1; }
 int IntegerKeyword::maxArguments() const { return 1; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool IntegerKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool IntegerKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (parser.hasArg(startArg))
     {

--- a/src/keywords/integer.h
+++ b/src/keywords/integer.h
@@ -65,7 +65,7 @@ class IntegerKeyword : public KeywordData<int>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/isotopologuecollection.cpp
+++ b/src/keywords/isotopologuecollection.cpp
@@ -52,7 +52,7 @@ int IsotopologueCollectionKeyword::minArguments() const { return 4; }
 int IsotopologueCollectionKeyword::maxArguments() const { return 4; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool IsotopologueCollectionKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool IsotopologueCollectionKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Find target Configuration (first argument)
     Configuration *cfg = coreData.findConfiguration(parser.argc(startArg));

--- a/src/keywords/isotopologuecollection.h
+++ b/src/keywords/isotopologuecollection.h
@@ -56,7 +56,7 @@ class IsotopologueCollectionKeyword : public KeywordData<IsotopologueCollection 
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/linkto.cpp
+++ b/src/keywords/linkto.cpp
@@ -53,7 +53,7 @@ int LinkToKeyword::maxArguments() const
 }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool LinkToKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool LinkToKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     Messenger::warn("Don't call LinkToKeyword::read() - go through base().\n");
     return data_->read(parser, startArg, coreData);

--- a/src/keywords/linkto.h
+++ b/src/keywords/linkto.h
@@ -49,7 +49,7 @@ class LinkToKeyword : public KeywordData<KeywordBase *>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/list.cpp
+++ b/src/keywords/list.cpp
@@ -245,7 +245,7 @@ void KeywordList::hasBeenSet(const char *name)
  */
 
 // Try to parse node keyword in specified LineParser
-KeywordBase::ParseResult KeywordList::parse(LineParser &parser, const CoreData &coreData)
+KeywordBase::ParseResult KeywordList::parse(LineParser &parser, CoreData &coreData)
 {
     // Do we recognise the first item (the 'keyword')?
     KeywordBase *keyword = find(parser.argc(0));

--- a/src/keywords/list.h
+++ b/src/keywords/list.h
@@ -217,7 +217,7 @@ class KeywordList
      */
     public:
     // Try to parse keyword in specified LineParser
-    KeywordBase::ParseResult parse(LineParser &parser, const CoreData &coreData);
+    KeywordBase::ParseResult parse(LineParser &parser, CoreData &coreData);
     // Write all keywords to specified LineParser
     bool write(LineParser &parser, const char *prefix, bool onlyIfSet = true);
     // Write all keywords in groups to specified LineParser

--- a/src/keywords/module.h
+++ b/src/keywords/module.h
@@ -79,7 +79,7 @@ template <class M> class ModuleKeyword : public ModuleKeywordBase, public Keywor
     // Return maximum number of arguments accepted
     int maxArguments() const { return 1; }
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData)
+    bool read(LineParser &parser, int startArg, CoreData &coreData)
     {
         Module *module = coreData.findModule(parser.argc(startArg));
         if (!module)

--- a/src/keywords/modulegroups.cpp
+++ b/src/keywords/modulegroups.cpp
@@ -49,7 +49,7 @@ int ModuleGroupsKeyword::maxArguments() const
 }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool ModuleGroupsKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool ModuleGroupsKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Find specified Module by its unique name
     Module *module = coreData.findModule(parser.argc(startArg));

--- a/src/keywords/modulegroups.h
+++ b/src/keywords/modulegroups.h
@@ -44,7 +44,7 @@ class ModuleGroupsKeyword : public KeywordData<ModuleGroups &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/modulereflist.cpp
+++ b/src/keywords/modulereflist.cpp
@@ -64,7 +64,7 @@ int ModuleRefListKeyword::minArguments() const { return 1; }
 int ModuleRefListKeyword::maxArguments() const { return (maxModules_ == -1 ? 99 : maxModules_); }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool ModuleRefListKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool ModuleRefListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Loop over arguments provided to the keyword
     for (int n = startArg; n < parser.nArgs(); ++n)

--- a/src/keywords/modulereflist.h
+++ b/src/keywords/modulereflist.h
@@ -64,7 +64,7 @@ class ModuleRefListKeyword : public KeywordData<RefList<Module> &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/node.h
+++ b/src/keywords/node.h
@@ -93,7 +93,7 @@ template <class N> class NodeKeyword : public NodeKeywordBase, public KeywordDat
     // Return maximum number of arguments accepted
     int maxArguments() const { return 1; }
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData)
+    bool read(LineParser &parser, int startArg, CoreData &coreData)
     {
         if (!parentNode())
             return Messenger::error("Can't read keyword %s since the parent ProcedureNode has not been set.\n",

--- a/src/keywords/nodeandinteger.h
+++ b/src/keywords/nodeandinteger.h
@@ -113,7 +113,7 @@ template <class N> class NodeAndIntegerKeyword : public NodeAndIntegerKeywordBas
     // Return maximum number of arguments accepted
     int maxArguments() const { return 1; }
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData)
+    bool read(LineParser &parser, int startArg, CoreData &coreData)
     {
         if (!parentNode())
             return Messenger::error("Can't read keyword %s since the parent ProcedureNode has not been set.\n",

--- a/src/keywords/nodearray.h
+++ b/src/keywords/nodearray.h
@@ -121,7 +121,7 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
     // Return maximum number of arguments accepted
     int maxArguments() const { return NodeArrayKeywordBase::isVariableSize() ? 99 : NodeArrayKeywordBase::fixedArraySize(); }
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData)
+    bool read(LineParser &parser, int startArg, CoreData &coreData)
     {
         if (!parentNode())
             return Messenger::error("Can't read keyword %s since the parent ProcedureNode has not been set.\n",

--- a/src/keywords/nodebranch.cpp
+++ b/src/keywords/nodebranch.cpp
@@ -52,7 +52,7 @@ int NodeBranchKeyword::minArguments() const { return 0; }
 int NodeBranchKeyword::maxArguments() const { return 0; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool NodeBranchKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool NodeBranchKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Check that a branch hasn't already been defined
     if (*data_)

--- a/src/keywords/nodebranch.h
+++ b/src/keywords/nodebranch.h
@@ -66,7 +66,7 @@ class NodeBranchKeyword : public KeywordData<SequenceProcedureNode **>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/nodereflist.h
+++ b/src/keywords/nodereflist.h
@@ -91,7 +91,7 @@ template <class N> class NodeRefListKeyword : public NodeRefListKeywordBase, pub
     // Return maximum number of arguments accepted
     int maxArguments() const { return 99; }
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData)
+    bool read(LineParser &parser, int startArg, CoreData &coreData)
     {
         if (!parentNode())
             return Messenger::error("Can't read keyword %s since the parent ProcedureNode has not been set.\n",

--- a/src/keywords/nodevalue.cpp
+++ b/src/keywords/nodevalue.cpp
@@ -42,7 +42,7 @@ int NodeValueKeyword::minArguments() const { return 1; }
 int NodeValueKeyword::maxArguments() const { return 1; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool NodeValueKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool NodeValueKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     return setValue(parser.argc(startArg));
 }

--- a/src/keywords/nodevalue.cpp
+++ b/src/keywords/nodevalue.cpp
@@ -42,10 +42,7 @@ int NodeValueKeyword::minArguments() const { return 1; }
 int NodeValueKeyword::maxArguments() const { return 1; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool NodeValueKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
-{
-    return setValue(parser.argc(startArg));
-}
+bool NodeValueKeyword::read(LineParser &parser, int startArg, CoreData &coreData) { return setValue(parser.argc(startArg)); }
 
 // Write keyword data to specified LineParser
 bool NodeValueKeyword::write(LineParser &parser, const char *keywordName, const char *prefix)

--- a/src/keywords/nodevalue.h
+++ b/src/keywords/nodevalue.h
@@ -51,7 +51,7 @@ class NodeValueKeyword : public KeywordData<NodeValue>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/nodevalueenumoptions.h
+++ b/src/keywords/nodevalueenumoptions.h
@@ -101,7 +101,7 @@ class NodeValueEnumOptionsKeyword : public NodeValueEnumOptionsBaseKeyword, publ
     // Return maximum number of arguments accepted
     int maxArguments() const { return 2; }
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData)
+    bool read(LineParser &parser, int startArg, CoreData &coreData)
     {
         // Check that the parent node has been set
         if (!parentNode_)

--- a/src/keywords/pairbroadeningfunction.cpp
+++ b/src/keywords/pairbroadeningfunction.cpp
@@ -40,7 +40,7 @@ int PairBroadeningFunctionKeyword::minArguments() const { return 1; }
 int PairBroadeningFunctionKeyword::maxArguments() const { return 2; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool PairBroadeningFunctionKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool PairBroadeningFunctionKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (data_.readAsKeyword(parser, startArg, coreData))
         set_ = true;

--- a/src/keywords/pairbroadeningfunction.h
+++ b/src/keywords/pairbroadeningfunction.h
@@ -50,7 +50,7 @@ class PairBroadeningFunctionKeyword : public KeywordData<PairBroadeningFunction>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/procedure.cpp
+++ b/src/keywords/procedure.cpp
@@ -39,7 +39,7 @@ int ProcedureKeyword::minArguments() const { return 0; }
 int ProcedureKeyword::maxArguments() const { return 0; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool ProcedureKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool ProcedureKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (!data_.read(parser, coreData))
         return false;

--- a/src/keywords/procedure.h
+++ b/src/keywords/procedure.h
@@ -43,7 +43,7 @@ class ProcedureKeyword : public KeywordData<Procedure &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/range.cpp
+++ b/src/keywords/range.cpp
@@ -47,7 +47,7 @@ int RangeKeyword::minArguments() const { return 2; }
 int RangeKeyword::maxArguments() const { return 2; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool RangeKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool RangeKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (parser.hasArg(startArg + 1))
     {

--- a/src/keywords/range.h
+++ b/src/keywords/range.h
@@ -55,7 +55,7 @@ class RangeKeyword : public KeywordData<Range>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/keywords/species.cpp
+++ b/src/keywords/species.cpp
@@ -39,7 +39,7 @@ int SpeciesKeyword::minArguments() const { return 1; }
 int SpeciesKeyword::maxArguments() const { return 1; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool SpeciesKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool SpeciesKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Find target Species (first argument)
     data_ = coreData.findSpecies(parser.argc(startArg));

--- a/src/keywords/species.h
+++ b/src/keywords/species.h
@@ -43,7 +43,7 @@ class SpeciesKeyword : public KeywordData<Species *>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/speciesreflist.cpp
+++ b/src/keywords/speciesreflist.cpp
@@ -49,7 +49,7 @@ int SpeciesRefListKeyword::minArguments() const { return 1; }
 int SpeciesRefListKeyword::maxArguments() const { return 99; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool SpeciesRefListKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool SpeciesRefListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Each argument is the name of a Species that we will add to our list
     for (int n = startArg; n < parser.nArgs(); ++n)

--- a/src/keywords/speciesreflist.h
+++ b/src/keywords/speciesreflist.h
@@ -50,7 +50,7 @@ class SpeciesRefListKeyword : public KeywordData<RefList<Species> &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/speciessite.cpp
+++ b/src/keywords/speciessite.cpp
@@ -50,7 +50,7 @@ int SpeciesSiteKeyword::minArguments() const { return 2; }
 int SpeciesSiteKeyword::maxArguments() const { return 2; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool SpeciesSiteKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool SpeciesSiteKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Find target Species (first argument)
     Species *sp = coreData.findSpecies(parser.argc(startArg));

--- a/src/keywords/speciessite.h
+++ b/src/keywords/speciessite.h
@@ -54,7 +54,7 @@ class SpeciesSiteKeyword : public KeywordData<SpeciesSite *>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/speciessitereflist.cpp
+++ b/src/keywords/speciessitereflist.cpp
@@ -51,7 +51,7 @@ int SpeciesSiteRefListKeyword::minArguments() const { return 2; }
 int SpeciesSiteRefListKeyword::maxArguments() const { return 99; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool SpeciesSiteRefListKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool SpeciesSiteRefListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Loop over arguments
     for (int n = startArg; n < parser.nArgs() - 1; n += 2)

--- a/src/keywords/speciessitereflist.h
+++ b/src/keywords/speciessitereflist.h
@@ -54,7 +54,7 @@ class SpeciesSiteRefListKeyword : public KeywordData<RefList<SpeciesSite> &>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/vec3double.cpp
+++ b/src/keywords/vec3double.cpp
@@ -119,7 +119,7 @@ int Vec3DoubleKeyword::minArguments() const { return 3; }
 int Vec3DoubleKeyword::maxArguments() const { return 3; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool Vec3DoubleKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool Vec3DoubleKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (parser.hasArg(startArg + 2))
     {

--- a/src/keywords/vec3double.h
+++ b/src/keywords/vec3double.h
@@ -80,7 +80,7 @@ class Vec3DoubleKeyword : public KeywordData<Vec3<double>>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/vec3integer.cpp
+++ b/src/keywords/vec3integer.cpp
@@ -118,7 +118,7 @@ int Vec3IntegerKeyword::minArguments() const { return 3; }
 int Vec3IntegerKeyword::maxArguments() const { return 3; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool Vec3IntegerKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool Vec3IntegerKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (parser.hasArg(startArg + 2))
     {

--- a/src/keywords/vec3integer.h
+++ b/src/keywords/vec3integer.h
@@ -80,7 +80,7 @@ class Vec3IntegerKeyword : public KeywordData<Vec3<int>>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/vec3nodevalue.cpp
+++ b/src/keywords/vec3nodevalue.cpp
@@ -50,7 +50,7 @@ int Vec3NodeValueKeyword::minArguments() const { return 3; }
 int Vec3NodeValueKeyword::maxArguments() const { return 3; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool Vec3NodeValueKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool Vec3NodeValueKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     if (!parentNode_)
         return Messenger::error("Can't read keyword %s since the parent ProcedureNode has not been set.\n", name());

--- a/src/keywords/vec3nodevalue.h
+++ b/src/keywords/vec3nodevalue.h
@@ -62,7 +62,7 @@ class Vec3NodeValueKeyword : public KeywordData<Vec3<NodeValue>>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 

--- a/src/keywords/windowfunction.cpp
+++ b/src/keywords/windowfunction.cpp
@@ -40,7 +40,7 @@ int WindowFunctionKeyword::minArguments() const { return 1; }
 int WindowFunctionKeyword::maxArguments() const { return MAXWINDOWFUNCTIONPARAMS; }
 
 // Parse arguments from supplied LineParser, starting at given argument offset
-bool WindowFunctionKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+bool WindowFunctionKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     bool result = data_.set(parser, startArg);
     if (result)

--- a/src/keywords/windowfunction.h
+++ b/src/keywords/windowfunction.h
@@ -43,7 +43,7 @@ class WindowFunctionKeyword : public KeywordData<WindowFunction>
     // Return maximum number of arguments accepted
     int maxArguments() const;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, CoreData &coreData);
     // Write keyword data to specified LineParser
     bool write(LineParser &parser, const char *keywordName, const char *prefix);
 };

--- a/src/math/broadeningfunction.cpp
+++ b/src/math/broadeningfunction.cpp
@@ -629,7 +629,7 @@ double BroadeningFunction::discreteKernelNormalisation(double deltaX, double ome
 const char *BroadeningFunction::itemClassName() { return "BroadeningFunction"; }
 
 // Read data through specified LineParser
-bool BroadeningFunction::read(LineParser &parser, const CoreData &coreData)
+bool BroadeningFunction::read(LineParser &parser, CoreData &coreData)
 {
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;

--- a/src/math/broadeningfunction.h
+++ b/src/math/broadeningfunction.h
@@ -128,7 +128,7 @@ class BroadeningFunction : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/math/data1d.cpp
+++ b/src/math/data1d.cpp
@@ -469,7 +469,7 @@ void Data1D::operator/=(const double factor)
 const char *Data1D::itemClassName() { return "Data1D"; }
 
 // Read data through specified LineParser
-bool Data1D::read(LineParser &parser, const CoreData &coreData)
+bool Data1D::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/math/data1d.h
+++ b/src/math/data1d.h
@@ -127,7 +127,7 @@ class Data1D : public PlottableData, public ListItem<Data1D>, public ObjectStore
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/math/data2d.cpp
+++ b/src/math/data2d.cpp
@@ -477,7 +477,7 @@ void Data2D::operator/=(const double factor)
 const char *Data2D::itemClassName() { return "Data2D"; }
 
 // Read data through specified LineParser
-bool Data2D::read(LineParser &parser, const CoreData &coreData)
+bool Data2D::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/math/data2d.h
+++ b/src/math/data2d.h
@@ -134,7 +134,7 @@ class Data2D : public PlottableData, public ListItem<Data2D>, public ObjectStore
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -494,7 +494,7 @@ void Data3D::operator/=(const double factor)
 const char *Data3D::itemClassName() { return "Data3D"; }
 
 // Read data through specified LineParser
-bool Data3D::read(LineParser &parser, const CoreData &coreData)
+bool Data3D::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/math/data3d.h
+++ b/src/math/data3d.h
@@ -139,7 +139,7 @@ class Data3D : public PlottableData, public ListItem<Data3D>, public ObjectStore
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/math/histogram1d.cpp
+++ b/src/math/histogram1d.cpp
@@ -208,7 +208,7 @@ void Histogram1D::operator=(const Histogram1D &source)
 const char *Histogram1D::itemClassName() { return "Histogram1D"; }
 
 // Read data through specified LineParser
-bool Histogram1D::read(LineParser &parser, const CoreData &coreData)
+bool Histogram1D::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/math/histogram1d.h
+++ b/src/math/histogram1d.h
@@ -112,7 +112,7 @@ class Histogram1D : public ListItem<Histogram1D>, public ObjectStore<Histogram1D
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/math/histogram2d.cpp
+++ b/src/math/histogram2d.cpp
@@ -229,7 +229,7 @@ void Histogram2D::operator=(const Histogram2D &source)
 const char *Histogram2D::itemClassName() { return "Histogram2D"; }
 
 // Read data through specified LineParser
-bool Histogram2D::read(LineParser &parser, const CoreData &coreData)
+bool Histogram2D::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/math/histogram2d.h
+++ b/src/math/histogram2d.h
@@ -126,7 +126,7 @@ class Histogram2D : public ListItem<Histogram2D>, public ObjectStore<Histogram2D
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/math/histogram3d.cpp
+++ b/src/math/histogram3d.cpp
@@ -278,7 +278,7 @@ void Histogram3D::operator=(const Histogram3D &source)
 const char *Histogram3D::itemClassName() { return "Histogram3D"; }
 
 // Read data through specified LineParser
-bool Histogram3D::read(LineParser &parser, const CoreData &coreData)
+bool Histogram3D::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/math/histogram3d.h
+++ b/src/math/histogram3d.h
@@ -153,7 +153,7 @@ class Histogram3D : public ListItem<Histogram3D>, public ObjectStore<Histogram3D
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/math/pairbroadeningfunction.cpp
+++ b/src/math/pairbroadeningfunction.cpp
@@ -88,7 +88,7 @@ int PairBroadeningFunction::nFunctionParameters(FunctionType func) { return Pair
  */
 
 // Read function data from LineParser source
-bool PairBroadeningFunction::readAsKeyword(LineParser &parser, int startArg, const CoreData &coreData)
+bool PairBroadeningFunction::readAsKeyword(LineParser &parser, int startArg, CoreData &coreData)
 {
     // First argument is the form of the function, or a '&' to indicate that a full block-style definition of the data
     if (DissolveSys::sameString("&", parser.argc(startArg)))
@@ -353,7 +353,7 @@ BroadeningFunction PairBroadeningFunction::broadeningFunction(AtomType &at1, Ato
 const char *PairBroadeningFunction::itemClassName() { return "PairBroadeningFunction"; }
 
 // Read data through specified LineParser
-bool PairBroadeningFunction::read(LineParser &parser, const CoreData &coreData)
+bool PairBroadeningFunction::read(LineParser &parser, CoreData &coreData)
 {
     // First line is function name
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)

--- a/src/math/pairbroadeningfunction.h
+++ b/src/math/pairbroadeningfunction.h
@@ -78,7 +78,7 @@ class PairBroadeningFunction : public GenericItemBase
 
     public:
     // Read function data from LineParser source
-    bool readAsKeyword(LineParser &parser, int startArg, const CoreData &coreData);
+    bool readAsKeyword(LineParser &parser, int startArg, CoreData &coreData);
     // Write function data to LineParser source
     bool writeAsKeyword(LineParser &parser, const char *prefix, bool writeBlockMarker = true);
     // Set function type
@@ -111,7 +111,7 @@ class PairBroadeningFunction : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/math/sampleddouble.cpp
+++ b/src/math/sampleddouble.cpp
@@ -150,7 +150,7 @@ void SampledDouble::operator/=(double x)
 const char *SampledDouble::itemClassName() { return "SampledDouble"; }
 
 // Read data through specified LineParser
-bool SampledDouble::read(LineParser &parser, const CoreData &coreData)
+bool SampledDouble::read(LineParser &parser, CoreData &coreData)
 {
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;

--- a/src/math/sampleddouble.h
+++ b/src/math/sampleddouble.h
@@ -79,7 +79,7 @@ class SampledDouble : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/math/windowfunction.cpp
+++ b/src/math/windowfunction.cpp
@@ -273,7 +273,7 @@ double WindowFunction::y(double x, double omega) const
 const char *WindowFunction::itemClassName() { return "WindowFunction"; }
 
 // Read data through specified LineParser
-bool WindowFunction::read(LineParser &parser, const CoreData &coreData)
+bool WindowFunction::read(LineParser &parser, CoreData &coreData)
 {
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;

--- a/src/math/windowfunction.h
+++ b/src/math/windowfunction.h
@@ -97,7 +97,7 @@ class WindowFunction : public GenericItemBase
     // Return class name
     static const char *itemClassName();
     // Read data through specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write data through specified LineParser
     bool write(LineParser &parser);
 

--- a/src/procedure/nodes/fit1d.cpp
+++ b/src/procedure/nodes/fit1d.cpp
@@ -250,7 +250,7 @@ bool Fit1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, con
  */
 
 // Read structure from specified LineParser
-bool Fit1DProcedureNode::read(LineParser &parser, const CoreData &coreData)
+bool Fit1DProcedureNode::read(LineParser &parser, CoreData &coreData)
 {
     // The current line in the parser may contain a node name for us
     if (parser.nArgs() == 2)

--- a/src/procedure/nodes/fit1d.h
+++ b/src/procedure/nodes/fit1d.h
@@ -114,7 +114,7 @@ class Fit1DProcedureNode : public ProcedureNode
      */
     public:
     // Read structure from specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write structure to specified LineParser
     bool write(LineParser &parser, const char *prefix);
 };

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -263,7 +263,7 @@ bool ProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, const ch
  */
 
 // Read node data from specified LineParser
-bool ProcedureNode::read(LineParser &parser, const CoreData &coreData)
+bool ProcedureNode::read(LineParser &parser, CoreData &coreData)
 {
     // Read until we encounter the ending keyword (derived from the node type), or we fail for some reason
     while (!parser.eofOrBlank())

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -215,7 +215,7 @@ class ProcedureNode : public ListItem<ProcedureNode>
      */
     public:
     // Read node data from specified LineParser
-    virtual bool read(LineParser &parser, const CoreData &coreData);
+    virtual bool read(LineParser &parser, CoreData &coreData);
     // Write node data to specified LineParser
     virtual bool write(LineParser &parser, const char *prefix);
 };

--- a/src/procedure/nodes/nodereference.cpp
+++ b/src/procedure/nodes/nodereference.cpp
@@ -78,7 +78,7 @@ void ProcedureNodeReference::operator=(const ProcedureNodeReference &nodeRef)
  */
 
 // Read structure from specified LineParser
-bool ProcedureNodeReference::read(LineParser &parser, int startArg, const CoreData &coreData, const Procedure *procedure)
+bool ProcedureNodeReference::read(LineParser &parser, int startArg, CoreData &coreData, const Procedure *procedure)
 {
     node_ = NULL;
 

--- a/src/procedure/nodes/nodereference.h
+++ b/src/procedure/nodes/nodereference.h
@@ -71,7 +71,7 @@ class ProcedureNodeReference : public ListItem<ProcedureNodeReference>
      */
     public:
     // Read structure from specified LineParser
-    bool read(LineParser &parser, int startArg, const CoreData &coreData, const Procedure *procedure);
+    bool read(LineParser &parser, int startArg, CoreData &coreData, const Procedure *procedure);
     // Write structure to specified LineParser
     bool write(LineParser &parser, const char *prefix);
 };

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -405,7 +405,7 @@ void SequenceProcedureNode::setBlockTerminationKeyword(const char *endKeyword) {
 const char *SequenceProcedureNode::blockTerminationKeyword() const { return blockTerminationKeyword_.get(); }
 
 // Read structure from specified LineParser
-bool SequenceProcedureNode::read(LineParser &parser, const CoreData &coreData)
+bool SequenceProcedureNode::read(LineParser &parser, CoreData &coreData)
 {
     // Read until we encounter the block-ending keyword, or we fail for some reason
     while (!parser.eofOrBlank())

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -141,7 +141,7 @@ class SequenceProcedureNode : public ProcedureNode
     // Return block termination keyword for current context
     const char *blockTerminationKeyword() const;
     // Read structure from specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write structure to specified LineParser
     bool write(LineParser &parser, const char *prefix);
 };

--- a/src/procedure/procedure.cpp
+++ b/src/procedure/procedure.cpp
@@ -102,7 +102,7 @@ bool Procedure::execute(ProcessPool &procPool, Configuration *cfg, const char *p
  */
 
 // Read structure from specified LineParser
-bool Procedure::read(LineParser &parser, const CoreData &coreData)
+bool Procedure::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 

--- a/src/procedure/procedure.h
+++ b/src/procedure/procedure.h
@@ -74,7 +74,7 @@ class Procedure
      */
     public:
     // Read procedure from specified LineParser
-    bool read(LineParser &parser, const CoreData &coreData);
+    bool read(LineParser &parser, CoreData &coreData);
     // Write procedure to specified LineParser
     bool write(LineParser &parser, const char *prefix);
 };


### PR DESCRIPTION
Back when CoreData contained mostly pointers, a const CoreData could
still mutate the values that it pointer to.  Now that we're moving to
references, the const references are immutable.

CoreData is essentially a global index of all of the values in the
simulation.  For example, it contains a list of molecules, a list of
atoms, and a list of isotopes.  Each molecules, in turn, has a list of
pointers/references to the atoms, and each atom a pointer/reference to
an isotope.  But these pointers/references are only to the ones in the
arrays in CoreData.

I bring this up to explain that the read and parse functions still
shouldn't be mutating the CoreData, but the created values that return
from the function need to contain non-constant references to the other
members in CoreData, so CoreData itself needs to be non-const.

As a future optimisation, we may eventually eliminate CoreData
entirely, since one of its main purposes is to encapsulate the
lifetime off all of the simulation data, but the move to references
allows the compiler to handle that on its own.  This is a ways down
the road, though.