### PR TITLE
Define optional reference wrapper as separate entity

### DIFF
--- a/src/classes/atomtypelist.cpp
+++ b/src/classes/atomtypelist.cpp
@@ -253,7 +253,7 @@ AtomType &AtomTypeList::atomType(int n)
 }
 
 // Return AtomTypeData for specified AtomType
-std::optional<std::reference_wrapper<const AtomTypeData>> AtomTypeList::atomTypeData(AtomType &atomType)
+OptionalReferenceWrapper<const AtomTypeData> AtomTypeList::atomTypeData(AtomType &atomType)
 {
     auto it = std::find_if(types_.begin(), types_.end(), [&atomType](const auto &atd) { return &atomType == &atd.atomType(); });
     if (it == types_.end())

--- a/src/classes/atomtypelist.h
+++ b/src/classes/atomtypelist.h
@@ -24,7 +24,7 @@
 #include "classes/atomtypedata.h"
 #include "classes/coredata.h"
 #include "genericitems/base.h"
-#include <optional>
+#include "templates/optionalref.h"
 #include <tuple>
 #include <vector>
 
@@ -89,7 +89,7 @@ class AtomTypeList : public GenericItemBase
     // Return nth referenced AtomType
     AtomType &atomType(int n);
     // Return AtomTypeData for specified AtomType
-    std::optional<std::reference_wrapper<const AtomTypeData>> atomTypeData(AtomType &atomType);
+    OptionalReferenceWrapper<const AtomTypeData> atomTypeData(AtomType &atomType);
     // Print AtomType populations
     void print() const;
 

--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -126,8 +126,7 @@ bool IsotopologueCollection::contains(const Configuration *cfg) const
 }
 
 // Return IsotopologueSet for the specified Configuration
-std::optional<std::reference_wrapper<const IsotopologueSet>>
-IsotopologueCollection::getIsotopologueSet(const Configuration *cfg) const
+OptionalReferenceWrapper<const IsotopologueSet> IsotopologueCollection::getIsotopologueSet(const Configuration *cfg) const
 {
     auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
                            [cfg](const auto &set) { return set.configuration() == cfg; });
@@ -147,8 +146,8 @@ bool IsotopologueCollection::contains(const Configuration *cfg, const Species *s
 }
 
 // Return Isotopologues for the Species in the specified Configuration
-std::optional<std::reference_wrapper<const Isotopologues>> IsotopologueCollection::getIsotopologues(const Configuration *cfg,
-                                                                                                    const Species *sp) const
+OptionalReferenceWrapper<const Isotopologues> IsotopologueCollection::getIsotopologues(const Configuration *cfg,
+                                                                                       const Species *sp) const
 {
     auto it = std::find_if(isotopologueSets_.cbegin(), isotopologueSets_.cend(),
                            [cfg](const auto &set) { return set.configuration() == cfg; });

--- a/src/classes/isotopologuecollection.h
+++ b/src/classes/isotopologuecollection.h
@@ -23,8 +23,8 @@
 
 #include "classes/isotopologueset.h"
 #include "genericitems/base.h"
+#include "templates/optionalref.h"
 #include "templates/reflist.h"
-#include <optional>
 
 // Forward Declarations
 class Configuration;
@@ -75,12 +75,11 @@ class IsotopologueCollection : public GenericItemBase
     // Return whether a set exists for the supplied Configuration
     bool contains(const Configuration *cfg) const;
     // Return IsotopologueSet for the specified Configuration
-    std::optional<std::reference_wrapper<const IsotopologueSet>> getIsotopologueSet(const Configuration *cfg) const;
+    OptionalReferenceWrapper<const IsotopologueSet> getIsotopologueSet(const Configuration *cfg) const;
     // Return whether the Species has a defined set of isotopologues in the specified Configuration
     bool contains(const Configuration *cfg, const Species *sp) const;
     // Return Isotopologues for the Species in the specified Configuration
-    std::optional<std::reference_wrapper<const Isotopologues>> getIsotopologues(const Configuration *cfg,
-                                                                                const Species *sp) const;
+    OptionalReferenceWrapper<const Isotopologues> getIsotopologues(const Configuration *cfg, const Species *sp) const;
     // Complete the collection by making sure it contains every Species in every Configuration in the supplied list
     void complete(const RefList<Configuration> &configurations);
 

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -125,7 +125,7 @@ bool IsotopologueSet::contains(const Species *sp) const
 }
 
 // Return IsotopologueSet for the specified Species
