### PR TITLE
std::accumulate for EnergyKernel claculations

### DIFF
--- a/src/classes/cell.cpp
+++ b/src/classes/cell.cpp
@@ -70,6 +70,7 @@ const Vec3<double> &Cell::centre() const { return centre_; }
 
 // Return array of contained Atoms
 OrderedVector<Atom *> &Cell::atoms() { return atoms_; }
+const OrderedVector<Atom *> &Cell::atoms() const { return atoms_; }
 
 // Return array of contained Atoms, ordered by their array indices
 const OrderedVector<Atom *> &Cell::indexOrderedAtoms() const { return indexOrderedAtoms_; }

--- a/src/classes/cell.h
+++ b/src/classes/cell.h
@@ -78,6 +78,7 @@ class Cell
     public:
     // Return array of contained Atoms
     OrderedVector<Atom *> &atoms();
+    const OrderedVector<Atom *> &atoms() const;
     // Return array of contained Atoms, ordered by their array indices
     const OrderedVector<Atom *> &indexOrderedAtoms() const;
     // Return number of Atoms in array

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -828,22 +828,30 @@ double EnergyKernel::intramolecularEnergy(std::shared_ptr<const Molecule> mol)
     auto intraEnergy = 0.0;
 
     // Loop over Bonds
-    for (const auto &bond : mol->species()->constBonds())
-        intraEnergy += energy(bond, mol->atom(bond.indexI()), mol->atom(bond.indexJ()));
-
+    intraEnergy = std::accumulate(mol->species()->constBonds().begin(), mol->species()->constBonds().end(), intraEnergy,
+                                  [mol, this](const auto acc, const auto &bond) {
+                                      return acc + energy(bond, mol->atom(bond.indexI()), mol->atom(bond.indexJ()));
+                                  });
     // Loop over Angles
-    for (const auto &angle : mol->species()->constAngles())
-        intraEnergy += energy(angle, mol->atom(angle.indexI()), mol->atom(angle.indexJ()), mol->atom(angle.indexK()));
+    intraEnergy = std::accumulate(mol->species()->constAngles().begin(), mol->species()->constAngles().end(), intraEnergy,
+                                  [mol, this](const auto acc, const auto &angle) {
+                                      return acc + energy(angle, mol->atom(angle.indexI()), mol->atom(angle.indexJ()),
+                                                          mol->atom(angle.indexK()));
+                                  });
 
     // Loop over Torsions
-    for (const auto &torsion : mol->species()->constTorsions())
-        intraEnergy += energy(torsion, mol->atom(torsion.indexI()), mol->atom(torsion.indexJ()), mol->atom(torsion.indexK()),
-                              mol->atom(torsion.indexL()));
+    intraEnergy = std::accumulate(mol->species()->constTorsions().begin(), mol->species()->constTorsions().end(), intraEnergy,
+                                  [mol, this](const auto acc, const auto &torsion) {
+                                      return acc + energy(torsion, mol->atom(torsion.indexI()), mol->atom(torsion.indexJ()),
+                                                          mol->atom(torsion.indexK()), mol->atom(torsion.indexL()));
+                                  });
 
     // Loop over Impropers
-    for (const auto &improper : mol->species()->constImpropers())
-        intraEnergy += energy(improper, mol->atom(improper.indexI()), mol->atom(improper.indexJ()),
-                              mol->atom(improper.indexK()), mol->atom(improper.indexL()));
+    intraEnergy = std::accumulate(mol->species()->constImpropers().begin(), mol->species()->constImpropers().end(), intraEnergy,
+                                  [mol, this](const auto acc, const auto &improper) {
+                                      return acc + energy(improper, mol->atom(improper.indexI()), mol->atom(improper.indexJ()),
+                                                          mol->atom(improper.indexK()), mol->atom(improper.indexL()));
+                                  });
 
     return intraEnergy;
 }

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -299,7 +299,7 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
 }
 
 // Return PairPotential energy between Atom and Cell contents
-double EnergyKernel::energy(const Atom *i, Cell *cell, int flags, ProcessPool::DivisionStrategy strategy, bool performSum)
+double EnergyKernel::energy(const Atom *i, const Cell *cell, int flags, ProcessPool::DivisionStrategy strategy, bool performSum)
 {
 #ifdef CHECKS
     if (i == NULL)
@@ -570,14 +570,11 @@ double EnergyKernel::energy(const Atom *i, ProcessPool::DivisionStrategy strateg
 // Return PairPotential energy of Molecule with world
 double EnergyKernel::energy(std::shared_ptr<const Molecule> mol, ProcessPool::DivisionStrategy strategy, bool performSum)
 {
-    Atom *ii;
-    Cell *cellI;
     double totalEnergy = 0.0;
 
-    for (int i = 0; i < mol->nAtoms(); ++i)
+    for (auto *ii : mol->atoms())
     {
-        ii = mol->atom(i);
-        cellI = ii->cell();
+        auto *cellI = ii->cell();
 
         // This Atom with its own Cell
         totalEnergy += energy(ii, cellI, KernelFlags::ExcludeIntraIGEJFlag, strategy, false);

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -612,17 +612,15 @@ double EnergyKernel::correct(const Atom *i)
     double scale, r, correctionEnergy = 0.0;
     const auto rI = i->r();
 
-    for (auto *j : atoms)
-    {
+    correctionEnergy = std::accumulate(atoms.begin(), atoms.end(), 0.0, [&](const auto &acc, auto *j) {
         if (i == j)
-            continue;
+            return acc;
         scale = 1.0 - i->scaling(j);
-        if (scale > 1.0e-3)
-        {
-            r = box_->minimumDistance(rI, j->r());
-            correctionEnergy += pairPotentialEnergy(i, j, r) * scale;
-        }
-    }
+        if (scale <= 1.0e-3)
+            return acc;
+        r = box_->minimumDistance(rI, j->r());
+        return acc + pairPotentialEnergy(i, j, r) * scale;
+    });
 
     return -correctionEnergy;
 }

--- a/src/classes/energykernel.h
+++ b/src/classes/energykernel.h
@@ -86,7 +86,7 @@ class EnergyKernel
     // Return PairPotential energy between Cell and its neighbours
     double energy(Cell *cell, bool excludeIgeJ, bool interMolecular, ProcessPool::DivisionStrategy strategy, bool performSum);
     // Return PairPotential energy between Atom and Cell
-    double energy(const Atom *i, Cell *cell, int flags, ProcessPool::DivisionStrategy strategy, bool performSum);
+    double energy(const Atom *i, const Cell *cell, int flags, ProcessPool::DivisionStrategy strategy, bool performSum);
     // Return PairPotential energy of atom with world
     double energy(const Atom *i, ProcessPool::DivisionStrategy strategy, bool performSum);
     // Return PairPotential energy of Molecule with world

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -65,6 +65,7 @@ int Molecule::nAtoms() const { return atoms_.size(); }
 
 // Return atoms array
 std::vector<Atom *> &Molecule::atoms() { return atoms_; }
+const std::vector<Atom *> &Molecule::atoms() const { return atoms_; }
 
 // Return nth Atom pointer
 Atom *Molecule::atom(int n) const

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -66,6 +66,8 @@ class Molecule : public DynamicArrayObject<Molecule>, public std::enable_shared_
     int nAtoms() const;
     // Return Atoms array
     std::vector<Atom *> &atoms();
+    // Return Atoms array
+    const std::vector<Atom *> &atoms() const;
     // Return nth Atom pointer
     Atom *atom(int n) const;
 


### PR DESCRIPTION
This PR replaces many of the trivial summation loops in EnergyKernel with std::accumulate.