### PR TITLE
Move to linuxdeploy

### DIFF
--- a/.azure-pipelines/templates/package-linux-serial-gui.yml
+++ b/.azure-pipelines/templates/package-linux-serial-gui.yml
@@ -5,21 +5,26 @@ parameters:
 steps:
   - bash: |
       set -ex
-      # Set environment vars
+      ci/scripts/prep-appimage -a Dissolve -v continuous -b build/dissolve
+      ci/scripts/prep-appimage -a Dissolve-GUI -v continuous -b build/dissolve-gui
+    displayName: 'Prepare AppDirs'
+  - bash: |
+      echo -e "\nRetrieving linuxdeploy...\n"
+      wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O linuxdeploy.AppImage
+      echo -e "\nRetrieving qt plugin for linuxdeploy...\n"
+      wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+      chmod u+x ./linuxdeploy*.AppImage
+    displayName: 'Download linuxdeploy Tools'
+  - bash: |
+      # Set environment vars to locate Qt
       QT_BASE_DIR="/opt/qt${{ parameters.qtver }}"
       export QTDIR=$QT_BASE_DIR
       export PATH=$QT_BASE_DIR/bin:$PATH
-      # Prep appimage directories
-      ci/scripts/prep-appimage -a Dissolve -v continuous -b build/bin/dissolve
-      ci/scripts/prep-appimage -a Dissolve-GUI -v continuous -b build/bin/dissolve-gui
-      # Retrieve linuxdeployqt
-      echo -e "\nRetrieving linuxdeployqt...\n"
-      wget -q https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage -O linuxdeployqt
-      chmod u+x ./linuxdeployqt
       # Run on the targets
-      ./linuxdeployqt Dissolve-continuous.AppDir/usr/share/applications/*.desktop -appimage
-      ./linuxdeployqt Dissolve-GUI-continuous.AppDir/usr/share/applications/*.desktop -appimage
-      # Store artifacts
+      ./linuxdeploy.AppImage --appdir Dissolve-continuous.AppDir --output appimage
+      ./linuxdeploy.AppImage --appdir Dissolve-GUI-continuous.AppDir --plugin qt --output appimage
+    displayName: 'Create AppImages'
+  - bash: |
       mkdir packages
       mv Dissolve-*-x86_64.AppImage packages
-    displayName: 'Create AppImages'
+    displayName: 'Move Artifacts'


### PR DESCRIPTION
This PR replaces the use of linuxdeployqt with linuxdeploy, in order to overcome glibc version enforcement and odd behaviour of the former.