-std::optional<std::reference_wrapper<const Isotopologues>> IsotopologueSet::getIsotopologues(const Species *sp) const
+OptionalReferenceWrapper<const Isotopologues> IsotopologueSet::getIsotopologues(const Species *sp) const
 {
     auto it =
         std::find_if(isotopologues_.cbegin(), isotopologues_.cend(), [sp](const auto &data) { return data.species() == sp; });

--- a/src/classes/isotopologueset.h
+++ b/src/classes/isotopologueset.h
@@ -23,7 +23,7 @@
 
 #include "classes/isotopologues.h"
 #include "genericitems/base.h"
-#include <optional>
+#include "templates/optionalref.h"
 #include <vector>
 
 // Forward Declarations
@@ -80,7 +80,7 @@ class IsotopologueSet : public GenericItemBase
     // Return whether Isotopologues for the specified Species exists
     bool contains(const Species *sp) const;
     // Return Isotopologues for the specified Species
-    std::optional<std::reference_wrapper<const Isotopologues>> getIsotopologues(const Species *sp) const;
+    OptionalReferenceWrapper<const Isotopologues> getIsotopologues(const Species *sp) const;
     // Return number of Isotopologues defined
     int nIsotopologues() const;
     // Return vector of all Isotopologues

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -194,32 +194,33 @@ void Forcefield::addImproperTerm(const char *typeI, const char *typeJ, const cha
 }
 
 // Return bond term for the supplied atom type pair (if it exists)
-std::optional<std::reference_wrapper<const ForcefieldBondTerm>> Forcefield::getBondTerm(const ForcefieldAtomType *i,
-                                                                                        const ForcefieldAtomType *j) const
+OptionalReferenceWrapper<const ForcefieldBondTerm> Forcefield::getBondTerm(const ForcefieldAtomType *i,
+                                                                           const ForcefieldAtomType *j) const
 {
     return termMatch_(bondTerms_, i, j);
 }
 
 // Return angle term for the supplied atom type trio (if it exists)
-std::optional<std::reference_wrapper<const ForcefieldAngleTerm>>
+OptionalReferenceWrapper<const ForcefieldAngleTerm>
 Forcefield::getAngleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k) const
 {
     return termMatch_(angleTerms_, i, j, k);
 }
 
 // Return torsion term for the supplied atom type quartet (if it exists)
-std::optional<std::reference_wrapper<const ForcefieldTorsionTerm>> Forcefield::getTorsionTerm(const ForcefieldAtomType *i,
-                                                                                              const ForcefieldAtomType *j,
-                                                                                              const ForcefieldAtomType *k,
-                                                                                              const ForcefieldAtomType *l) const
+OptionalReferenceWrapper<const ForcefieldTorsionTerm> Forcefield::getTorsionTerm(const ForcefieldAtomType *i,
+                                                                                 const ForcefieldAtomType *j,
+                                                                                 const ForcefieldAtomType *k,
+                                                                                 const ForcefieldAtomType *l) const
 {
     return termMatch_(torsionTerms_, i, j, k, l);
 }
 
 // Return improper term for the supplied atom type quartet (if it exists)
-std::optional<std::reference_wrapper<const ForcefieldImproperTerm>>
-Forcefield::getImproperTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k,
-                            const ForcefieldAtomType *l) const
+OptionalReferenceWrapper<const ForcefieldImproperTerm> Forcefield::getImproperTerm(const ForcefieldAtomType *i,
+                                                                                   const ForcefieldAtomType *j,
+                                                                                   const ForcefieldAtomType *k,
+                                                                                   const ForcefieldAtomType *l) const
 {
     return termMatch_(improperTerms_, i, j, k, l);
 }

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -32,9 +32,9 @@
 #include "data/ffimproperterm.h"
 #include "data/ffparameters.h"
 #include "data/fftorsionterm.h"
+#include "templates/optionalref.h"
 #include <algorithm>
 #include <functional>
-#include <optional>
 #include <tuple>
 #include <vector>
 
