### PR TITLE
Condense TableWidgetUpdater

### DIFF
--- a/src/gui/datamanagerdialog.h
+++ b/src/gui/datamanagerdialog.h
@@ -26,6 +26,8 @@
 #include "templates/list.h"
 #include <QDialog>
 
+Q_DECLARE_METATYPE(ReferencePoint *)
+
 // Forward Declarations
 class Dissolve;
 class GenericItem;

--- a/src/gui/forcefieldtab.h
+++ b/src/gui/forcefieldtab.h
@@ -21,13 +21,15 @@
 
 #pragma once
 
+#include "classes/atomtype.h"
+#include "classes/masterintra.h"
+#include "classes/pairpotential.h"
 #include "gui/maintab.h"
 #include "gui/ui_forcefieldtab.h"
 
-// Forward Declarations
-class MasterIntra;
-class AtomType;
-class PairPotential;
+Q_DECLARE_METATYPE(MasterIntra *)
+Q_DECLARE_METATYPE(AtomType *)
+Q_DECLARE_METATYPE(PairPotential *)
 
 // Forcefield Tab
 class ForcefieldTab : public QWidget, public MainTab

--- a/src/gui/helpers/tablewidgetupdater.h
+++ b/src/gui/helpers/tablewidgetupdater.h
@@ -36,8 +36,12 @@ template <class T, class I, typename Raw = I *, typename... Args> class TableWid
     typedef void (T::*TableWidgetRowUpdateFunction)(int row, Raw item, bool createItems, Args... args);
 
     private:
-    static void inner_(QTableWidget *table, int rowCount, Raw dataItem, T *functionParent,
-                       TableWidgetRowUpdateFunction updateRow, Args... args)
+    // For a given QTableWidget, ensure that the given dataItem is at
+    // the given rowCount index.  If there are other items in the way,
+    // remove them.  If the item isn't in the table, add it.  Finally,
+    // updateRow.
+    static void updateItemAtIndex(QTableWidget *table, int rowCount, Raw dataItem, T *functionParent,
+                                  TableWidgetRowUpdateFunction updateRow, Args... args)
     {
         // Our table may or may not be populated, and with different items to those in the list.
 
@@ -79,7 +83,7 @@ template <class T, class I, typename Raw = I *, typename... Args> class TableWid
         ListIterator<I> dataIterator(list);
         while (I *dataItem = dataIterator.iterate())
         {
-            inner_(table, rowCount, dataItem, functionParent, updateRow);
+            updateItemAtIndex(table, rowCount, dataItem, functionParent, updateRow);
             ++rowCount;
         }
 
@@ -93,7 +97,7 @@ template <class T, class I, typename Raw = I *, typename... Args> class TableWid
 
         for (I *dataItem : list)
         {
-            inner_(table, rowCount, dataItem, functionParent, updateRow);
+            updateItemAtIndex(table, rowCount, dataItem, functionParent, updateRow);
             ++rowCount;
         }
         table->setRowCount(rowCount);
@@ -105,7 +109,7 @@ template <class T, class I, typename Raw = I *, typename... Args> class TableWid
         DynamicArrayIterator<I> dataIterator(array);
         while (I *dataItem = dataIterator.iterate())
         {
-            inner_(table, rowCount, dataItem, functionParent, updateRow);
+            updateItemAtIndex(table, rowCount, dataItem, functionParent, updateRow);
             ++rowCount;
         }
 
@@ -121,7 +125,7 @@ template <class T, class I, typename Raw = I *, typename... Args> class TableWid
         auto itemIterator(list);
         while (I *dataItem = itemIterator.iterate())
         {
-            inner_(table, rowCount, dataItem, functionParent, updateRow, itemIterator.currentData());
+            updateItemAtIndex(table, rowCount, dataItem, functionParent, updateRow, itemIterator.currentData());
             ++rowCount;
         }
     }

