### PR TITLE
Geometry optimise charged species

### DIFF
--- a/.azure-pipelines/templates/system-tests.yml
+++ b/.azure-pipelines/templates/system-tests.yml
@@ -23,7 +23,7 @@ jobs:
           ./go -a -s ./dissolve
         displayName: 'Run Serial System Tests'
       - bash: |
-          mkdir test-outputs
+          mkdir test-output
           cp -rv $(System.ArtifactsDirectory)/linux-tests-serial/*.out test-output/
         displayName: 'Copy Test Output'
         condition: always()
@@ -57,7 +57,7 @@ jobs:
           ./go -a -p ./dissolve-mpi
         displayName: 'Run Parallel System Tests'
       - bash: |
-          mkdir test-outputs
+          mkdir test-output
           cp -rv $(System.ArtifactsDirectory)/linux-tests-parallel/*.out test-output/
         displayName: 'Copy Test Output'
         condition: always()

--- a/.azure-pipelines/templates/system-tests.yml
+++ b/.azure-pipelines/templates/system-tests.yml
@@ -26,11 +26,13 @@ jobs:
           mkdir test-outputs
           cp -rv $(System.ArtifactsDirectory)/linux-tests-serial/*.out test-output/
         displayName: 'Copy Test Output'
+        condition: always()
       - task: PublishBuildArtifacts@1
         inputs:
           PathtoPublish: "test-output/"
           ArtifactName: 'linux-test-output-serial'
         displayName: 'Publish Serial Test Output Artifacts'
+        condition: always()
   - job:
     condition: eq('${{ parameters.parallel }}', true)
     displayName: 'System Tests (Parallel)'
@@ -58,8 +60,10 @@ jobs:
           mkdir test-outputs
           cp -rv $(System.ArtifactsDirectory)/linux-tests-parallel/*.out test-output/
         displayName: 'Copy Test Output'
+        condition: always()
       - task: PublishBuildArtifacts@1
         inputs:
           PathtoPublish: "test-output/"
           ArtifactName: 'linux-test-output-parallel'
         displayName: 'Publish Parallel Test Output Artifacts'
+        condition: always()

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -671,10 +671,7 @@ double EnergyKernel::energy(const SpeciesBond *b, const Atom *i, const Atom *j)
 }
 
 // Return SpeciesBond energy
-double EnergyKernel::energy(const SpeciesBond *b)
-{
-    return b->energy((b->j()->r() - b->i()->r()).magnitude());
-}
+double EnergyKernel::energy(const SpeciesBond *b) { return b->energy((b->j()->r() - b->i()->r()).magnitude()); }
 
 // Return SpeciesAngle energy at Atoms specified
 double EnergyKernel::energy(const SpeciesAngle *a, const Atom *i, const Atom *j, const Atom *k)

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -654,7 +654,7 @@ double EnergyKernel::energy(const CellArray &cellArray, bool interMolecular, Pro
  * Intramolecular Terms
  */
 
-// Return SpeciesBond energy
+// Return SpeciesBond energy at Atoms specified
 double EnergyKernel::energy(const SpeciesBond *b, const Atom *i, const Atom *j)
 {
 #ifdef CHECKS
@@ -670,7 +670,13 @@ double EnergyKernel::energy(const SpeciesBond *b, const Atom *i, const Atom *j)
         return b->energy((i->r() - j->r()).magnitude());
 }
 
-// Return SpeciesAngle energy
+// Return SpeciesBond energy
+double EnergyKernel::energy(const SpeciesBond *b)
+{
+    return b->energy((b->j()->r() - b->i()->r()).magnitude());
+}
+
+// Return SpeciesAngle energy at Atoms specified
 double EnergyKernel::energy(const SpeciesAngle *a, const Atom *i, const Atom *j, const Atom *k)
 {
     Vec3<double> vecji, vecjk;
@@ -693,11 +699,23 @@ double EnergyKernel::energy(const SpeciesAngle *a, const Atom *i, const Atom *j,
     return a->energy(Box::angleInDegrees(vecji, vecjk));
 }
 
-// Return SpeciesTorsion energy
+// Return SpeciesAngle energy
+double EnergyKernel::energy(const SpeciesAngle *a)
+{
+    Vec3<double> vecji = a->i()->r() - a->j()->r(), vecjk = a->k()->r() - a->j()->r();
+
+    // Normalise vectors
+    vecji.normalise();
+    vecjk.normalise();
+
+    // Determine Angle energy
+    return a->energy(Box::angleInDegrees(vecji, vecjk));
+}
+
+// Return SpeciesTorsion energy at Atoms specified
 double EnergyKernel::energy(const SpeciesTorsion *t, const Atom *i, const Atom *j, const Atom *k, const Atom *l)
 {
-    Vec3<double> vecji, vecjk, veckl, xpj, xpk, dcos_dxpj, dcos_dxpk, temp, force;
-    Matrix3 dxpj_dij, dxpj_dkj, dxpk_dkj, dxpk_dlk;
+    Vec3<double> vecji, vecjk, veckl;
 
     // Calculate vectors, ensuring we account for minimum image
     if (j->cell()->mimRequired(i->cell()))
@@ -714,6 +732,12 @@ double EnergyKernel::energy(const SpeciesTorsion *t, const Atom *i, const Atom *
         veckl = l->r() - k->r();
 
     return t->energy(Box::torsionInDegrees(vecji, vecjk, veckl));
+}
+
+// Return SpeciesTorsion energy
+double EnergyKernel::energy(const SpeciesTorsion *t)
+{
+    return t->energy(Box::torsionInDegrees(t->i()->r() - t->j()->r(), t->k()->r() - t->j()->r(), t->l()->r() - t->k()->r()));
 }
 
 // Return intramolecular energy for the supplied Atom

--- a/src/classes/energykernel.h
+++ b/src/classes/energykernel.h
@@ -100,20 +100,18 @@ class EnergyKernel
      * Intramolecular Terms
      */
     public:
-    // Return SpeciesBond energy
+    // Return SpeciesBond energy at Atoms specified
     double energy(const SpeciesBond *b, const Atom *i, const Atom *j);
     // Return SpeciesBond energy
     static double energy(const SpeciesBond *b);
-    // Return SpeciesAngle energy
+    // Return SpeciesAngle energy at Atoms specified
     double energy(const SpeciesAngle *a, const Atom *i, const Atom *j, const Atom *k);
     // Return SpeciesAngle energy
     static double energy(const SpeciesAngle *a);
-    // Return SpeciesTorsion energy
+    // Return SpeciesTorsion energy at Atoms specified
     double energy(const SpeciesTorsion *t, const Atom *i, const Atom *j, const Atom *k, const Atom *l);
     // Return SpeciesTorsion energy
     static double energy(const SpeciesTorsion *t);
-    // Return SpeciesImproper energy
-    static double energy(const SpeciesImproper *i);
     // Return intramolecular energy for the supplied Atom
     double intramolecularEnergy(std::shared_ptr<const Molecule> mol, const Atom *i);
     // Return intramolecular energy for the supplied Molecule

--- a/src/classes/energykernel.h
+++ b/src/classes/energykernel.h
@@ -36,6 +36,7 @@ class PotentialMap;
 class Molecule;
 class SpeciesBond;
 class SpeciesAngle;
+class SpeciesImproper;
 class SpeciesTorsion;
 
 // Energy Kernel
@@ -101,10 +102,18 @@ class EnergyKernel
     public:
     // Return SpeciesBond energy
     double energy(const SpeciesBond *b, const Atom *i, const Atom *j);
+    // Return SpeciesBond energy
+    static double energy(const SpeciesBond *b);
     // Return SpeciesAngle energy
     double energy(const SpeciesAngle *a, const Atom *i, const Atom *j, const Atom *k);
+    // Return SpeciesAngle energy
+    static double energy(const SpeciesAngle *a);
     // Return SpeciesTorsion energy
     double energy(const SpeciesTorsion *t, const Atom *i, const Atom *j, const Atom *k, const Atom *l);
+    // Return SpeciesTorsion energy
+    static double energy(const SpeciesTorsion *t);
+    // Return SpeciesImproper energy
+    static double energy(const SpeciesImproper *i);
     // Return intramolecular energy for the supplied Atom
     double intramolecularEnergy(std::shared_ptr<const Molecule> mol, const Atom *i);
     // Return intramolecular energy for the supplied Molecule

--- a/src/classes/forcekernel.h
+++ b/src/classes/forcekernel.h
@@ -41,20 +41,16 @@ class SpeciesTorsion;
 class ForceKernel
 {
     public:
-    ForceKernel(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, Array<double> &fx,
-                Array<double> &fy, Array<double> &fz, double cutoffDistance = -1.0);
-    ~ForceKernel();
+    ForceKernel(ProcessPool &procPool, const Box *box, const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy,
+                Array<double> &fz, double cutoffDistance = -1.0);
+    ~ForceKernel() = default;
 
     /*
      * Source Data
      */
     protected:
-    // Source Configuration
-    const Configuration *configuration_;
     // Source Box (from Configuration)
     const Box *box_;
-    // Source CellArray (from Configuration)
-    const CellArray &cells_;
     // Potential map to use
     const PotentialMap &potentialMap_;
     // Squared cutoff distance to use in calculation
@@ -93,17 +89,38 @@ class ForceKernel
     /*
      * Intramolecular Terms
      */
+    private:
+    // Local calculated angle parameters
+    double theta_;
+    Vec3<double> dfi_dtheta_, dfk_dtheta_;
+    // Local calculated torsion parameters
+    double phi_;
+    Matrix3 dxpj_dij_, dxpj_dkj_, dxpk_dkj_, dxpk_dlk_;
+    Vec3<double> dcos_dxpj_, dcos_dxpk_;
+
+    private:
+    // Calculate angle force parameters from supplied vectors, storing result in local class variables
+    void calculateAngleParameters(Vec3<double> vecji, Vec3<double> vecjk);
+    // Calculate torsion force parameters from supplied vectors, storing result in local class variables
+    void calculateTorsionParameters(const Vec3<double> vecji, const Vec3<double> vecjk, const Vec3<double> veckl);
+
     public:
     // Calculate SpeciesBond forces
     void forces(const SpeciesBond *b, const Atom *i, const Atom *j);
+    // Calculate SpeciesBond forces
+    void forces(const SpeciesBond *b);
     // Calculate SpeciesBond forces for specified Atom only
     void forces(const Atom *onlyThis, const SpeciesBond *b, const Atom *i, const Atom *j);
     // Calculate SpeciesAngle forces
     void forces(const SpeciesAngle *a, const Atom *i, const Atom *j, const Atom *k);
+    // Calculate SpeciesAngle forces
+    void forces(const SpeciesAngle *a);
     // Calculate SpeciesAngle forces for specified Atom only
     void forces(const Atom *onlyThis, const SpeciesAngle *a, const Atom *i, const Atom *j, const Atom *k);
     // Calculate SpeciesTorsion forces
     void forces(const SpeciesTorsion *t, const Atom *i, const Atom *j, const Atom *k, const Atom *l);
+    // Calculate SpeciesTorsion forces
+    void forces(const SpeciesTorsion *t);
     // Calculate SpeciesTorsion forces for specified Atom only
     void forces(const Atom *onlyThis, const SpeciesTorsion *t, const Atom *i, const Atom *j, const Atom *k, const Atom *l);
 

--- a/src/classes/potentialmap.cpp
+++ b/src/classes/potentialmap.cpp
@@ -135,7 +135,7 @@ double PotentialMap::energy(const Atom *i, const Atom *j, double r) const
     // interpolated potential
     PairPotential *pp = potentialMatrix_.constAt(i->masterTypeIndex(), j->masterTypeIndex());
     return pp->energy(r) +
-           (pp->includeCoulomb() ? pp->analyticCoulombEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r) : 0);
+           (pp->includeCoulomb() ? 0 : pp->analyticCoulombEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r));
 }
 
 // Return energy between SpeciesAtoms at distance specified