@@ -138,24 +138,25 @@ class Forcefield : public Elements
                          SpeciesImproper::ImproperFunction form, double data0 = 0.0, double data1 = 0.0, double data2 = 0.0,
                          double data3 = 0.0);
     // Match any kind of term
-    template <class T, typename... Args>
-    static std::optional<std::reference_wrapper<const T>> termMatch_(std::vector<T>, Args...);
+    template <class T, typename... Args> static OptionalReferenceWrapper<const T> termMatch_(std::vector<T>, Args...);
 
     public:
     // Return bond term for the supplied atom type pair (if it exists)
-    virtual std::optional<std::reference_wrapper<const ForcefieldBondTerm>> getBondTerm(const ForcefieldAtomType *i,
-                                                                                        const ForcefieldAtomType *j) const;
+    virtual OptionalReferenceWrapper<const ForcefieldBondTerm> getBondTerm(const ForcefieldAtomType *i,
+                                                                           const ForcefieldAtomType *j) const;
     // Return angle term for the supplied atom type trio (if it exists)
-    virtual std::optional<std::reference_wrapper<const ForcefieldAngleTerm>>
+    virtual OptionalReferenceWrapper<const ForcefieldAngleTerm>
     getAngleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k) const;
     // Return torsion term for the supplied atom type quartet (if it exists)
-    virtual std::optional<std::reference_wrapper<const ForcefieldTorsionTerm>>
-    getTorsionTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k,
-                   const ForcefieldAtomType *l) const;
+    virtual OptionalReferenceWrapper<const ForcefieldTorsionTerm> getTorsionTerm(const ForcefieldAtomType *i,
+                                                                                 const ForcefieldAtomType *j,
+                                                                                 const ForcefieldAtomType *k,
+                                                                                 const ForcefieldAtomType *l) const;
     // Return improper term for the supplied atom type quartet (if it exists)
-    virtual std::optional<std::reference_wrapper<const ForcefieldImproperTerm>>
-    getImproperTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k,
-                    const ForcefieldAtomType *l) const;
+    virtual OptionalReferenceWrapper<const ForcefieldImproperTerm> getImproperTerm(const ForcefieldAtomType *i,
+                                                                                   const ForcefieldAtomType *j,
+                                                                                   const ForcefieldAtomType *k,
+                                                                                   const ForcefieldAtomType *l) const;
 
     /*
      * Term Assignment
@@ -219,7 +220,7 @@ class Forcefield : public Elements
 };
 
 template <class T, typename... Args>
-std::optional<std::reference_wrapper<const T>> Forcefield::termMatch_(std::vector<T> container, Args... args)
+OptionalReferenceWrapper<const T> Forcefield::termMatch_(std::vector<T> container, Args... args)
 {
     auto it = std::find_if(container.begin(), container.end(), [&](const T &item) { return item.isMatch(args...); });
     if (it == container.end())

--- a/src/data/ff/oplsaa2005/base.h
+++ b/src/data/ff/oplsaa2005/base.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "data/ff.h"
-#include <optional>
+#include "templates/optionalref.h"
 
 // Forward Declarations
 /* none */
@@ -55,19 +55,17 @@ class OPLSAA2005BaseForcefield : public Forcefield
      */
     public:
     // Return bond term for the supplied atom type pair (if it exists)
-    std::optional<std::reference_wrapper<const ForcefieldBondTerm>> bondTerm(const ForcefieldAtomType *i,
-                                                                             const ForcefieldAtomType *j) const;
+    OptionalReferenceWrapper<const ForcefieldBondTerm> bondTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j) const;
     // Return angle term for the supplied atom type trio (if it exists)
-    std::optional<std::reference_wrapper<const ForcefieldAngleTerm>>
-    angleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k) const;
+    OptionalReferenceWrapper<const ForcefieldAngleTerm> angleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
+                                                                  const ForcefieldAtomType *k) const;
     // Return torsion term for the supplied atom type quartet (if it exists)
-    std::optional<std::reference_wrapper<const ForcefieldTorsionTerm>> torsionTerm(const ForcefieldAtomType *i,
-                                                                                   const ForcefieldAtomType *j,
-                                                                                   const ForcefieldAtomType *k,
-                                                                                   const ForcefieldAtomType *l) const;
+    OptionalReferenceWrapper<const ForcefieldTorsionTerm> torsionTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j,
+                                                                      const ForcefieldAtomType *k,
+                                                                      const ForcefieldAtomType *l) const;
     // Return improper term for the supplied atom type quartet (if it exists)
