### PR TITLE
Return const refs to Cell neighbour vectors

### DIFF
--- a/src/classes/cell.cpp
+++ b/src/classes/cell.cpp
@@ -172,13 +172,13 @@ int Cell::nMimCellNeighbours() const { return nMimCellNeighbours_; }
 int Cell::nTotalCellNeighbours() const { return nCellNeighbours_ + nMimCellNeighbours_; }
 
 // Return adjacent Cell neighbour list
-std::vector<Cell *> Cell::cellNeighbours() { return cellNeighbours_; }
+const std::vector<Cell *> &Cell::cellNeighbours() const { return cellNeighbours_; }
 
 // Return specified adjacent Cell neighbour
 Cell *Cell::cellNeighbour(int id) const { return cellNeighbours_[id]; }
 
 // Return list of Cell neighbours requiring minimum image calculation
-std::vector<Cell *> Cell::mimCellNeighbours() { return mimCellNeighbours_; }
+const std::vector<Cell *> &Cell::mimCellNeighbours() const { return mimCellNeighbours_; }
 
 // Return specified Cell neighbour, requiring minimum image calculation
 Cell *Cell::mimCellNeighbour(int id) const { return mimCellNeighbours_[id]; }
@@ -193,4 +193,4 @@ bool Cell::mimRequired(const Cell *otherCell) const
 }
 
 // Return list of all Cell neighbours
-std::vector<CellNeighbour> Cell::allCellNeighbours() { return allCellNeighbours_; }
+const std::vector<CellNeighbour> &Cell::allCellNeighbours() const { return allCellNeighbours_; }

--- a/src/classes/cell.h
+++ b/src/classes/cell.h
@@ -109,15 +109,15 @@ class Cell
     // Return total number of Cell neighbours
     int nTotalCellNeighbours() const;
     // Return adjacent Cell neighbour list
-    std::vector<Cell *> cellNeighbours();
+    const std::vector<Cell *> &cellNeighbours() const;
     // Return specified adjacent Cell neighbour
     Cell *cellNeighbour(int id) const;
     // Return list of Cell neighbours requiring minimum image calculation
-    std::vector<Cell *> mimCellNeighbours();
+    const std::vector<Cell *> &mimCellNeighbours() const;
     // Return specified Cell neighbour requiring minimum image calculation
     Cell *mimCellNeighbour(int id) const;
     // Return if the specified Cell requires minimum image calculation
     bool mimRequired(const Cell *otherCell) const;
     // Return list of all Cell neighbours
-    std::vector<CellNeighbour> allCellNeighbours();
+    const std::vector<CellNeighbour> &allCellNeighbours() const;
 };

--- a/src/classes/cellneighbour.cpp
+++ b/src/classes/cellneighbour.cpp
@@ -38,7 +38,7 @@ void CellNeighbour::set(Cell *cell, bool useMim)
 }
 
 // Return referenced cell
-Cell *CellNeighbour::cell() { return cell_; }
+const Cell *CellNeighbour::cell() const { return cell_; }
 
 // Return whether mim should be applied
 bool CellNeighbour::useMim() { return useMim_; }

--- a/src/classes/cellneighbour.h
+++ b/src/classes/cellneighbour.h
@@ -45,7 +45,7 @@ class CellNeighbour
     // Set cell and mim flag
     void set(Cell *cell, bool useMim);
     // Return referenced cell
-    Cell *cell();
+    const Cell *cell() const;
     // Return whether mim should be applied
     bool useMim();
 };

--- a/src/classes/regionaldistributor.cpp
+++ b/src/classes/regionaldistributor.cpp
@@ -285,7 +285,8 @@ bool RegionalDistributor::canLockCellForEditing(int processOrGroup, int cellInde
 // Assign Molecule to process/group if possible
 bool RegionalDistributor::assignMolecule(std::shared_ptr<const Molecule> mol, int processOrGroup)
 {
-    Cell *primaryCell, *readOnlyCell;
+    Cell *primaryCell;
+    const Cell *readOnlyCell;
     int cellIndex;
 
     // Obvious check first - is the Molecule available for distribution / assignment?
@@ -332,11 +333,11 @@ bool RegionalDistributor::assignMolecule(std::shared_ptr<const Molecule> mol, in
 
     // We are able to lock all Cells that we need to edit, so now construct a list of those within the cutoff range of any
     // primaryCell that we must be able to read (but not modify)
-    OrderedPointerList<Cell> readOnlyCells;
+    OrderedPointerList<const Cell> readOnlyCells;
     for (int c = 0; c < primaryCells.nItems(); ++c)
     {
         // Loop over all cell neighbours for this primary Cell
-        for (auto &neighbour : primaryCells[c]->allCellNeighbours())
+        for (const auto &neighbour : primaryCells[c]->allCellNeighbours())
         {
             readOnlyCell = neighbour.cell();
             cellIndex = readOnlyCell->index();
@@ -380,7 +381,7 @@ bool RegionalDistributor::assignMolecule(std::shared_ptr<const Molecule> mol, in
     }
 
     // For the read-only Cells, we just need to set relevant ownership in the cellLockOwners_ array
-    OrderedPointerListIterator<Cell> readOnlyCellIterator(readOnlyCells);
+    OrderedPointerListIterator<const Cell> readOnlyCellIterator(readOnlyCells);
     while ((readOnlyCell = readOnlyCellIterator.iterate()))
     {
         cellIndex = readOnlyCell->index();


### PR DESCRIPTION
This PR fixes a bug where the recently added usage of `std::accumulate` would run over the end of its target vector, `Cell::cellNeighbours()`, as the vector in question was returned as a copy rather than a reference, resulting in invalid checks on the end iterator.

Unfortunately this was not captured by the system tests, as the `std::accumulate` usage causing the problem is only really instigated when using the `MolShake` module. A new system test for this will follow.