@@ -144,7 +144,7 @@ double PotentialMap::energy(const SpeciesAtom *i, const SpeciesAtom *j, double r
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     PairPotential *pp = potentialMatrix_.constAt(i->atomType()->index(), j->atomType()->index());
-    return pp->energy(r) + (pp->includeCoulomb() ? pp->analyticCoulombEnergy(i->charge() * j->charge(), r) : 0);
+    return pp->energy(r) + (pp->includeCoulomb() ? 0 : pp->analyticCoulombEnergy(i->charge() * j->charge(), r));
 }
 
 // Return analytic energy between Atom types at distance specified
@@ -174,10 +174,8 @@ double PotentialMap::analyticEnergy(const Atom *i, const Atom *j, double r) cons
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being local to the atom
     // types
     PairPotential *pp = potentialMatrix_.constAt(i->masterTypeIndex(), j->masterTypeIndex());
-    if (pp->includeCoulomb())
-        pp->analyticEnergy(r);
-    else
-        return (pp->analyticEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r));
+    return pp->includeCoulomb() ? pp->analyticEnergy(r)
+                                : pp->analyticEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r);
 }
 
 // Return force between Atoms at distance specified
@@ -214,10 +212,9 @@ double PotentialMap::force(const Atom *i, const Atom *j, double r) const
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     PairPotential *pp = potentialMatrix_.constAt(i->masterTypeIndex(), j->masterTypeIndex());
-    if (pp->includeCoulomb())
-        return pp->force(r);
-    else
-        return (pp->force(r) + pp->analyticCoulombForce(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r));
+    return pp->includeCoulomb()
+               ? pp->force(r)
+               : pp->force(r) + pp->analyticCoulombForce(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r);
 }
 
 // Return force between SpeciesAtoms at distance specified
@@ -226,10 +223,7 @@ double PotentialMap::force(const SpeciesAtom *i, const SpeciesAtom *j, double r)
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     PairPotential *pp = potentialMatrix_.constAt(i->atomType()->index(), j->atomType()->index());
-    if (pp->includeCoulomb())
-        return pp->force(r);
-    else
-        return (pp->force(r) + pp->analyticCoulombForce(i->charge() * j->charge(), r));
+    return pp->includeCoulomb() ? pp->force(r) : pp->force(r) + pp->analyticCoulombForce(i->charge() * j->charge(), r);
 }
 
 // Return analytic force between Atom types at distance specified
@@ -259,8 +253,6 @@ double PotentialMap::analyticForce(const Atom *i, const Atom *j, double r) const
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     PairPotential *pp = potentialMatrix_.constAt(i->masterTypeIndex(), j->masterTypeIndex());
-    if (pp->includeCoulomb())
-        return pp->analyticForce(r);
-    else
-        return (pp->analyticForce(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r));
+    return pp->includeCoulomb() ? pp->analyticForce(r)
+                                : pp->analyticForce(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r);
 }

--- a/src/classes/potentialmap.cpp
+++ b/src/classes/potentialmap.cpp
@@ -140,6 +140,18 @@ double PotentialMap::energy(const Atom *i, const Atom *j, double r) const
         return (pp->energy(r) + pp->analyticCoulombEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r));
 }
 
+// Return energy between master atom types at distance specified
+double PotentialMap::energy(const SpeciesAtom *i, const SpeciesAtom *j, double r) const
+{
+    // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
+    // interpolated potential
+    PairPotential *pp = potentialMatrix_.constAt(i->atomType()->index(), j->atomType()->index());
+    if (pp->includeCoulomb())
+        return pp->energy(r);
+    else
+        return (pp->energy(r) + pp->analyticCoulombEnergy(i->charge() * j->charge(), r));
+}
+
 // Return analytic energy between Atom types at squared distance specified
 double PotentialMap::analyticEnergy(const Atom *i, const Atom *j, double r) const
 {

--- a/src/classes/potentialmap.cpp
+++ b/src/classes/potentialmap.cpp
@@ -100,7 +100,7 @@ double PotentialMap::range() const { return range_; }
  * Energy / Force
  */
 
-// Return energy between Atom types at squared distance specified
+// Return energy between Atoms at distance specified
 double PotentialMap::energy(const Atom *i, const Atom *j, double r) const
 {
 #ifdef CHECKS
@@ -140,7 +140,7 @@ double PotentialMap::energy(const Atom *i, const Atom *j, double r) const
         return (pp->energy(r) + pp->analyticCoulombEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r));
 }
 
-// Return energy between master atom types at distance specified
+// Return energy between SpeciesAtoms at distance specified
 double PotentialMap::energy(const SpeciesAtom *i, const SpeciesAtom *j, double r) const
 {
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
@@ -152,7 +152,7 @@ double PotentialMap::energy(const SpeciesAtom *i, const SpeciesAtom *j, double r
         return (pp->energy(r) + pp->analyticCoulombEnergy(i->charge() * j->charge(), r));
 }
 
-// Return analytic energy between Atom types at squared distance specified
+// Return analytic energy between Atom types at distance specified
 double PotentialMap::analyticEnergy(const Atom *i, const Atom *j, double r) const
 {
 #ifdef CHECKS
@@ -185,7 +185,7 @@ double PotentialMap::analyticEnergy(const Atom *i, const Atom *j, double r) cons
         return (pp->analyticEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r));
 }
 
-// Return force between Atom types at squared distance specified
+// Return force between Atoms at distance specified
 double PotentialMap::force(const Atom *i, const Atom *j, double r) const
 {
 #ifdef CHECKS

--- a/src/classes/potentialmap.cpp
+++ b/src/classes/potentialmap.cpp
@@ -134,10 +134,8 @@ double PotentialMap::energy(const Atom *i, const Atom *j, double r) const
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     PairPotential *pp = potentialMatrix_.constAt(i->masterTypeIndex(), j->masterTypeIndex());
-    if (pp->includeCoulomb())
-        return pp->energy(r);
-    else
-        return (pp->energy(r) + pp->analyticCoulombEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r));
+    return pp->energy(r) +
+           (pp->includeCoulomb() ? pp->analyticCoulombEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r) : 0);
 }
 
 // Return energy between SpeciesAtoms at distance specified
