### PR TITLE
Possible solution to Renderable bug

### DIFF
--- a/src/gui/render/renderabledata1d.cpp
+++ b/src/gui/render/renderabledata1d.cpp
@@ -154,10 +154,10 @@ const Data1D &RenderableData1D::transformedData()
 
     // If the value transform is not enabled, just return the original data
     if (!valuesTransform_.enabled())
-        return *source_;
-
-    // Make sure the transformed data is up-to-date
-    transformValues();
+        transformedData_ = *source_;
+    else
+        // Make sure the transformed data is up-to-date
+        transformValues();
 
     return transformedData_;
 }

--- a/src/gui/render/renderabledata2d.cpp
+++ b/src/gui/render/renderabledata2d.cpp
@@ -161,10 +161,10 @@ const Data2D &RenderableData2D::transformedData()
 
     // If the value transform is not enabled, just return the original data
     if (!valuesTransform_.enabled())
-        return *source_;
-
-    // Make sure the transformed data is up-to-date
-    transformValues();
+        transformedData_ = *source_;
+    else
+      // Make sure the transformed data is up-to-date
+      transformValues();
 
     return transformedData_;
 }

--- a/src/gui/render/renderabledata2d.cpp
+++ b/src/gui/render/renderabledata2d.cpp
@@ -163,8 +163,8 @@ const Data2D &RenderableData2D::transformedData()
     if (!valuesTransform_.enabled())
         transformedData_ = *source_;
     else
-      // Make sure the transformed data is up-to-date
-      transformValues();
+        // Make sure the transformed data is up-to-date
+        transformValues();
 
     return transformedData_;
 }

--- a/src/gui/render/renderabledata3d.cpp
+++ b/src/gui/render/renderabledata3d.cpp
@@ -183,8 +183,8 @@ const Data3D &RenderableData3D::transformedData()
     if (!valuesTransform_.enabled())
         transformedData_ = *source_;
     else
-      // Make sure the transformed data is up-to-date
-      transformValues();
+        // Make sure the transformed data is up-to-date
+        transformValues();
 
     return transformedData_;
 }

--- a/src/gui/render/renderabledata3d.cpp
+++ b/src/gui/render/renderabledata3d.cpp
@@ -181,10 +181,10 @@ const Data3D &RenderableData3D::transformedData()
 
     // If the value transform is not enabled, just return the original data
     if (!valuesTransform_.enabled())
-        return *source_;
-
-    // Make sure the transformed data is up-to-date
-    transformValues();
+        transformedData_ = *source_;
+    else
+      // Make sure the transformed data is up-to-date
+      transformValues();
 
     return transformedData_;
 }


### PR DESCRIPTION
When transform was not enabled, it was possible for a reference to the
original source from the simulation to be passed to the GUI.  This now
ensures that the GUI is always passed an independent copy.

This should hopefully solve #139.