### PR TITLE
Actually create NETA descriptions for atom types

### DIFF
--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -136,6 +136,21 @@ void Forcefield::addParameters(std::string_view name, double data0, double data1
     shortRangeParameters_.emplace_back(name, data0, data1, data2, data3);
 }
 
+// Create NETA definitions for all atom types from stored defs
+bool Forcefield::createNETADefinitions()
+{
+    auto nFailed = 0;
+    for (auto &atomType : atomTypes_)
+        if (!atomType.createNETA(this))
+            ++nFailed;
+
+    if (nFailed > 0)
+        Messenger::error("Failed to create {} NETA {} for the forcefield '{}'.\n", nFailed,
+                         nFailed == 1 ? "definition" : "definitions", name());
+
+    return (nFailed == 0);
+}
+
 // Return named short-range parameters (if they exist)
 const OptionalReferenceWrapper<const ForcefieldParameters> Forcefield::shortRangeParameters(std::string_view name) const
 {

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -139,10 +139,7 @@ void Forcefield::addParameters(std::string_view name, double data0, double data1
 // Create NETA definitions for all atom types from stored defs
 bool Forcefield::createNETADefinitions()
 {
-    auto nFailed = 0;
-    for (auto &atomType : atomTypes_)
-        if (!atomType.createNETA(this))
-            ++nFailed;
+    auto nFailed = std::count_if(atomTypes_.begin(), atomTypes_.end(), [this](auto &atomType){return !atomType.createNETA(this);});
 
     if (nFailed > 0)
         Messenger::error("Failed to create {} NETA {} for the forcefield '{}'.\n", nFailed,

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -139,7 +139,8 @@ void Forcefield::addParameters(std::string_view name, double data0, double data1
 // Create NETA definitions for all atom types from stored defs
 bool Forcefield::createNETADefinitions()
 {
-    auto nFailed = std::count_if(atomTypes_.begin(), atomTypes_.end(), [this](auto &atomType){return !atomType.createNETA(this);});
+    auto nFailed =
+        std::count_if(atomTypes_.begin(), atomTypes_.end(), [this](auto &atomType) { return !atomType.createNETA(this); });
 
     if (nFailed > 0)
         Messenger::error("Failed to create {} NETA {} for the forcefield '{}'.\n", nFailed,

--- a/src/data/ff.h
+++ b/src/data/ff.h
@@ -114,6 +114,8 @@ class Forcefield : public Elements
     virtual OptionalReferenceWrapper<const ForcefieldAtomType> determineAtomType(SpeciesAtom *i) const;
 
     public:
+    // Create NETA definitions for all atom types from stored defs
+    bool createNETADefinitions();
     // Return named short-range parameters (if they exist)
     const OptionalReferenceWrapper<const ForcefieldParameters> shortRangeParameters(std::string_view name) const;
     // Return the named ForcefieldAtomType (if it exists)

--- a/src/data/fflibrary.cpp
+++ b/src/data/fflibrary.cpp
@@ -49,6 +49,11 @@ bool ForcefieldLibrary::registerForcefield(std::shared_ptr<Forcefield> ff)
     if (!ff->prepare())
         return Messenger::error("Failed to prepare and set up forcefield '{}' - it will not be registered.\n", ff->name());
 
+    // Generate NETA definitions for all atom types in the forcefield
+    if (!ff->createNETADefinitions())
+        return Messenger::error("Failed to generate NETA definitions for forcefield '{}' - it will not be registered.\n",
+                                ff->name());
+
     forcefields_.push_back(ff);
 
     return true;


### PR DESCRIPTION
This PR fixes a severe error whereby atom type descriptions (NETA) were not generated at all for any atom types, leading to incorrect typing of species.