@@ -146,10 +144,7 @@ double PotentialMap::energy(const SpeciesAtom *i, const SpeciesAtom *j, double r
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     PairPotential *pp = potentialMatrix_.constAt(i->atomType()->index(), j->atomType()->index());
-    if (pp->includeCoulomb())
-        return pp->energy(r);
-    else
-        return (pp->energy(r) + pp->analyticCoulombEnergy(i->charge() * j->charge(), r));
+    return pp->energy(r) + (pp->includeCoulomb() ? pp->analyticCoulombEnergy(i->charge() * j->charge(), r) : 0);
 }
 
 // Return analytic energy between Atom types at distance specified

--- a/src/classes/potentialmap.cpp
+++ b/src/classes/potentialmap.cpp
@@ -225,7 +225,19 @@ double PotentialMap::force(const Atom *i, const Atom *j, double r) const
         return (pp->force(r) + pp->analyticCoulombForce(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r));
 }
 
-// Return analytic force between Atom types at squared distance specified
+// Return force between SpeciesAtoms at distance specified
+double PotentialMap::force(const SpeciesAtom *i, const SpeciesAtom *j, double r) const
+{
+    // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
+    // interpolated potential
+    PairPotential *pp = potentialMatrix_.constAt(i->atomType()->index(), j->atomType()->index());
+    if (pp->includeCoulomb())
+        return pp->force(r);
+    else
+        return (pp->force(r) + pp->analyticCoulombForce(i->charge() * j->charge(), r));
+}
+
+// Return analytic force between Atom types at distance specified
 double PotentialMap::analyticForce(const Atom *i, const Atom *j, double r) const
 {
 #ifdef CHECKS

--- a/src/classes/potentialmap.h
+++ b/src/classes/potentialmap.h
@@ -28,6 +28,7 @@
 class PairPotential;
 class Atom;
 class Molecule;
+class SpeciesAtom;
 
 // PotentialMap Definition
 class PotentialMap
@@ -60,8 +61,10 @@ class PotentialMap
      * Energy / Force
      */
     public:
-    // Return energy between Atom types at distance specified
+    // Return energy between Atoms at distance specified
     double energy(const Atom *i, const Atom *j, double r) const;
+    // Return energy between SpeciesAtoms at distance specified
+    double energy(const SpeciesAtom *i, const SpeciesAtom *j, double r) const;
     // Return analytic energy between Atom types at distance specified
     double analyticEnergy(const Atom *i, const Atom *j, double r) const;
     // Return force between Atom types at distance specified

--- a/src/classes/potentialmap.h
+++ b/src/classes/potentialmap.h
@@ -67,8 +67,10 @@ class PotentialMap
     double energy(const SpeciesAtom *i, const SpeciesAtom *j, double r) const;
     // Return analytic energy between Atom types at distance specified
     double analyticEnergy(const Atom *i, const Atom *j, double r) const;
-    // Return force between Atom types at distance specified
+    // Return force between Atoms at distance specified
     double force(const Atom *i, const Atom *j, double r) const;
+    // Return force between SpeciesAtoms at distance specified
+    double force(const SpeciesAtom *i, const SpeciesAtom *j, double r) const;
     // Return analytic force between Atom types at distance specified
     double analyticForce(const Atom *i, const Atom *j, double r) const;
 };

--- a/src/classes/species_transform.cpp
+++ b/src/classes/species_transform.cpp
@@ -50,6 +50,8 @@ void Species::setCentre(const Box *box, const Vec3<double> newCentre)
             newR = box->minimumVector(i->r(), cog) + newCentre;
             i->setCoordinates(newR);
         }
+
+    ++version_;
 }
 
 // Centre coordinates at origin
@@ -61,4 +63,6 @@ void Species::centreAtOrigin()
     centre /= atoms_.nItems();
     for (auto *i = atoms_.first(); i != NULL; i = i->next())
         i->translateCoordinates(-centre);
+
+    ++version_;
 }

--- a/src/gui/specieseditor.h
+++ b/src/gui/specieseditor.h
@@ -24,7 +24,7 @@
 #include "gui/ui_specieseditor.h"
 
 // Forward Declarations
-class CoreData;
+class Dissolve;
 
 // Species Widget
 class SpeciesEditor : public QWidget
@@ -37,12 +37,12 @@ class SpeciesEditor : public QWidget
     ~SpeciesEditor();
 
     private:
-    // Main CoreData
-    CoreData *coreData_;
+    // Main Dissolve pointer
+    Dissolve *dissolve_;
 
     public:
