### PR TITLE
Bugfix 19-08-20 AtomTypes and IsotopologueCollection."

### DIFF
--- a/src/classes/isotopologuecollection.cpp
+++ b/src/classes/isotopologuecollection.cpp
@@ -181,7 +181,7 @@ void IsotopologueCollection::complete(const RefList<Configuration> &configuratio
         while (SpeciesInfo *spInfo = spInfoIterator.iterate())
         {
             // If the Species already exists in our set, nothing more to do...
-            if (it->contains(spInfo->species()))
+            if (setForCfg->contains(spInfo->species()))
                 continue;
 
             // Add the natural isotopologue for this Species

--- a/src/main/atomtypes.cpp
+++ b/src/main/atomtypes.cpp
@@ -41,7 +41,7 @@ std::vector<std::shared_ptr<AtomType>> &Dissolve::atomTypes() { return coreData_
 std::shared_ptr<AtomType> Dissolve::atomType(int n) { return coreData_.atomType(n); }
 
 // Search for AtomType by name
-std::optional<std::shared_ptr<AtomType>> Dissolve::findAtomType(const char *name) const { return coreData_.findAtomType(name); }
+std::shared_ptr<AtomType> Dissolve::findAtomType(const char *name) const { return coreData_.findAtomType(name); }
 
 // Clear all AtomTypes
 void Dissolve::clearAtomTypes() { coreData_.atomTypes().clear(); }

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -75,8 +75,7 @@ class Dissolve
     // Return nth AtomType in list
     std::shared_ptr<AtomType> atomType(int n);
     // Search for AtomType by name
-    std::optional<std::shared_ptr<AtomType>> findAtomType(const char *name) const;
-
+    std::shared_ptr<AtomType> findAtomType(const char *name) const;
     // Clear all AtomTypes
     void clearAtomTypes();
 

--- a/src/main/species.cpp
+++ b/src/main/species.cpp
@@ -69,16 +69,14 @@ void Dissolve::copyAtomType(const SpeciesAtom *sourceAtom, SpeciesAtom *destAtom
     }
 
     // Search for the existing atom's AtomType by name, and create it if it doesn't exist
-    std::shared_ptr<AtomType> at;
-    auto opt_at = findAtomType(sourceAtom->atomType()->name());
-    if (!opt_at)
+    auto at = findAtomType(sourceAtom->atomType()->name());
+    if (!at)
     {
         at = addAtomType(sourceAtom->element());
         at->setName(sourceAtom->atomType()->name());
         at->parameters() = sourceAtom->atomType()->parameters();
         at->setShortRangeType(sourceAtom->atomType()->shortRangeType());
     }
-    at = *opt_at;
 
     destAtom->setAtomType(at);
 }

--- a/src/modules/epsr/io.cpp
+++ b/src/modules/epsr/io.cpp
@@ -161,7 +161,7 @@ bool EPSRModule::readPCof(Dissolve &dissolve, ProcessPool &procPool, const char 
         auto at2 = dissolve.findAtomType(parser.argc(1));
         if (!at2)
             return Messenger::error("Unrecognised AtomType '%s' referenced in pcof file.\n", parser.argc(1));
-        Messenger::print("Found %s-%s potential...\n", (*at1)->name(), (*at2)->name());
+        Messenger::print("Found %s-%s potential...\n", at1->name(), at2->name());
 
         // Next line contains ??? and ??? TODO
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
@@ -169,7 +169,7 @@ bool EPSRModule::readPCof(Dissolve &dissolve, ProcessPool &procPool, const char 
 
         // Grab the coefficient storage from the module data and read the coefficients in - they will all be on one
         // single line in the file.
-        Array<double> &coefficients = potentialCoefficients.at((*at1)->index(), (*at2)->index());
+        Array<double> &coefficients = potentialCoefficients.at(at1->index(), at2->index());
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return Messenger::error("Failed to read coefficients from pcof file.\n");
         if (parser.nArgs() != ncoeffp)


### PR DESCRIPTION
This PR patches two bugs causing crashes in the current version.

- Remove std::optional enclosure from Dissolve::findAtomType().
- Fix crash in IsotopologueCollection::complete() from wrong pointer usage.