-    std::optional<std::reference_wrapper<const ForcefieldImproperTerm>> improperTerm(const ForcefieldAtomType *i,
-                                                                                     const ForcefieldAtomType *j,
-                                                                                     const ForcefieldAtomType *k,
-                                                                                     const ForcefieldAtomType *l) const;
+    OptionalReferenceWrapper<const ForcefieldImproperTerm> improperTerm(const ForcefieldAtomType *i,
+                                                                        const ForcefieldAtomType *j,
+                                                                        const ForcefieldAtomType *k,
+                                                                        const ForcefieldAtomType *l) const;
 };

--- a/src/data/ff/oplsaa2005/intramolecular.cpp
+++ b/src/data/ff/oplsaa2005/intramolecular.cpp
@@ -34,8 +34,8 @@
  */
 
 // Return bond term for the supplied atom type pair (if it exists)
-std::optional<std::reference_wrapper<const ForcefieldBondTerm>>
-OPLSAA2005BaseForcefield::bondTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j) const
+OptionalReferenceWrapper<const ForcefieldBondTerm> OPLSAA2005BaseForcefield::bondTerm(const ForcefieldAtomType *i,
+                                                                                      const ForcefieldAtomType *j) const
 {
     static std::vector<ForcefieldBondTerm> bondTerms = {
         //	i	j	Type (Harmonic)			k	eq
@@ -398,7 +398,7 @@ OPLSAA2005BaseForcefield::bondTerm(const ForcefieldAtomType *i, const Forcefield
 }
 
 // Return angle term for the supplied atom type trio (if it exists)
-std::optional<std::reference_wrapper<const ForcefieldAngleTerm>>
+OptionalReferenceWrapper<const ForcefieldAngleTerm>
 OPLSAA2005BaseForcefield::angleTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k) const
 {
     static std::vector<ForcefieldAngleTerm> angleTerms = {
@@ -1413,9 +1413,10 @@ OPLSAA2005BaseForcefield::angleTerm(const ForcefieldAtomType *i, const Forcefiel
 }
 
 // Return torsion term for the supplied atom type quartet (if it exists)
-std::optional<std::reference_wrapper<const ForcefieldTorsionTerm>>
-OPLSAA2005BaseForcefield::torsionTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k,
-                                      const ForcefieldAtomType *l) const
+OptionalReferenceWrapper<const ForcefieldTorsionTerm> OPLSAA2005BaseForcefield::torsionTerm(const ForcefieldAtomType *i,
+                                                                                            const ForcefieldAtomType *j,
+                                                                                            const ForcefieldAtomType *k,
+                                                                                            const ForcefieldAtomType *l) const
 {
     static std::vector<ForcefieldTorsionTerm> torsionTerms = {
         //	i	j	k	l	Type (CosineForm)		k		n	eq	s
@@ -2171,9 +2172,10 @@ OPLSAA2005BaseForcefield::torsionTerm(const ForcefieldAtomType *i, const Forcefi
 }
 
 // Return improper term for the supplied atom type quartet (if it exists)
-std::optional<std::reference_wrapper<const ForcefieldImproperTerm>>
-OPLSAA2005BaseForcefield::improperTerm(const ForcefieldAtomType *i, const ForcefieldAtomType *j, const ForcefieldAtomType *k,
-                                       const ForcefieldAtomType *l) const
+OptionalReferenceWrapper<const ForcefieldImproperTerm> OPLSAA2005BaseForcefield::improperTerm(const ForcefieldAtomType *i,
+                                                                                              const ForcefieldAtomType *j,
+                                                                                              const ForcefieldAtomType *k,
+                                                                                              const ForcefieldAtomType *l) const
 {
     static std::vector<ForcefieldImproperTerm> improperTerms = {};
     return Forcefield::termMatch_(improperTerms, i, j, k, l);

--- a/src/data/formfactors.cpp
+++ b/src/data/formfactors.cpp
@@ -40,7 +40,7 @@ EnumOptions<XRayFormFactors::XRayFormFactorData> xRayFormFactorData()
 }
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-optional_reference_wrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge)
+OptionalReferenceWrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge)
 {
     switch (dataSet)
     {
@@ -54,7 +54,7 @@ optional_reference_wrapper<const FormFactorData> formFactorData(XRayFormFactorDa
 }
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-optional_reference_wrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge)
+OptionalReferenceWrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge)
 {
     return formFactorData(dataSet, el->Z(), formalCharge);
 }

--- a/src/data/formfactors.h
+++ b/src/data/formfactors.h
@@ -24,10 +24,8 @@
 #include "base/enumoptions.h"
 #include "data/elements.h"
 #include "data/formfactordata.h"
-#include <optional>
+#include "templates/optionalref.h"
 #include <tuple>
-
-template <class T> using optional_reference_wrapper = std::optional<std::reference_wrapper<T>>;
 
 // X-Ray Form Factors
 namespace XRayFormFactors
@@ -44,11 +42,11 @@ enum XRayFormFactorData
 EnumOptions<XRayFormFactorData> xRayFormFactorData();
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-optional_reference_wrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge = 0);
+OptionalReferenceWrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, int Z, int formalCharge = 0);
 
 // Return form factor data from specified dataset for given element and formal charge (if it exists)