-    // Set main CoreData pointer
-    void setCoreData(CoreData *coreData);
+    // Set main Dissolve pointer
+    void setDissolve(Dissolve *dissolve);
 
     /*
      * UI

--- a/src/gui/specieseditor_funcs.cpp
+++ b/src/gui/specieseditor_funcs.cpp
@@ -25,12 +25,15 @@
 #include "gui/specieseditor.h"
 #include "gui/widgets/elementselector.hui"
 #include "main/dissolve.h"
+#include "modules/geomopt/geomopt.h"
 #include "procedure/nodes/addspecies.h"
 #include "procedure/nodes/box.h"
 #include <QButtonGroup>
 
 SpeciesEditor::SpeciesEditor(QWidget *parent) : QWidget(parent)
 {
+    dissolve_ = nullptr;
+
     // Set up our UI
     ui_.setupUi(this);
 
@@ -53,8 +56,8 @@ SpeciesEditor::SpeciesEditor(QWidget *parent) : QWidget(parent)
 
 SpeciesEditor::~SpeciesEditor() {}
 
-// Set main CoreData pointer
-void SpeciesEditor::setCoreData(CoreData *coreData) { coreData_ = coreData; }
+// Set main Dissolve pointer
+void SpeciesEditor::setDissolve(Dissolve *dissolve) { dissolve_ = dissolve; }
 
 /*
  * UI
@@ -95,7 +98,7 @@ void SpeciesEditor::updateToolbar()
 void SpeciesEditor::updateStatusBar()
 {
     // Get displayed Species
-    const Species *sp = speciesViewer()->species();
+    const auto *sp = speciesViewer()->species();
 
     // Set interaction mode text
     ui_.ModeLabel->setText(speciesViewer()->interactionModeText());
@@ -187,7 +190,7 @@ void SpeciesEditor::on_ViewCopyToClipboardButton_clicked(bool checked) { species
 void SpeciesEditor::on_ToolsCalculateBondingButton_clicked(bool checked)
 {
     // Get displayed Species
-    Species *sp = speciesViewer()->species();
+    auto *sp = speciesViewer()->species();
     if (!sp)
         return;
 
@@ -202,55 +205,20 @@ void SpeciesEditor::on_ToolsCalculateBondingButton_clicked(bool checked)
 void SpeciesEditor::on_ToolsMinimiseButton_clicked(bool checked)
 {
     // Get displayed Species
-    Species *sp = speciesViewer()->species();
+    auto *sp = speciesViewer()->species();
     if (!sp)
         return;
 
     // Apply forcefield terms now?
     if (sp->forcefield())
-    {
-        sp->applyForcefieldTerms(*coreData_);
-    }
+        sp->applyForcefieldTerms(dissolve_->coreData());
 
     // Check that the Species set up is valid
     if (!sp->checkSetUp())
         return;
 
-    // Create a temporary CoreData and Dissolve
-    CoreData temporaryCoreData;
-    Dissolve temporaryDissolve(temporaryCoreData);
-    if (!temporaryDissolve.registerMasterModules())
-        return;
-
-    // Copy our target species to the temporary structure, and create a simple Configuration from it
-    Species *temporarySpecies = temporaryDissolve.copySpecies(sp);
-    Configuration *temporaryCfg = temporaryDissolve.addConfiguration();
-    Procedure &generator = temporaryCfg->generator();
-    generator.addRootSequenceNode(new BoxProcedureNode(Vec3<double>(1.0, 1.0, 1.0), Vec3<double>(90, 90, 90), true));
-    AddSpeciesProcedureNode *addSpeciesNode = new AddSpeciesProcedureNode(temporarySpecies, 1, 0.0001);
-    addSpeciesNode->setKeyword<bool>("Rotate", false);
-    addSpeciesNode->setEnumeration<AddSpeciesProcedureNode::PositioningType>("Positioning",
-                                                                             AddSpeciesProcedureNode::CentralPositioning);
-    generator.addRootSequenceNode(addSpeciesNode);
-    if (!temporaryCfg->initialiseContent(temporaryDissolve.worldPool(), 15.0))
-        return;
-
-    // Create a Geometry Optimisation Module in a new processing layer, and set everything up
-    if (!temporaryDissolve.createModuleInLayer("GeometryOptimisation", "Processing", temporaryCfg))
-        return;
-    if (!temporaryDissolve.generatePairPotentials())
-        return;
-
-    // Run the calculation
-    if (!temporaryDissolve.prepare())
-        return;
-    temporaryDissolve.iterate(1);
-
-    // Copy the optimised coordinates from the temporary Configuration to the target Species
-    ListIterator<SpeciesAtom> atomIterator(sp->atoms());
-    auto index = 0;
-    while (SpeciesAtom *i = atomIterator.iterate())
-        sp->setAtomCoordinates(i, temporaryCfg->atom(index++)->r());
+    GeometryOptimisationModule optimiser;
+    optimiser.optimiseSpecies(*dissolve_, dissolve_->worldPool(), sp);
 
     // Centre the Species back at the origin
     sp->centreAtOrigin();

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -68,7 +68,7 @@ SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainT
     ui_.ImproperTable->horizontalHeader()->setVisible(true);
 
     // Set up SpeciesViewer
-    ui_.ViewerWidget->setCoreData(&dissolve.coreData());
+    ui_.ViewerWidget->setDissolve(&dissolve);
     ui_.ViewerWidget->setSpecies(species_);
 
     // Set up SiteViewer

--- a/src/gui/specieswidget.h
+++ b/src/gui/specieswidget.h
@@ -24,7 +24,7 @@
 #include "gui/ui_specieswidget.h"
 
 // Forward Declarations
-class CoreData;
+class Dissolve;
 
 // Species Widget
 class SpeciesWidget : public QWidget
@@ -34,15 +34,15 @@ class SpeciesWidget : public QWidget
 
     public:
     SpeciesWidget(QWidget *parent = 0);
-    ~SpeciesWidget();
+    ~SpeciesWidget() = default;
 
     private:
-    // Main CoreData
-    CoreData *coreData_;
+    // Main Dissolve pointer
+    Dissolve *dissolve_;
 
     public:
-    // Set main CoreData pointer
-    void setCoreData(CoreData *coreData);
+    // Set main Dissolve pointer
+    void setDissolve(Dissolve *dissolve);
 
     /*
      * UI

--- a/src/gui/specieswidget_funcs.cpp
+++ b/src/gui/specieswidget_funcs.cpp
@@ -74,7 +74,7 @@ void SpeciesWidget::updateToolbar()
 void SpeciesWidget::updateStatusBar()
 {
     // Get displayed Species
-    const Species *sp = speciesViewer()->species();
+    const auto *sp = speciesViewer()->species();
 
     // Set interaction mode text
     ui_.ModeLabel->setText(speciesViewer()->interactionModeText());
@@ -134,7 +134,7 @@ void SpeciesWidget::on_ViewCopyToClipboardButton_clicked(bool checked) { species
 void SpeciesWidget::on_ToolsCalculateBondingButton_clicked(bool checked)
 {
     // Get displayed Species
-    Species *sp = speciesViewer()->species();
+    auto *sp = speciesViewer()->species();
     if (!sp)
         return;
 
@@ -149,15 +149,13 @@ void SpeciesWidget::on_ToolsCalculateBondingButton_clicked(bool checked)
 void SpeciesWidget::on_ToolsMinimiseButton_clicked(bool checked)
 {
     // Get displayed Species
-    Species *sp = speciesViewer()->species();
+    auto *sp = speciesViewer()->species();
     if (!sp)
         return;
 
     // Apply forcefield terms now?
     if (sp->forcefield())
-    {
         sp->applyForcefieldTerms(*coreData_);
-    }
 
     // Check that the Species set up is valid
     if (!sp->checkSetUp())

--- a/src/gui/specieswidget_funcs.cpp
+++ b/src/gui/specieswidget_funcs.cpp
@@ -25,12 +25,15 @@
 #include "gui/specieswidget.h"
 #include "gui/widgets/elementselector.hui"
 #include "main/dissolve.h"
+#include "modules/geomopt/geomopt.h"
 #include "procedure/nodes/addspecies.h"
 #include "procedure/nodes/box.h"
 #include <QButtonGroup>
 
 SpeciesWidget::SpeciesWidget(QWidget *parent) : QWidget(parent)
 {
+    dissolve_ = nullptr;
+
     // Set up our UI
     ui_.setupUi(this);
 
@@ -44,10 +47,8 @@ SpeciesWidget::SpeciesWidget(QWidget *parent) : QWidget(parent)
     updateStatusBar();
 }
 
-SpeciesWidget::~SpeciesWidget() {}
-
-// Set main CoreData pointer
-void SpeciesWidget::setCoreData(CoreData *coreData) { coreData_ = coreData; }
+// Set main Dissolve pointer
+void SpeciesWidget::setDissolve(Dissolve *dissolve) { dissolve_ = dissolve; }
 
 /*
  * UI
@@ -155,47 +156,14 @@ void SpeciesWidget::on_ToolsMinimiseButton_clicked(bool checked)
 
     // Apply forcefield terms now?
     if (sp->forcefield())
-        sp->applyForcefieldTerms(*coreData_);
+        sp->applyForcefieldTerms(dissolve_->coreData());
 
     // Check that the Species set up is valid
     if (!sp->checkSetUp())
         return;
 
-    // Create a temporary CoreData and Dissolve
-    CoreData temporaryCoreData;
-    Dissolve temporaryDissolve(temporaryCoreData);
-    if (!temporaryDissolve.registerMasterModules())
-        return;
-
-    // Copy our target species to the temporary structure, and create a simple Configuration from it
-    Species *temporarySpecies = temporaryDissolve.copySpecies(sp);
-    Configuration *temporaryCfg = temporaryDissolve.addConfiguration();
-    Procedure &generator = temporaryCfg->generator();
-    generator.addRootSequenceNode(new BoxProcedureNode(Vec3<double>(1.0, 1.0, 1.0), Vec3<double>(90, 90, 90), true));
-    AddSpeciesProcedureNode *addSpeciesNode = new AddSpeciesProcedureNode(temporarySpecies, 1, 0.0001);
-    addSpeciesNode->setKeyword<bool>("Rotate", false);
-    addSpeciesNode->setEnumeration<AddSpeciesProcedureNode::PositioningType>("Positioning",
-                                                                             AddSpeciesProcedureNode::CentralPositioning);
-    generator.addRootSequenceNode(addSpeciesNode);
-    if (!temporaryCfg->initialiseContent(temporaryDissolve.worldPool(), 15.0))
-        return;
-
-    // Create a Geometry Optimisation Module in a new processing layer, and set everything up
-    if (!temporaryDissolve.createModuleInLayer("GeometryOptimisation", "Processing", temporaryCfg))
-        return;
-    if (!temporaryDissolve.generatePairPotentials())
-        return;
-
-    // Run the calculation
-    if (!temporaryDissolve.prepare())
-        return;
-    temporaryDissolve.iterate(1);
-
-    // Copy the optimised coordinates from the temporary Configuration to the target Species
-    ListIterator<SpeciesAtom> atomIterator(sp->atoms());
-    auto index = 0;
-    while (SpeciesAtom *i = atomIterator.iterate())
-        sp->setAtomCoordinates(i, temporaryCfg->atom(index++)->r());
+    GeometryOptimisationModule optimiser;
+    optimiser.optimiseSpecies(*dissolve_, dissolve_->worldPool(), sp);
 
     // Centre the Species back at the origin
     sp->centreAtOrigin();

--- a/src/math/matrix3.cpp
+++ b/src/math/matrix3.cpp
@@ -670,13 +670,9 @@ Vec3<double> Matrix3::transform(Vec3<double> vec) const
  */
 
 // Construct 'cross-product' matrix of the supplied vector using cyclic permutations
-void Matrix3::makeCrossProductMatrix(Vec3<double> &v)
+void Matrix3::makeCrossProductMatrix(const Vec3<double> &v)
 {
-    Vec3<double> temp;
-    for (int n = 0; n < 3; ++n)
-    {
-        temp = Vec3<double>::unit(DissolveMath::cp3(n + 1)) * v.get(DissolveMath::cp3(n + 2)) -
-               Vec3<double>::unit(DissolveMath::cp3(n + 2)) * v.get(DissolveMath::cp3(n + 1));
-        setColumn(n, temp);
-    }
+    for (auto n = 0; n < 3; ++n)
+        setColumn(n, Vec3<double>::unit(DissolveMath::cp3(n + 1)) * v.get(DissolveMath::cp3(n + 2)) -
+                         Vec3<double>::unit(DissolveMath::cp3(n + 2)) * v.get(DissolveMath::cp3(n + 1)));
 }

--- a/src/math/matrix3.h
+++ b/src/math/matrix3.h
@@ -146,5 +146,5 @@ class Matrix3
      */
     public:
     // Construct 'cross-product' matrix of the supplied vector using cyclic permutations
-    void makeCrossProductMatrix(Vec3<double> &v);
+    void makeCrossProductMatrix(const Vec3<double> &v);
 };

--- a/src/modules/calibration/process.cpp
+++ b/src/modules/calibration/process.cpp
@@ -63,10 +63,10 @@ bool CalibrationModule::process(Dissolve &dissolve, ProcessPool &procPool)
          */
         if (onlyWhenEnergyStable)
         {
-            auto stabilityResult = EnergyModule::checkStability(configs);
-            if (stabilityResult == -1)
+            auto stabilityResult = EnergyModule::nUnstable(configs);
+            if (stabilityResult == EnergyModule::NotAssessable)
                 return false;
-            else if (stabilityResult != 0)
+            else if (stabilityResult > 0)
             {
                 Messenger::print("At least one Configuration energy is not yet stable. No adjustments will be "
                                  "made this iteration.\n");

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -79,26 +79,30 @@ class EnergyModule : public Module
      * Functions
      */
     public:
-    // Return total intramolecular energy
-    static double intraMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
-    // Return total intramolecular energy, storing components in provided variables
-    static double intraMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
-                                       double &bondEnergy, double &angleEnergy, double &torsionEnergy);
-    // Return total interatomic energy
+    // Energy Stability Enum
+    enum EnergyStability {
+        NotAssessable = -1,
+        EnergyStable = 0,
+        EnergyUnstable = 1
+    };
+    // Return total interatomic energy of Configuration
     static double interAtomicEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
-    // Return total energy (interatomic and intramolecular)
-    static double totalEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
-    // Return total energy (interatomic and intramolecular), storing components in provided variables
-    static double totalEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, double &interEnergy,
-                              double &bondEnergy, double &angleEnergy, double &torsionEnergy);
     // Return total intermolecular energy
     static double interMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