--- a/src/gui/helpers/tablewidgetupdater.h
+++ b/src/gui/helpers/tablewidgetupdater.h
@@ -31,14 +31,14 @@
 
 // TableWidgetUpdater - Constructor-only template class to update contents of a QTableWidget, preserving original items as much
 // as possible
-template <class T, class I> class TableWidgetUpdater
+template <class T, class I, typename... Args> class TableWidgetUpdater
 {
     // Typedefs for passed functions
-    typedef void (T::*TableWidgetRowUpdateFunction)(int row, I *item, bool createItems);
+    typedef void (T::*TableWidgetRowUpdateFunction)(int row, I *item, bool createItems, Args... args);
 
     private:
     static void inner_(QTableWidget *table, int rowCount, I *dataItem, T *functionParent,
-                       TableWidgetRowUpdateFunction updateRow)
+                       TableWidgetRowUpdateFunction updateRow, Args... args)
     {
         // Our table may or may not be populated, and with different items to those in the list.
 
@@ -52,7 +52,7 @@ template <class T, class I> class TableWidgetUpdater
             if (rowData == dataItem)
             {
                 // Update the current row and quit the loop
-                (functionParent->*updateRow)(rowCount, dataItem, false);
+                (functionParent->*updateRow)(rowCount, dataItem, false, args...);
 
                 break;
             }
@@ -114,61 +114,16 @@ template <class T, class I> class TableWidgetUpdater
         // iterate over
         table->setRowCount(rowCount);
     }
-};
-
-// TableWidgetRefDataUpdater - Constructor-only template class to update contents of a QTableWidget from a RefDataList,
-// preserving original items as much as possible
-template <class T, class I, class D> class TableWidgetRefDataListUpdater
-{
-    // Typedefs for passed functions
-    typedef void (T::*TableWidgetRowUpdateFunction)(int row, I *item, D data, bool createItems);
-
-    public:
-    TableWidgetRefDataListUpdater(QTableWidget *table, const RefDataList<I, D> &list, T *functionParent,
-                                  TableWidgetRowUpdateFunction updateRow)
+    template <typename D>
+    TableWidgetUpdater(QTableWidget *table, RefDataList<I, D> &list, T *functionParent, TableWidgetRowUpdateFunction updateRow)
     {
-        QTableWidgetItem *tableItem;
-
         int rowCount = 0;
 
-        RefDataListIterator<I, D> itemIterator(list);
-        while (I *item = itemIterator.iterate())
+        auto itemIterator(list);
+        while (I *dataItem = itemIterator.iterate())
         {
-            // Our table may or may not be populated, and with different items to those in the list.
-
-            // If there is an item already on this row, check it
-            // If it represents the current pointer data, just update it and move on. Otherwise, delete it and check
-            // again
-            while (rowCount < table->rowCount())
-            {
-                tableItem = table->item(rowCount, 0);
-                I *rowData = (tableItem ? VariantPointer<I>(tableItem->data(Qt::UserRole)) : NULL);
-                if (rowData == item)
-                {
-                    // Update the current row and quit the loop
-                    (functionParent->*updateRow)(rowCount, item, itemIterator.currentData(), false);
-
-                    break;
-                }
-                else
-                    table->removeRow(rowCount);
-            }
-
-            // If the current row index is (now) out of range, add a new row to the table
-            if (rowCount == table->rowCount())
-            {
-                // Increase row count
-                table->setRowCount(rowCount + 1);
-
-                // Create new items
-                (functionParent->*updateRow)(rowCount, item, itemIterator.currentData(), true);
-            }
-
+            inner_(table, rowCount, dataItem, functionParent, updateRow, itemIterator.currentData());
             ++rowCount;
         }
-
-        // Set the number of table rows again here in order to catch the case where there were zero data items to
-        // iterate over
-        table->setRowCount(rowCount);
     }
 };

--- a/src/gui/helpers/tablewidgetupdater.h
+++ b/src/gui/helpers/tablewidgetupdater.h
@@ -36,46 +36,51 @@ template <class T, class I> class TableWidgetUpdater
     // Typedefs for passed functions
     typedef void (T::*TableWidgetRowUpdateFunction)(int row, I *item, bool createItems);
 