-optional_reference_wrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge = 0);
+OptionalReferenceWrapper<const FormFactorData> formFactorData(XRayFormFactorData dataSet, Element *el, int formalCharge = 0);
 
 // Return Waasmaier & Kirfel (1995) form factor data for given element and formal charge (if it exists)
-optional_reference_wrapper<const FormFactorData> wk1995Data(int Z, int formalCharge = 0);
+OptionalReferenceWrapper<const FormFactorData> wk1995Data(int Z, int formalCharge = 0);
 }; // namespace XRayFormFactors

--- a/src/data/formfactors_wk1995.cpp
+++ b/src/data/formfactors_wk1995.cpp
@@ -66,7 +66,7 @@ namespace XRayFormFactors
 {
 
 // Return Waasmaier & Kirfel (1995) form factor data for given element and formal charge (if it exists)
-std::optional<std::reference_wrapper<const FormFactorData>> wk1995Data(int Z, int formalCharge)
+OptionalReferenceWrapper<const FormFactorData> wk1995Data(int Z, int formalCharge)
 {
     /*
      * New Analytical Scattering Factor Functions for Free Atoms and Ions

--- a/src/gui/helpers/treewidgetupdater.h
+++ b/src/gui/helpers/treewidgetupdater.h
@@ -20,11 +20,11 @@
 */
 
 #include "templates/list.h"
+#include "templates/optionalref.h"
 #include "templates/refdatalist.h"
 #include "templates/reflist.h"
 #include "templates/variantpointer.h"
 #include <QTreeWidget>
-#include <optional>
 
 #pragma once
 
@@ -414,7 +414,7 @@ template <class P, class T> class TreeWidgetItemManager
     // Return whether the specified QTreeWidgetItem is mapped to a reference
     bool isMapped(QTreeWidgetItem *item) const { return (referenceMap_.find(item) != referenceMap_.end()); }
     // Retrieve reference associated to specified QTreeWidgetItem
-    std::optional<std::reference_wrapper<T>> reference(QTreeWidgetItem *item) const
+    OptionalReferenceWrapper<T> reference(QTreeWidgetItem *item) const
     {
         auto it = referenceMap_.find(item);
         if (it == referenceMap_.end())

--- a/src/templates/optionalref.h
+++ b/src/templates/optionalref.h
@@ -1,0 +1,26 @@
+/*
+    *** Optional Reference
+    *** src/templates/optionalref.h
+    Copyright T. Youngs 2012-2020
+
+    This file is part of Dissolve.
+
+    Dissolve is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Dissolve is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Dissolve.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <optional>
+
+template <class T> using OptionalReferenceWrapper = std::optional<std::reference_wrapper<T>>;


### PR DESCRIPTION
This PR removes the need for manual definition of the rather lengthy `std::optional<std::reference_wrapper<T>>` by defining it once in a separate header (src/templates/optionalref.h).

New class is named `OptionalReferenceWrapper` for consistency with other classes in the code.