-    // Check energy stability of specified Configuration, returning 1 if the energy is not stable, or -1 if stability could
-    // not be assessed
-    static int checkStability(Configuration *cfg);
-    // Check energy stability of specified Configurations, returning the number that failed, or -1 if stability could not be
-    // assessed
-    static int checkStability(const RefList<Configuration> &configurations);
+    // Return total intramolecular energy of Configuration
+    static double intraMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
+    // Return total intramolecular energy of Configuration, storing components in provided variables
+    static double intraMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
+                                       double &bondEnergy, double &angleEnergy, double &torsionEnergy);
+    // Return total energy (interatomic and intramolecular) of Configuration
+    static double totalEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
+    // Return total energy (interatomic and intramolecular) of Configuration, storing components in provided variables
+    static double totalEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, double &interEnergy,
+                              double &bondEnergy, double &angleEnergy, double &torsionEnergy);
+    // Check energy stability of specified Configuration
+    static EnergyStability checkStability(Configuration *cfg);
+    // Check energy stability of specified Configurations, returning the number that are unstable
+    static int nUnstable(const RefList<Configuration> &configurations);
 
     /*
      * GUI Widget

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -80,13 +80,16 @@ class EnergyModule : public Module
      */
     public:
     // Energy Stability Enum
-    enum EnergyStability {
+    enum EnergyStability
+    {
         NotAssessable = -1,
         EnergyStable = 0,
         EnergyUnstable = 1
     };
     // Return total interatomic energy of Configuration
     static double interAtomicEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
+    // Return total interatomic energy of Species
+    static double interAtomicEnergy(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap);
     // Return total intermolecular energy
     static double interMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
     // Return total intramolecular energy of Configuration
@@ -94,11 +97,15 @@ class EnergyModule : public Module
     // Return total intramolecular energy of Configuration, storing components in provided variables
     static double intraMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
                                        double &bondEnergy, double &angleEnergy, double &torsionEnergy);
+    // Return total intramolecular energy of Species
+    static double intraMolecularEnergy(ProcessPool &procPool, Species *sp);
     // Return total energy (interatomic and intramolecular) of Configuration
     static double totalEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
     // Return total energy (interatomic and intramolecular) of Configuration, storing components in provided variables
     static double totalEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, double &interEnergy,
                               double &bondEnergy, double &angleEnergy, double &torsionEnergy);
+    // Return total energy (interatomic and intramolecular) of Species
+    static double totalEnergy(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap);
     // Check energy stability of specified Configuration
     static EnergyStability checkStability(Configuration *cfg);
     // Check energy stability of specified Configurations, returning the number that are unstable

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -225,11 +225,6 @@ double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Species *sp)
     while (const SpeciesTorsion *t = torsionIterator.iterate())
         energy += EnergyKernel::energy(t);
 
-    // Loop over impropers
-    DynamicArrayConstIterator<SpeciesImproper> improperIterator(sp->constImpropers());
-    while (const SpeciesImproper *i = improperIterator.iterate())
-        energy += EnergyKernel::energy(i);
-
     return energy;
 }
 

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -70,6 +70,7 @@ double EnergyModule::interAtomicEnergy(ProcessPool &procPool, Species *sp, const
     auto loopEnd = procPool.twoBodyLoopEnd(sp->nAtoms());
 
     // Double loop over species atoms
+    // NOTE PR #334 : use for_each_pair
     for (auto indexI = loopStart; indexI <= loopEnd; ++indexI)
     {
         i = sp->atom(indexI);

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -200,7 +200,7 @@ int EnergyModule::checkStability(Configuration *cfg)
         if (!stable)
         {
             Messenger::print("Energy for Configuration '%s' is not yet stable.\n", cfg->name());
-            return Module::ExactlyOneTarget;
+            return 1;
         }
     }
     else
@@ -210,7 +210,7 @@ int EnergyModule::checkStability(Configuration *cfg)
         return -1;
     }
 