+    private:
+    static void inner_(QTableWidget *table, int rowCount, I *dataItem, T *functionParent,
+                       TableWidgetRowUpdateFunction updateRow)
+    {
+        // Our table may or may not be populated, and with different items to those in the list.
+
+        // If there is an item already on this row, check it
+        // If it represents the current pointer data, just update it and move on. Otherwise, delete it and check
+        // again
+        while (rowCount < table->rowCount())
+        {
+            auto tableItem = table->item(rowCount, 0);
+            I *rowData = (tableItem ? VariantPointer<I>(tableItem->data(Qt::UserRole)) : NULL);
+            if (rowData == dataItem)
+            {
+                // Update the current row and quit the loop
+                (functionParent->*updateRow)(rowCount, dataItem, false);
+
+                break;
+            }
+            else
+                table->removeRow(rowCount);
+        }
+
+        // If the current row index is (now) out of range, add a new row to the table
+        if (rowCount == table->rowCount())
+        {
+            // Increase row count
+            table->setRowCount(rowCount + 1);
+
+            // Create new items
+            (functionParent->*updateRow)(rowCount, dataItem, true);
+        }
+    }
+
     public:
     TableWidgetUpdater(QTableWidget *table, const List<I> &list, T *functionParent, TableWidgetRowUpdateFunction updateRow)
     {
-        QTableWidgetItem *tableItem;
 
         int rowCount = 0;
 
         ListIterator<I> dataIterator(list);
         while (I *dataItem = dataIterator.iterate())
         {
-            // Our table may or may not be populated, and with different items to those in the list.
-
-            // If there is an item already on this row, check it
-            // If it represents the current pointer data, just update it and move on. Otherwise, delete it and check
-            // again
-            while (rowCount < table->rowCount())
-            {
-                tableItem = table->item(rowCount, 0);
-                I *rowData = (tableItem ? VariantPointer<I>(tableItem->data(Qt::UserRole)) : NULL);
-                if (rowData == dataItem)
-                {
-                    // Update the current row and quit the loop
-                    (functionParent->*updateRow)(rowCount, dataItem, false);
-
-                    break;
-                }
-                else
-                    table->removeRow(rowCount);
-            }
-
-            // If the current row index is (now) out of range, add a new row to the table
-            if (rowCount == table->rowCount())
-            {
-                // Increase row count
-                table->setRowCount(rowCount + 1);
-
-                // Create new items
-                (functionParent->*updateRow)(rowCount, dataItem, true);
-            }
-
+            inner_(table, rowCount, dataItem, functionParent, updateRow);
             ++rowCount;
         }
 
@@ -85,88 +90,23 @@ template <class T, class I> class TableWidgetUpdater
     }
     TableWidgetUpdater(QTableWidget *table, const RefList<I> &list, T *functionParent, TableWidgetRowUpdateFunction updateRow)
     {
-        QTableWidgetItem *tableItem;
-
         int rowCount = 0;
 
-        for (I *item : list)
+        for (I *dataItem : list)
         {
-            // Our table may or may not be populated, and with different items to those in the list.
-
-            // If there is an item already on this row, check it
-            // If it represents the current pointer data, just update it and move on. Otherwise, delete it and check
-            // again
-            while (rowCount < table->rowCount())
-            {
-                tableItem = table->item(rowCount, 0);
-                I *rowData = (tableItem ? VariantPointer<I>(tableItem->data(Qt::UserRole)) : NULL);
-                if (rowData == item)
-                {
-                    // Update the current row and quit the loop
-                    (functionParent->*updateRow)(rowCount, item, false);
-
-                    break;
-                }
-                else
-                    table->removeRow(rowCount);
-            }
-
-            // If the current row index is (now) out of range, add a new row to the table
-            if (rowCount == table->rowCount())
-            {
-                // Increase row count
-                table->setRowCount(rowCount + 1);
-
-                // Create new items
-                (functionParent->*updateRow)(rowCount, item, true);
-            }
-
+            inner_(table, rowCount, dataItem, functionParent, updateRow);
             ++rowCount;
         }
-
-        // Set the number of table rows again here in order to catch the case where there were zero data items to
-        // iterate over
         table->setRowCount(rowCount);
     }
     TableWidgetUpdater(QTableWidget *table, DynamicArray<I> &array, T *functionParent, TableWidgetRowUpdateFunction updateRow)
     {
-        QTableWidgetItem *tableItem;
-
         int rowCount = 0;
 
         DynamicArrayIterator<I> dataIterator(array);
         while (I *dataItem = dataIterator.iterate())
         {
-            // Our table may or may not be populated, and with different items to those in the list.
-
-            // If there is an item already on this row, check it
-            // If it represents the current pointer data, just update it and move on. Otherwise, delete it and check
-            // again
-            while (rowCount < table->rowCount())
-            {
-                tableItem = table->item(rowCount, 0);
-                I *rowData = (tableItem ? VariantPointer<I>(tableItem->data(Qt::UserRole)) : NULL);
-                if (rowData == dataItem)
-                {
-                    // Update the current row and quit the loop
-                    (functionParent->*updateRow)(rowCount, dataItem, false);
-
-                    break;
-                }
-                else
-                    table->removeRow(rowCount);
-            }
-
-            // If the current row index is (now) out of range, add a new row to the table
-            if (rowCount == table->rowCount())
-            {
-                // Increase row count
-                table->setRowCount(rowCount + 1);
-
-                // Create new items
-                (functionParent->*updateRow)(rowCount, dataItem, true);
-            }
-
+            inner_(table, rowCount, dataItem, functionParent, updateRow);
             ++rowCount;
         }
 

--- a/src/gui/helpers/tablewidgetupdater.h
+++ b/src/gui/helpers/tablewidgetupdater.h
@@ -24,20 +24,19 @@
 #include "templates/list.h"
 #include "templates/refdatalist.h"
 #include "templates/reflist.h"
-#include "templates/variantpointer.h"
 #include <QTableWidget>
 
 #pragma once
 
 // TableWidgetUpdater - Constructor-only template class to update contents of a QTableWidget, preserving original items as much
 // as possible
-template <class T, class I, typename... Args> class TableWidgetUpdater
+template <class T, class I, typename Raw = I *, typename... Args> class TableWidgetUpdater
 {
     // Typedefs for passed functions
-    typedef void (T::*TableWidgetRowUpdateFunction)(int row, I *item, bool createItems, Args... args);
+    typedef void (T::*TableWidgetRowUpdateFunction)(int row, Raw item, bool createItems, Args... args);
 
     private:
-    static void inner_(QTableWidget *table, int rowCount, I *dataItem, T *functionParent,
+    static void inner_(QTableWidget *table, int rowCount, Raw dataItem, T *functionParent,
                        TableWidgetRowUpdateFunction updateRow, Args... args)
     {
         // Our table may or may not be populated, and with different items to those in the list.
@@ -48,7 +47,7 @@ template <class T, class I, typename... Args> class TableWidgetUpdater
         while (rowCount < table->rowCount())
         {
             auto tableItem = table->item(rowCount, 0);
-            I *rowData = (tableItem ? VariantPointer<I>(tableItem->data(Qt::UserRole)) : NULL);
+            auto rowData = (tableItem ? tableItem->data(Qt::UserRole).value<Raw>() : NULL);
             if (rowData == dataItem)
             {
                 // Update the current row and quit the loop

--- a/src/gui/keywordwidgets/expressionvariablelist.h
+++ b/src/gui/keywordwidgets/expressionvariablelist.h
@@ -24,9 +24,11 @@
 #include "gui/keywordwidgets/base.h"
 #include "gui/keywordwidgets/ui_expressionvariablelist.h"
 #include "keywords/expressionvariablelist.h"
+#include "procedure/nodes/node.h"
+
+Q_DECLARE_METATYPE(ExpressionNode *);
 
 // Forward Declarations
-class ExpressionNode;
 class QWidget;
 
 class ExpressionVariableListKeywordWidget : public QWidget, public KeywordWidgetBase

--- a/src/gui/keywordwidgets/expressionvariablelist_funcs.cpp
+++ b/src/gui/keywordwidgets/expressionvariablelist_funcs.cpp
@@ -26,6 +26,7 @@
 #include "gui/helpers/tablewidgetupdater.h"
 #include "gui/keywordwidgets/expressionvariablelist.h"
 #include "procedure/nodes/node.h"
+#include "templates/variantpointer.h"
 #include <QComboBox>
 #include <QHBoxLayout>
 #include <QString>

--- a/src/gui/keywordwidgets/modulegroups.h
+++ b/src/gui/keywordwidgets/modulegroups.h
@@ -25,10 +25,10 @@
 #include "gui/keywordwidgets/dropdown.h"
 #include "gui/keywordwidgets/ui_modulegroups.h"
 #include "keywords/modulegroups.h"
+#include "module/module.h"
 #include <QWidget>
 
 // Forward Declarations
-class Module;
 class ModuleGroup;
 
 class ModuleGroupsKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
@@ -78,3 +78,5 @@ class ModuleGroupsKeywordWidget : public KeywordDropDown, public KeywordWidgetBa
     // Update summary text
     void updateSummaryText();
 };
+
+Q_DECLARE_METATYPE(Module *);

--- a/src/gui/keywordwidgets/modulegroups_funcs.cpp
+++ b/src/gui/keywordwidgets/modulegroups_funcs.cpp
@@ -27,6 +27,7 @@
 #include "module/group.h"
 #include "module/groups.h"
 #include "module/module.h"
+#include "templates/variantpointer.h"
 #include <QComboBox>
 #include <QHBoxLayout>
 #include <QString>

--- a/src/gui/speciestab.h
+++ b/src/gui/speciestab.h
@@ -21,6 +21,11 @@
 
 #pragma once
 
+#include "classes/speciesangle.h"
+#include "classes/speciesatom.h"
+#include "classes/speciesbond.h"
+#include "classes/speciesimproper.h"
+#include "classes/speciestorsion.h"
 #include "gui/maintab.h"
 #include "gui/ui_speciestab.h"
 
@@ -29,10 +34,12 @@ class AtomType;
 class Isotope;
 class Isotopologue;
 class Species;
-class SpeciesAtom;
-class SpeciesBond;
-class SpeciesAngle;
-class SpeciesTorsion;
+
+Q_DECLARE_METATYPE(SpeciesAtom *)
+Q_DECLARE_METATYPE(SpeciesBond *)
+Q_DECLARE_METATYPE(SpeciesAngle *)
+Q_DECLARE_METATYPE(SpeciesTorsion *)
+Q_DECLARE_METATYPE(SpeciesImproper *)
 
 // Species Tab
 class SpeciesTab : public QWidget, public ListItem<SpeciesTab>, public MainTab


### PR DESCRIPTION
As part of my work on switch AtomType over to shared pointers, I need the TableWidgetUpdater to work with vectors or shared pointers.  This requires adding a new function which is *largely* similar to the existing ones, but uses shared pointers.  To make this easier, I wanted to simplify down the class.  Now, each "Constructor" merely iterates through the container type that has been passed to it and calls the `inner_` function on each value.  The third template argument allows us to swap out a shared_ptr (or a reference or another type) for a raw pointer, if that's what the container holds.  The variadic argument allows for extra data types to be passed in, which allowed for the `TableWidgetRefDataList` updater to be merged in with the original `TableWidgetUpdater`

Eventually, once we've moved away from custom containers and onto stl containers, much of this infrastruction can go away, but we'll need it during the interim.