-    return Module::ZeroTargets;
+    return 0;
 }
 
 // Check energy stability of specified Configurations, returning the number that failed, or -1 if stability could not be

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -290,10 +290,10 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
     if (onlyWhenEnergyStable)
     {
-        auto stabilityResult = EnergyModule::checkStability(configs);
-        if (stabilityResult == -1)
+        auto stabilityResult = EnergyModule::nUnstable(configs);
+        if (stabilityResult == EnergyModule::NotAssessable)
             return false;
-        else if (stabilityResult != 0)
+        else if (stabilityResult > 0)
         {
             Messenger::print("At least one Configuration energy is not yet stable. No potential refinement will be "
                              "performed this iteration.\n");

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -86,24 +86,24 @@ class ForcesModule : public Module
     bool setUp(Dissolve &dissolve, ProcessPool &procPool);
 
     /*
-     * Force Methods
+     * Functions
      */
     public:
-    // Calculate total intramolecular forces
-    static void intramolecularForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
-                                     Array<double> &fx, Array<double> &fy, Array<double> &fz);
     // Calculate interatomic forces within the specified Configuration
-    static void interatomicForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
+    static void interAtomicForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
                                   Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    // Calculate interatomic forces on specified atoms within the specified Configuration
+    static void interAtomicForces(ProcessPool &procPool, Configuration *cfg, const Array<int> &targetIndices,
+                                  const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    // Calculate total intramolecular forces acting on specific atoms in the Configuration
+    static void intraMolecularForces(ProcessPool &procPool, Configuration *cfg, const Array<int> &targetIndices,
+                                     const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    // Calculate total intramolecular forces in Configuration
+    static void intraMolecularForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
+                                     Array<double> &fx, Array<double> &fy, Array<double> &fz);
     // Calculate total forces within the specified Configuration
     static void totalForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, Array<double> &fx,
                             Array<double> &fy, Array<double> &fz);
-    // Calculate total intramolecular forces acting on specific atoms
-    static void intramolecularForces(ProcessPool &procPool, Configuration *cfg, const Array<int> &targetIndices,
-                                     const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
-    // Calculate interatomic forces on specified atoms within the specified Configuration
-    static void interatomicForces(ProcessPool &procPool, Configuration *cfg, const Array<int> &targetIndices,
-                                  const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
     // Calculate forces acting on specific atoms within the specified Configuration (arising from all atoms)
     static void totalForces(ProcessPool &procPool, Configuration *cfg, const Array<int> &targetIndices,
                             const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -95,12 +95,18 @@ class ForcesModule : public Module
     // Calculate interatomic forces on specified atoms within the specified Configuration
     static void interAtomicForces(ProcessPool &procPool, Configuration *cfg, const Array<int> &targetIndices,
                                   const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    // Calculate interatomic forces within the specified Species
+    static void interAtomicForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap, Array<double> &fx,
+                                  Array<double> &fy, Array<double> &fz);
     // Calculate total intramolecular forces acting on specific atoms in the Configuration
     static void intraMolecularForces(ProcessPool &procPool, Configuration *cfg, const Array<int> &targetIndices,
                                      const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
     // Calculate total intramolecular forces in Configuration
     static void intraMolecularForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
                                      Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    // Calculate total intramolecular forces in Species
+    static void intraMolecularForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap, Array<double> &fx,
+                                     Array<double> &fy, Array<double> &fz);
     // Calculate total forces within the specified Configuration
     static void totalForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, Array<double> &fx,
                             Array<double> &fy, Array<double> &fz);
@@ -110,4 +116,7 @@ class ForcesModule : public Module
     // Calculate forces acting on specific Molecules within the specified Configuration (arising from all atoms)
     static void totalForces(ProcessPool &procPool, Configuration *cfg, const Array<std::shared_ptr<Molecule>> &targetMolecules,
                             const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    // Calculate total forces within the specified Species
+    static void totalForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap, Array<double> &fx,
+                            Array<double> &fy, Array<double> &fz);
 };

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -39,7 +39,7 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, 
     const CellArray &cellArray = cfg->cells();
 
     // Create a ForceKernel
-    ForceKernel kernel(procPool, cfg, potentialMap, fx, fy, fz);
+    ForceKernel kernel(procPool, cfg->box(), potentialMap, fx, fy, fz);
 
     Cell *cell;
 
@@ -81,7 +81,7 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, 
      */
 
     // Create a ForceKernel
-    ForceKernel kernel(procPool, cfg, potentialMap, fx, fy, fz);
+    ForceKernel kernel(procPool, cfg->box(), potentialMap, fx, fy, fz);
 
     ProcessPool::DivisionStrategy strategy = ProcessPool::PoolStrategy;
 
@@ -115,7 +115,7 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
      */
 
     // Create a ForceKernel
-    ForceKernel kernel(procPool, cfg, potentialMap, fx, fy, fz);
+    ForceKernel kernel(procPool, cfg->box(), potentialMap, fx, fy, fz);
 
     // Set start/stride for parallel loop
     auto start = procPool.interleavedLoopStart(ProcessPool::PoolStrategy);
@@ -165,7 +165,7 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
      */
 
     // Create a ForceKernel
-    ForceKernel kernel(procPool, cfg, potentialMap, fx, fy, fz);
+    ForceKernel kernel(procPool, cfg->box(), potentialMap, fx, fy, fz);
 
     // Set start/stride for parallel loop
     auto start = procPool.interleavedLoopStart(ProcessPool::PoolStrategy);

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -188,19 +188,19 @@ void ForcesModule::intramolecularForces(ProcessPool &procPool, Configuration *cf
         const SpeciesAtom *spAtom = i->speciesAtom();
         std::shared_ptr<const Molecule> mol = i->molecule();
 
-        // Calcualte forces from SpeciesBond terms
+        // Calculate forces from SpeciesBond terms
         for (const auto *bond : spAtom->bonds())
         {
             kernel.forces(i, bond, mol->atom(bond->indexI()), mol->atom(bond->indexJ()));
         }
 
-        // Add energy from SpeciesAngle terms
+        // Calculate forces from SpeciesAngle terms
         for (const auto *angle : spAtom->angles())
         {
             kernel.forces(i, angle, mol->atom(angle->indexI()), mol->atom(angle->indexJ()), mol->atom(angle->indexK()));
         }
 
-        // Add energy from SpeciesTorsion terms
+        // Calculate forces from SpeciesTorsion terms
         for (const auto *torsion : spAtom->torsions())
         {
             kernel.forces(i, torsion, mol->atom(torsion->indexI()), mol->atom(torsion->indexJ()), mol->atom(torsion->indexK()),

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -109,6 +109,7 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Species *sp, const P
     const auto cutoffSq = potentialMap.range() * potentialMap.range();
     Vec3<double> vecij;
     SpeciesAtom *j;
+    // NOTE PR #334 : use for_each_pair
     for (auto indexI = 0; indexI < sp->nAtoms() - 1; ++indexI)
     {
         auto *i = sp->atom(indexI);

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -391,7 +391,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 Timer interTimer;
                 interTimer.start();
 
-                interatomicForces(procPool, cfg, dissolve.potentialMap(), checkInterFx, checkInterFy, checkInterFz);
+                interAtomicForces(procPool, cfg, dissolve.potentialMap(), checkInterFx, checkInterFy, checkInterFz);
                 if (!procPool.allSum(checkInterFx, cfg->nAtoms()))
                     return false;
                 if (!procPool.allSum(checkInterFy, cfg->nAtoms()))
@@ -409,7 +409,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 Timer intraTimer;
                 intraTimer.start();
 
-                intramolecularForces(procPool, cfg, dissolve.potentialMap(), checkIntraFx, checkIntraFy, checkIntraFz);
+                intraMolecularForces(procPool, cfg, dissolve.potentialMap(), checkIntraFx, checkIntraFy, checkIntraFz);
                 if (!procPool.allSum(checkIntraFx, cfg->nAtoms()))
                     return false;
                 if (!procPool.allSum(checkIntraFy, cfg->nAtoms()))
@@ -639,14 +639,14 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
             // Calculate interatomic forces
             Timer interTimer;
             interTimer.start();
-            interatomicForces(procPool, cfg, dissolve.potentialMap(), fx, fy, fz);
+            interAtomicForces(procPool, cfg, dissolve.potentialMap(), fx, fy, fz);
             interTimer.stop();
             Messenger::printVerbose("Forces: Time to do interatomic forces was %s.\n", interTimer.totalTimeString());
 
             // Calculate intramolecular forces
             Timer intraTimer;
             intraTimer.start();
-            intramolecularForces(procPool, cfg, dissolve.potentialMap(), fx, fy, fz);
+            intraMolecularForces(procPool, cfg, dissolve.potentialMap(), fx, fy, fz);
             intraTimer.stop();
 
             Messenger::print("Forces: Time to do interatomic forces was %s, intramolecular forces was %s (%s comms).\n",

--- a/src/modules/geomopt/functions.cpp
+++ b/src/modules/geomopt/functions.cpp
@@ -25,7 +25,7 @@
 #include "modules/geomopt/geomopt.h"
 
 // Copy coordinates from supplied Configuration into reference arrays
-void GeometryOptimisationModule::setReferenceCoordinates(Configuration *cfg)
+template <> void GeometryOptimisationModule::setReferenceCoordinates(Configuration *cfg)
 {
     for (int n = 0; n < cfg->nAtoms(); ++n)
     {
@@ -37,7 +37,7 @@ void GeometryOptimisationModule::setReferenceCoordinates(Configuration *cfg)
 }
 
 // Revert Configuration to reference coordinates
-void GeometryOptimisationModule::revertToReferenceCoordinates(Configuration *cfg)
+template <> void GeometryOptimisationModule::revertToReferenceCoordinates(Configuration *cfg)
 {
     for (int n = 0; n < cfg->nAtoms(); ++n)
         cfg->atom(n)->setCoordinates(xRef_[n], yRef_[n], zRef_[n]);
@@ -83,6 +83,7 @@ void GeometryOptimisationModule::sortBoundsAndEnergies(Vec3<double> &bounds, Vec
 }
 
 // Return energy of adjusted coordinates, following the force vectors by the supplied amount
+template <>
 double GeometryOptimisationModule::energyAtGradientPoint(ProcessPool &procPool, Configuration *cfg,
                                                          const PotentialMap &potentialMap, double delta)
 {
@@ -92,150 +93,4 @@ double GeometryOptimisationModule::energyAtGradientPoint(ProcessPool &procPool, 
     cfg->updateCellContents();
 
     return EnergyModule::totalEnergy(procPool, cfg, potentialMap);
-}
-
-// Perform Golden Search within specified bounds
-double GeometryOptimisationModule::goldenSearch(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
-                                                const double tolerance, Vec3<double> &bounds, Vec3<double> &energies,
-                                                int &nPointsAccepted)
-{
-    // Ensure that the energy minimum is the midpoint
-    sortBoundsAndEnergies(bounds, energies);
-
-    // Check convergence, ready for early return
-    if (fabs(bounds.x - bounds.z) < tolerance)
-        return energies.y;
-
-    // Calculate deltas between bound values
-    double dxy = bounds[0] - bounds[1];
-    double dyz = bounds[2] - bounds[1];
-    Messenger::printVerbose("Trying Golden Search -  %f-%f-%f, dxy = %12.5e, dyz = %12.5e", bounds.x, bounds.y, bounds.z, dxy,
-                            dyz);
-
-    // Select largest of two intervals to be the target of the search
-    auto xyLargest = fabs(dxy) > fabs(dyz);
-    double newMinimum = bounds[1] + 0.3819660 * (xyLargest ? dxy : dyz);
-
-    // Test energy at new trial minimum
-    double eNew = energyAtGradientPoint(procPool, cfg, potentialMap, newMinimum);
-    Messenger::printVerbose("--> GOLD point is %12.5e [%12.5e] ", eNew, newMinimum);
-
-    // Set order for checking of energy points
-    Vec3<int> order(1, xyLargest ? 0 : 2, xyLargest ? 2 : 0);
-
-    // Check each energy to see if our new energy is lower. If it is, overwrite it and recurse
-    for (int n = 0; n < 3; ++n)
-    {
-        if (eNew < energies[order[n]])
-        {
-            Messenger::printVerbose("--> GOLD point is lower than point %i...", order[n]);
-
-            // Overwrite the outermost bound with the old minimum
-            bounds[xyLargest ? 0 : 2] = newMinimum;
-            energies[xyLargest ? 0 : 2] = eNew;
-
-            ++nPointsAccepted;
-
-            // Recurse into the new region
-            return goldenSearch(procPool, cfg, potentialMap, tolerance, bounds, energies, nPointsAccepted);
-        }
-    }
-
-    // Nothing better than the current central energy value, so revert to the stored reference coordinates
-    revertToReferenceCoordinates(cfg);
-
-    return energies.y;
-}
-
-// Line minimise supplied Configuration from the reference coordinates along the stored force vectors
-double GeometryOptimisationModule::lineMinimise(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
-                                                const double tolerance, double &stepSize)
-{
-    // Brent-style line minimiser with parabolic interpolation and Golden Search backup
-
-    // Set initial bounding values
-    Vec3<double> bounds, energies;
-    bounds.x = 0.0;
-    energies.x = EnergyModule::totalEnergy(procPool, cfg, potentialMap);
-    bounds.y = stepSize;
-    energies.y = energyAtGradientPoint(procPool, cfg, potentialMap, bounds.y);
-    bounds.z = 2.0 * stepSize;
-    energies.z = energyAtGradientPoint(procPool, cfg, potentialMap, bounds.z);
-
-    Messenger::printVerbose("Initial bounding values/energies = %12.5e (%12.5e) %12.5e (%12.5e) %12.5e (%12.5e)", bounds[0],
-                            energies[0], bounds[1], energies[1], bounds[2], energies[2]);
-
-    // Perform linesearch along the gradient vector
-    do
-    {
-        // Sort w.r.t. energy so that the minimum is in the central point
-        sortBoundsAndEnergies(bounds, energies);
-
-        Messenger::printVerbose("Energies [Bounds] = %12.5e (%12.5e) %12.5e (%12.5e) %12.5e (%12.5e)", energies[0], bounds[0],
-                                energies[1], bounds[1], energies[2], bounds[2]);
-
-        // Perform parabolic interpolation to find new minimium point
-        double b10 = bounds[1] - bounds[0];
-        double b12 = bounds[1] - bounds[2];
-        double a = (b10 * b10 * (energies[1] - energies[2])) - (b12 * b12 * (energies[1] - energies[0]));
-        double b = (b10 * (energies[1] - energies[2])) - (b12 * (energies[1] - energies[0]));
-        double newBound = bounds[1] - 0.5 * (a / b);
-
-        // Compute energy of new point and check that it went down...
-        double eNew = energyAtGradientPoint(procPool, cfg, potentialMap, newBound);
-
-        Messenger::printVerbose("PARABOLIC point gives energy %12.5e @ %12.5e", eNew, newBound);
-        if (eNew < energies[1])
-        {
-            // New point found...
-            Messenger::printVerbose("--> PARABOLIC point is new minimum...");
-
-            // Overwrite the largest of bounds[0] and bounds[2] with the old minimum
-            auto largest = energies[2] > energies[0] ? 2 : 0;
-            bounds.swap(1, largest);
-            energies.swap(1, largest);
-
-            // Set the new central values
-            bounds[1] = newBound;
-            energies[1] = eNew;
-        }
-        else if ((energies[2] - eNew) > tolerance)
-        {
-            Messenger::printVerbose("--> PARABOLIC point is better than bounds[2]...");
-            bounds[2] = newBound;
-            energies[2] = eNew;
-        }
-        else if ((energies[0] - eNew) > tolerance)
-        {
-            Messenger::printVerbose("--> PARABOLIC point is better than bounds[0]...");
-            bounds[0] = newBound;
-            energies[0] = eNew;
-        }
-        else
-        {
-            Messenger::printVerbose("--> PARABOLIC point is worse than all current values...");
-
-            // Revert to the stored reference coordinates
-            revertToReferenceCoordinates(cfg);
-
-            // Try recursive Golden Search instead, into the largest of the two sections
-            auto nPointsAccepted = 0;
-            goldenSearch(procPool, cfg, potentialMap, tolerance, bounds, energies, nPointsAccepted);
-            if (nPointsAccepted == 0)
-                break;
-        }
-        // 		printf("DIFF = %f, 2tol = %f\n", fabs(bounds[0]-bounds[2]), 2.0 * tolerance);
-        // 		++count;
-        // 		if (count > 10) break;
-    } while (fabs(bounds[0] - bounds[2]) > (2.0 * tolerance));
-    // 	printf("Final bounding values are %12.5e %12.5e %12.5e\n",bounds[0],bounds[1],bounds[2]);
-    // 	printf("             energies are %12.5e %12.5e %12.5e\n",energies[0],energies[1],energies[2]);
-
-    // Sort w.r.t. energy so that the minimum is in the central point
-    sortBoundsAndEnergies(bounds, energies);
-
-    // Set an updated step size based on the current bounds
-    stepSize = (bounds.x + bounds.y + bounds.z);
-
-    return energies.y;
 }

--- a/src/modules/geomopt/functions.cpp
+++ b/src/modules/geomopt/functions.cpp
@@ -117,8 +117,8 @@ double GeometryOptimisationModule::energyAtGradientPoint(ProcessPool &procPool, 
 
 // Return energy of adjusted coordinates, following the force vectors by the supplied amount
 template <>
-double GeometryOptimisationModule::energyAtGradientPoint(ProcessPool &procPool, Species *sp,
-                                                         const PotentialMap &potentialMap, double delta)
+double GeometryOptimisationModule::energyAtGradientPoint(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap,
+                                                         double delta)
 {
     for (auto n = 0; n < sp->nAtoms(); ++n)
         sp->setAtomCoordinates(n, xRef_[n] + xForce_[n] * delta, yRef_[n] + yForce_[n] * delta, zRef_[n] + zForce_[n] * delta);

--- a/src/modules/geomopt/geomopt.h
+++ b/src/modules/geomopt/geomopt.h
@@ -21,7 +21,10 @@
 
 #pragma once
 
+#include "main/dissolve.h"
 #include "module/module.h"
+#include "modules/energy/energy.h"
+#include "modules/forces/forces.h"
 
 // Forward Declarations
 class PotentialMap;
@@ -77,12 +80,16 @@ class GeometryOptimisationModule : public Module
     Array<double> xTemp_, yTemp_, zTemp_;
     // Current forces
     Array<double> xForce_, yForce_, zForce_;
+    // Control variables (retrieved from keywords)
+    int nCycles_;
+    double tolerance_;
+    double initialStepSize_;
 
     private:
-    // Copy coordinates from supplied Configuration into reference arrays
-    void setReferenceCoordinates(Configuration *cfg);
-    // Revert Configuration to reference coordinates
-    void revertToReferenceCoordinates(Configuration *cfg);
+    // Copy coordinates from supplied target into reference arrays
+    template <class T> void setReferenceCoordinates(T *target);
+    // Revert target to reference coordinates
+    template <class T> void revertToReferenceCoordinates(T *target);
     // Return current RMS force
     double rmsForce() const;
     // Determine suitable step size from current forces
@@ -90,13 +97,212 @@ class GeometryOptimisationModule : public Module
     // Sort bounds / energies so that minimum energy is in the central position
     void sortBoundsAndEnergies(Vec3<double> &bounds, Vec3<double> &energies);
     // Return energy of adjusted coordinates, following the force vectors by the supplied amount
-    double energyAtGradientPoint(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, double delta);
+    template <class T>
+    double energyAtGradientPoint(ProcessPool &procPool, T *target, const PotentialMap &potentialMap, double delta);
     // Perform Golden Search within specified bounds
-    double goldenSearch(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, const double tolerance,
-                        Vec3<double> &bounds, Vec3<double> &energies, int &nPointsAccepted);
-    // Line minimise supplied Configuration from the reference coordinates along the stored force vectors
-    double lineMinimise(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, const double tolerance,
-                        double &stepSize);
+    template <class T>
+    double goldenSearch(ProcessPool &procPool, T *target, const PotentialMap &potentialMap, const double tolerance,
+                        Vec3<double> &bounds, Vec3<double> &energies, int &nPointsAccepted)
+    {
+        // Ensure that the energy minimum is the midpoint
+        sortBoundsAndEnergies(bounds, energies);
+
+        // Check convergence, ready for early return
+        if (fabs(bounds.x - bounds.z) < tolerance)
+            return energies.y;
+
+        // Calculate deltas between bound values
+        double dxy = bounds[0] - bounds[1];
+        double dyz = bounds[2] - bounds[1];
+        Messenger::printVerbose("Trying Golden Search -  %f-%f-%f, dxy = %12.5e, dyz = %12.5e", bounds.x, bounds.y, bounds.z,
+                                dxy, dyz);
+
+        // Select largest of two intervals to be the target of the search
+        auto xyLargest = fabs(dxy) > fabs(dyz);
+        double newMinimum = bounds[1] + 0.3819660 * (xyLargest ? dxy : dyz);
+
+        // Test energy at new trial minimum
+        double eNew = energyAtGradientPoint(procPool, target, potentialMap, newMinimum);
+        Messenger::printVerbose("--> GOLD point is %12.5e [%12.5e] ", eNew, newMinimum);
+
+        // Set order for checking of energy points
+        Vec3<int> order(1, xyLargest ? 0 : 2, xyLargest ? 2 : 0);
+
+        // Check each energy to see if our new energy is lower. If it is, overwrite it and recurse
+        for (int n = 0; n < 3; ++n)
+        {
+            if (eNew < energies[order[n]])
+            {
+                Messenger::printVerbose("--> GOLD point is lower than point %i...", order[n]);
+
+                // Overwrite the outermost bound with the old minimum
+                bounds[xyLargest ? 0 : 2] = newMinimum;
+                energies[xyLargest ? 0 : 2] = eNew;
+
+                ++nPointsAccepted;
+
+                // Recurse into the new region
+                return goldenSearch(procPool, target, potentialMap, tolerance, bounds, energies, nPointsAccepted);
+            }
+        }
+
+        // Nothing better than the current central energy value, so revert to the stored reference coordinates
+        revertToReferenceCoordinates(target);
+
+        return energies.y;
+    }
+    // Line minimise supplied target from the reference coordinates along the stored force vectors
+    template <class T>
+    double lineMinimise(ProcessPool &procPool, T *target, const PotentialMap &potentialMap, const double tolerance,
+                        double &stepSize)
+    {
+        // Brent-style line minimiser with parabolic interpolation and Golden Search backup
+
+        // Set initial bounding values
+        Vec3<double> bounds, energies;
+        bounds.x = 0.0;
+        energies.x = EnergyModule::totalEnergy(procPool, target, potentialMap);
+        bounds.y = stepSize;
+        energies.y = energyAtGradientPoint(procPool, target, potentialMap, bounds.y);
+        bounds.z = 2.0 * stepSize;
+        energies.z = energyAtGradientPoint(procPool, target, potentialMap, bounds.z);
+
+        Messenger::printVerbose("Initial bounding values/energies = %12.5e (%12.5e) %12.5e (%12.5e) %12.5e (%12.5e)", bounds[0],
+                                energies[0], bounds[1], energies[1], bounds[2], energies[2]);
+
+        // Perform linesearch along the gradient vector
+        do
+        {
+            // Sort w.r.t. energy so that the minimum is in the central point
+            sortBoundsAndEnergies(bounds, energies);
+
+            Messenger::printVerbose("Energies [Bounds] = %12.5e (%12.5e) %12.5e (%12.5e) %12.5e (%12.5e)", energies[0],
+                                    bounds[0], energies[1], bounds[1], energies[2], bounds[2]);
+
+            // Perform parabolic interpolation to find new minimium point
+            double b10 = bounds[1] - bounds[0];
+            double b12 = bounds[1] - bounds[2];
+            double a = (b10 * b10 * (energies[1] - energies[2])) - (b12 * b12 * (energies[1] - energies[0]));
+            double b = (b10 * (energies[1] - energies[2])) - (b12 * (energies[1] - energies[0]));
+            double newBound = bounds[1] - 0.5 * (a / b);
+
+            // Compute energy of new point and check that it went down...
+            double eNew = energyAtGradientPoint(procPool, target, potentialMap, newBound);
+
+            Messenger::printVerbose("PARABOLIC point gives energy %12.5e @ %12.5e", eNew, newBound);
+            if (eNew < energies[1])
+            {
+                // New point found...
+                Messenger::printVerbose("--> PARABOLIC point is new minimum...");
+
+                // Overwrite the largest of bounds[0] and bounds[2] with the old minimum
+                auto largest = energies[2] > energies[0] ? 2 : 0;
+                bounds.swap(1, largest);
+                energies.swap(1, largest);
+
+                // Set the new central values
+                bounds[1] = newBound;
+                energies[1] = eNew;
+            }
+            else if ((energies[2] - eNew) > tolerance)
+            {
+                Messenger::printVerbose("--> PARABOLIC point is better than bounds[2]...");
+                bounds[2] = newBound;
+                energies[2] = eNew;
+            }
+            else if ((energies[0] - eNew) > tolerance)
+            {
+                Messenger::printVerbose("--> PARABOLIC point is better than bounds[0]...");
+                bounds[0] = newBound;
+                energies[0] = eNew;
+            }
+            else
+            {
+                Messenger::printVerbose("--> PARABOLIC point is worse than all current values...");
+
+                // Revert to the stored reference coordinates
+                revertToReferenceCoordinates(target);
+
+                // Try recursive Golden Search instead, into the largest of the two sections
+                auto nPointsAccepted = 0;
+                goldenSearch(procPool, target, potentialMap, tolerance, bounds, energies, nPointsAccepted);
+                if (nPointsAccepted == 0)
+                    break;
+            }
+            // 		printf("DIFF = %f, 2tol = %f\n", fabs(bounds[0]-bounds[2]), 2.0 * tolerance);
+            // 		++count;
+            // 		if (count > 10) break;
+        } while (fabs(bounds[0] - bounds[2]) > (2.0 * tolerance));
+        // 	printf("Final bounding values are %12.5e %12.5e %12.5e\n",bounds[0],bounds[1],bounds[2]);
+        // 	printf("             energies are %12.5e %12.5e %12.5e\n",energies[0],energies[1],energies[2]);
+
+        // Sort w.r.t. energy so that the minimum is in the central point
+        sortBoundsAndEnergies(bounds, energies);
+
+        // Set an updated step size based on the current bounds
+        stepSize = (bounds.x + bounds.y + bounds.z);
+
+        return energies.y;
+    }
+    // Geometry optimise the target object
+    template <class T> void optimise(Dissolve &dissolve, ProcessPool &procPool, T *target)
+    {
+        const auto nStepSizeResetsAllowed = 5;
+
+        // Get the initial energy and forces of the Configuration
+        double oldEnergy = EnergyModule::totalEnergy(procPool, target, dissolve.potentialMap());
+        ForcesModule::totalForces(procPool, target, dissolve.potentialMap(), xForce_, yForce_, zForce_);
+        double oldRMSForce = rmsForce();
+
+        // Set initial step size - the line minimiser will modify this as we proceed
+        double stepSize = initialStepSize_;
+
+        Messenger::print("Cycle  %-16s  %-16s  %-16s  %-16s  %-16s\n", "E(total), kJ/mol", "dE, kJ/mol", "RMS(force)", "dRMS",
+                         "Step Size");
+        Messenger::print(" --    %16.9e  %-16s  %16.9e  %-16s  %16.9e\n", oldEnergy, "------", oldRMSForce, "------", stepSize);
+
+        auto nStepSizeResets = 0;
+        for (int cycle = 1; cycle <= nCycles_; ++cycle)
+        {
+            // Copy current target coordinates as our reference (they will be modified by lineMinimise())
+            setReferenceCoordinates(target);
+
+            // Line minimise along the force gradient
+            double newEnergy = lineMinimise(procPool, target, dissolve.potentialMap(), tolerance_ * 0.01, stepSize);
+
+            // Get new forces and RMS for the adjusted coordinates (now stored in the Configuration) and determine
+            // new step size
+            ForcesModule::totalForces(procPool, target, dissolve.potentialMap(), xForce_, yForce_, zForce_);
+            double newRMSForce = rmsForce();
+
+            // Calculate deltas
+            double dE = newEnergy - oldEnergy;
+            double dF = newRMSForce - oldRMSForce;
+
+            // Print summary
+            Messenger::print("%5i  %16.9e  %16.9e  %16.9e  %16.9e  %16.9e\n", cycle, newEnergy, dE, newRMSForce, dF, stepSize);
+
+            // Check convergence
+            if ((fabs(dE) < tolerance_) || (fabs(dF) < tolerance_))
+            {
+                // Reset the step size and try again?
+                if (nStepSizeResets < nStepSizeResetsAllowed)
+                {
+                    ++nStepSizeResets;
+                    stepSize = initialStepSize_;
+                }
+                else
+                {
+                    Messenger::print(" *** Steepest Descent converged at step %i ***", cycle);
+                    break;
+                }
+            }
+
+            // Store new energy / forces as current forces
+            oldEnergy = newEnergy;
+            oldRMSForce = newRMSForce;
+        }
+    }
 
     /*
      * GUI Widget

--- a/src/modules/geomopt/geomopt.h
+++ b/src/modules/geomopt/geomopt.h
@@ -304,6 +304,10 @@ class GeometryOptimisationModule : public Module
         }
     }
 
+    public:
+    // Geometry optimise supplied Species
+    bool optimiseSpecies(Dissolve &dissolve, ProcessPool &procPool, Species *sp);
+
     /*
      * GUI Widget
      */

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -104,9 +104,9 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (onlyWhenEnergyStable)
         {
             auto stabilityResult = EnergyModule::checkStability(cfg);
-            if (stabilityResult == -1)
+            if (stabilityResult == EnergyModule::NotAssessable)
                 return false;
-            else if (stabilityResult == 1)
+            else if (stabilityResult == EnergyModule::EnergyUnstable)
             {
                 Messenger::print("Skipping MD for Configuration '%s'.\n", cfg->niceName());
                 continue;

--- a/src/modules/refine/process.cpp
+++ b/src/modules/refine/process.cpp
@@ -220,10 +220,10 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
     if (onlyWhenEnergyStable)
     {
-        auto stabilityResult = EnergyModule::checkStability(configs);
-        if (stabilityResult == -1)
+        auto stabilityResult = EnergyModule::nUnstable(configs);
+        if (stabilityResult == EnergyModule::NotAssessable)
             return false;
-        else if (stabilityResult != 0)
+        else if (stabilityResult > 0)
         {
             Messenger::print("At least one Configuration energy is not yet stable. No potential refinement will be "
                              "performed this iteration.\n");


### PR DESCRIPTION
This PR addresses an issue with the GUI which prevents species with non-zero net charge being subjected to geometry minimisation, even though this is a completely legitimate thing to do.

### Cause
The `GeometryOptimisationModule` contains the core routines to perform geometry minimisation w.r.t. energy, however the focus of the module is on Configurations rather than Species. This resulted in the need to utilise a temporary instance of Dissolve to create and apply a module layer containing a GeometryOptimisationModule to a Configuration containing a single Molecule instance of the target Species to geometry optimise. Messy, but working. A previous commit put in place measures to prevent full simulations running on Configurations with net non-zero charge, as this is usually indicative of a problem with Species setup, and so the optimisation of the charged Species molecule is prevented.

### Resolution
The `GeometryOptimisationModule` has been rewritten to allow it to target either Configurations or Species (with no checks for charges on the latter), and associated functions added to `EnergyKernel` and `ForceKernel`. Other modifications allow the module to be used directly to perform the optimisation, rather than having to instantiate a temporary Dissolve object.

### Additional
Duplicate code has been removed in several areas.
Closes #195.
Closes #96.
Addresses undocumented bug whereby atomic coordinates were mirrored after each minimisation cycle.
