### PR TITLE
Move terms in SpeciesAtom to references

### DIFF
--- a/src/base/messenger.h
+++ b/src/base/messenger.h
@@ -146,7 +146,7 @@ class Messenger
         std::string headingText = fmt::format(format, args...);
 
         outputBlank();
-        outputText(fmt::format("*{:^80}*", headingText));
+        outputText(fmt::format("{:^80}", headingText));
         outputText(headingBorder);
         outputBlank();
     }

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -790,22 +790,22 @@ double EnergyKernel::intramolecularEnergy(std::shared_ptr<const Molecule> mol, c
 
     // Add energy from SpeciesAngle terms
     intraEnergy +=
-        std::accumulate(spAtom->angles().begin(), spAtom->angles().end(), 0.0, [this, &mol](const auto acc, const auto &angle) {
-            return acc + energy(*angle, mol->atom(angle->indexI()), mol->atom(angle->indexJ()), mol->atom(angle->indexK()));
+        std::accumulate(spAtom->angles().begin(), spAtom->angles().end(), 0.0, [this, &mol](const auto acc, const SpeciesAngle &angle) {
+            return acc + energy(angle, mol->atom(angle.indexI()), mol->atom(angle.indexJ()), mol->atom(angle.indexK()));
         });
 
     // Add energy from SpeciesTorsion terms
     intraEnergy += std::accumulate(spAtom->torsions().begin(), spAtom->torsions().end(), 0.0,
-                                   [this, &mol](const auto acc, const auto &torsion) {
-                                       return acc + energy(*torsion, mol->atom(torsion->indexI()), mol->atom(torsion->indexJ()),
-                                                           mol->atom(torsion->indexK()), mol->atom(torsion->indexL()));
+                                   [this, &mol](const auto acc, const SpeciesTorsion &torsion) {
+                                       return acc + energy(torsion, mol->atom(torsion.indexI()), mol->atom(torsion.indexJ()),
+                                                           mol->atom(torsion.indexK()), mol->atom(torsion.indexL()));
                                    });
 
     // Add energy from SpeciesImproper terms
     intraEnergy += std::accumulate(
-        spAtom->impropers().begin(), spAtom->impropers().end(), 0.0, [this, &mol](const auto acc, const auto &improper) {
-            return acc + energy(*improper, mol->atom(improper->indexI()), mol->atom(improper->indexJ()),
-                                mol->atom(improper->indexK()), mol->atom(improper->indexL()));
+        spAtom->impropers().begin(), spAtom->impropers().end(), 0.0, [this, &mol](const auto acc, const SpeciesImproper &improper) {
+            return acc + energy(improper, mol->atom(improper.indexI()), mol->atom(improper.indexJ()),
+                                mol->atom(improper.indexK()), mol->atom(improper.indexL()));
         });
 
     return intraEnergy;

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -783,14 +783,14 @@ double EnergyKernel::intramolecularEnergy(std::shared_ptr<const Molecule> mol, c
     auto intraEnergy = 0.0;
 
     // Add energy from SpeciesAngle terms
-    intraEnergy +=
-        std::accumulate(spAtom->bonds().begin(), spAtom->bonds().end(), 0.0, [this, &mol](const auto acc, const SpeciesBond &bond) {
-            return acc + energy(bond, mol->atom(bond.indexI()), mol->atom(bond.indexJ()));
-        });
+    intraEnergy += std::accumulate(spAtom->bonds().begin(), spAtom->bonds().end(), 0.0,
+                                   [this, &mol](const auto acc, const SpeciesBond &bond) {
+                                       return acc + energy(bond, mol->atom(bond.indexI()), mol->atom(bond.indexJ()));
+                                   });
 
     // Add energy from SpeciesAngle terms
-    intraEnergy +=
-        std::accumulate(spAtom->angles().begin(), spAtom->angles().end(), 0.0, [this, &mol](const auto acc, const SpeciesAngle &angle) {
+    intraEnergy += std::accumulate(
+        spAtom->angles().begin(), spAtom->angles().end(), 0.0, [this, &mol](const auto acc, const SpeciesAngle &angle) {
             return acc + energy(angle, mol->atom(angle.indexI()), mol->atom(angle.indexJ()), mol->atom(angle.indexK()));
         });
 
@@ -802,11 +802,11 @@ double EnergyKernel::intramolecularEnergy(std::shared_ptr<const Molecule> mol, c
                                    });
 
     // Add energy from SpeciesImproper terms
-    intraEnergy += std::accumulate(
-        spAtom->impropers().begin(), spAtom->impropers().end(), 0.0, [this, &mol](const auto acc, const SpeciesImproper &improper) {
-            return acc + energy(improper, mol->atom(improper.indexI()), mol->atom(improper.indexJ()),
-                                mol->atom(improper.indexK()), mol->atom(improper.indexL()));
-        });
+    intraEnergy += std::accumulate(spAtom->impropers().begin(), spAtom->impropers().end(), 0.0,
+                                   [this, &mol](const auto acc, const SpeciesImproper &improper) {
+                                       return acc + energy(improper, mol->atom(improper.indexI()), mol->atom(improper.indexJ()),
+                                                           mol->atom(improper.indexK()), mol->atom(improper.indexL()));
+                                   });
 
     return intraEnergy;
 }

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -784,8 +784,8 @@ double EnergyKernel::intramolecularEnergy(std::shared_ptr<const Molecule> mol, c
 
     // Add energy from SpeciesAngle terms
     intraEnergy +=
-        std::accumulate(spAtom->bonds().begin(), spAtom->bonds().end(), 0.0, [this, &mol](const auto acc, const auto &bond) {
-            return acc + energy(*bond, mol->atom(bond->indexI()), mol->atom(bond->indexJ()));
+        std::accumulate(spAtom->bonds().begin(), spAtom->bonds().end(), 0.0, [this, &mol](const auto acc, const SpeciesBond &bond) {
+            return acc + energy(bond, mol->atom(bond.indexI()), mol->atom(bond.indexJ()));
         });
 
     // Add energy from SpeciesAngle terms

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -107,9 +107,9 @@ bool Species::checkSetUp()
         }
 
         // Check each Bond for two-way consistency
-        for (const auto *bond : i->bonds())
+        for (const SpeciesBond &bond : i->bonds())
         {
-            SpeciesAtom *partner = bond->partner(i);
+            SpeciesAtom *partner = bond.partner(i);
             if (!partner->hasBond(i))
             {
                 Messenger::error("SpeciesAtom {} references a Bond to SpeciesAtom {}, but SpeciesAtom {} does not.\n",

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -113,7 +113,7 @@ class Species : public ListItem<Species>, public ObjectStore<Species>
     // Toggle selection state of specified atom
     void toggleAtomSelection(SpeciesAtom *i);
     // Select atoms along any path from the specified one, ignoring the bond(s) provided
-    void selectFromAtom(SpeciesAtom *i, SpeciesBond *exclude, SpeciesBond *excludeToo = NULL);
+    void selectFromAtom(SpeciesAtom *i, SpeciesBond &exclude, OptionalReferenceWrapper<SpeciesBond> excludeToo = std::nullopt);
     // Return current atom selection
     const RefList<SpeciesAtom> &selectedAtoms() const;
     // Return nth selected atom

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -45,7 +45,7 @@ void Species::removeAtom(SpeciesAtom *i)
 
     // Remove any bond terms that involve 'i'
     while (i->nBonds())
-        removeBond(i, i->bond(0)->partner(i));
+        removeBond(i, i->bond(0).partner(i));
 
     // Now remove the atom
     atoms_.remove(i);
@@ -154,20 +154,20 @@ void Species::toggleAtomSelection(SpeciesAtom *i)
 }
 
 // Select Atoms along any path from the specified one, ignoring the bond(s) provided
-void Species::selectFromAtom(SpeciesAtom *i, SpeciesBond *exclude, SpeciesBond *excludeToo)
+void Species::selectFromAtom(SpeciesAtom *i, SpeciesBond &exclude, OptionalReferenceWrapper<SpeciesBond> excludeToo)
 {
     // Loop over Bonds on specified Atom
     selectAtom(i);
-    for (const auto *bond : i->bonds())
+    for (const SpeciesBond &bond : i->bonds())
     {
         // Is this either of the excluded bonds?
-        if (exclude == bond)
+        if (&exclude == &bond)
             continue;
-        if (excludeToo == bond)
+        if (excludeToo && &(*excludeToo).get() == &bond)
             continue;
 
         // Get the partner atom in the bond and select it (if it is not selected already)
-        auto *partner = bond->partner(i);
+        auto *partner = bond.partner(i);
 
         if (selectedAtoms_.contains(partner))
             continue;

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -244,8 +244,7 @@ SpeciesAngle &Species::addAngle(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k)
     // We can't use emplace_back since SpeciesAngle needs
     // to derference its `this` pointer in the constructor
     // to update the SpeciesAtoms.
-    SpeciesAngle tmp = SpeciesAngle(i, j, k);
-    angles_.push_back(std::move(tmp));
+    angles_.push_back(std::move(SpeciesAngle(i, j, k)));
     angles_.back().setParent(this);
 
     ++version_;

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -240,7 +240,13 @@ SpeciesAngle &Species::addAngle(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k)
     }
 
     // OK to add new angle
-    angles_.emplace_back(i, j, k).setParent(this);
+
+    // We can't use emplace_back since SpeciesAngle needs
+    // to derference its `this` pointer in the constructor
+    // to update the SpeciesAtoms.
+    SpeciesAngle tmp = SpeciesAngle(i, j, k);
+    angles_.push_back(std::move(tmp));
+    angles_.back().setParent(this);
 
     ++version_;
 

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -42,28 +42,28 @@ void Species::updateIntramolecularTerms()
         k = jk.j();
 
         // Loop over bonds 'ij'
-        for (auto *ij : j->bonds())
+        for (SpeciesBond &ij : j->bonds())
         {
             // Avoid 'ij' == 'jk'
-            if (ij == &jk)
+            if (&ij == &jk)
                 continue;
 
             // Get atom 'i'
-            i = ij->partner(j);
+            i = ij.partner(j);
 
             // Attempt to add angle term 'ijk' if 'i' > 'k'
             if (!hasAngle(i, j, k))
                 addAngle(i, j, k);
 
             // Loop over bonds 'kl'
-            for (auto *kl : k->bonds())
+            for (SpeciesBond &kl : k->bonds())
             {
                 // Avoid 'kl' == 'jk'
-                if (kl == &jk)
+                if (&kl == &jk)
                     continue;
 
                 // Get atom 'l'
-                l = kl->partner(k);
+                l = kl.partner(k);
 
                 // Attempt to add angle term 'jkl'
                 if (!hasAngle(j, k, l))
@@ -399,7 +399,7 @@ void Species::generateAttachedAtomLists()
     {
         // Select all Atoms attached to Atom 'i', excluding the Bond as a path
         clearAtomSelection();
-        selectFromAtom(bond.i(), &bond);
+        selectFromAtom(bond.i(), bond);
 
         // If the list now contains Atom j, the two atoms are present in a cycle of some sort, and we can only add the
         // Atom 'i' itself In that case we can also finish the list for Atom 'j', and continue the loop.
@@ -418,7 +418,7 @@ void Species::generateAttachedAtomLists()
 
         // Select all Atoms attached to Atom 'i', excluding the Bond as a path
         clearAtomSelection();
-        selectFromAtom(bond.j(), &bond);
+        selectFromAtom(bond.j(), bond);
         bond.setAttachedAtoms(1, selectedAtoms_);
     }
 
@@ -426,12 +426,12 @@ void Species::generateAttachedAtomLists()
     for (auto &angle : angles_)
     {
         // Grab relevant Bonds (if they exist)
-        auto *ji = angle.j()->hasBond(angle.i());
-        auto *jk = angle.j()->hasBond(angle.k());
+        auto ji = angle.j()->hasBond(angle.i());
+        auto jk = angle.j()->hasBond(angle.k());
 
         // Select all Atoms attached to Atom 'i', excluding the Bond ji as a path
         clearAtomSelection();
-        selectFromAtom(angle.i(), ji, jk);
+        selectFromAtom(angle.i(), *ji, *jk);
 
         // Remove Atom 'j' from the list if it's there
         selectedAtoms_.remove(angle.j());
@@ -453,7 +453,7 @@ void Species::generateAttachedAtomLists()
 
         // Select all Atoms attached to Atom 'k', excluding the Bond jk as a path
         clearAtomSelection();
-        selectFromAtom(angle.k(), ji, jk);
+        selectFromAtom(angle.k(), *ji, jk);
 
         // Remove Atom 'j' from the list if it's there
         selectedAtoms_.remove(angle.j());
@@ -465,11 +465,11 @@ void Species::generateAttachedAtomLists()
     for (auto &torsion : torsions_)
     {
         // Grab relevant Bond (if it exists)
-        SpeciesBond *jk = torsion.j()->hasBond(torsion.k());
+        OptionalReferenceWrapper<SpeciesBond> jk = torsion.j()->hasBond(torsion.k());
 
         // Select all Atoms attached to Atom 'j', excluding the Bond ji as a path
         clearAtomSelection();
-        selectFromAtom(torsion.j(), jk);
+        selectFromAtom(torsion.j(), *jk);
 
         // Remove Atom 'j' from the list
         selectedAtoms_.remove(torsion.j());
@@ -492,7 +492,7 @@ void Species::generateAttachedAtomLists()
 
         // Select all Atoms attached to Atom 'k', excluding the Bond jk as a path
         clearAtomSelection();
-        selectFromAtom(torsion.k(), jk);
+        selectFromAtom(torsion.k(), *jk);
 
         // Remove Atom 'k' from the list
         selectedAtoms_.remove(torsion.k());

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -71,7 +71,7 @@ SpeciesAngle::SpeciesAngle(SpeciesAngle &&source) : SpeciesIntra(source)
     source.k_ = nullptr;
 }
 
-SpeciesAngle &SpeciesAngle::operator=(const SpeciesAngle &source)
+SpeciesAngle &SpeciesAngle::operator=(SpeciesAngle &source)
 {
     // Copy data
     i_ = source.i_;

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -35,9 +35,9 @@ SpeciesAngle::SpeciesAngle(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k) : Spe
     // Add ourself to the list of bonds on each atom
     if (i_ && j_ && k_)
     {
-        i_->addAngle(this);
-        j_->addAngle(this);
-        k_->addAngle(this);
+        i_->addAngle(*this);
+        j_->addAngle(*this);
+        k_->addAngle(*this);
     }
 }
 
@@ -48,9 +48,9 @@ SpeciesAngle::SpeciesAngle(SpeciesAngle &&source) : SpeciesIntra(source)
     // Detach source bond referred to by the species atoms
     if (source.i_ && source.j_ && source.k_)
     {
-        source.i_->removeAngle(&source);
-        source.j_->removeAngle(&source);
-        source.k_->removeAngle(&source);
+        source.i_->removeAngle(source);
+        source.j_->removeAngle(source);
+        source.k_->removeAngle(source);
     }
 
     // Copy data
@@ -59,9 +59,9 @@ SpeciesAngle::SpeciesAngle(SpeciesAngle &&source) : SpeciesIntra(source)
     k_ = source.k_;
     if (i_ && j_ && k_)
     {
-        i_->addAngle(this);
-        j_->addAngle(this);
-        k_->addAngle(this);
+        i_->addAngle(*this);
+        j_->addAngle(*this);
+        k_->addAngle(*this);
     }
     form_ = source.form_;
 
@@ -79,9 +79,9 @@ SpeciesAngle &SpeciesAngle::operator=(const SpeciesAngle &source)
     k_ = source.k_;
     if (i_ && j_ && k_)
     {
-        i_->addAngle(this);
-        j_->addAngle(this);
-        k_->addAngle(this);
+        i_->addAngle(*this);
+        j_->addAngle(*this);
+        k_->addAngle(*this);
     }
     form_ = source.form_;
     SpeciesIntra::operator=(source);
@@ -101,9 +101,9 @@ SpeciesAngle &SpeciesAngle::operator=(SpeciesAngle &&source)
     k_ = source.k_;
     if (i_ && j_ && k_)
     {
-        i_->addAngle(this);
-        j_->addAngle(this);
-        k_->addAngle(this);
+        i_->addAngle(*this);
+        j_->addAngle(*this);
+        k_->addAngle(*this);
     }
     form_ = source.form_;
     SpeciesIntra::operator=(source);
@@ -210,9 +210,9 @@ void SpeciesAngle::detach()
 {
     if (i_ && j_ && k_)
     {
-        i_->removeAngle(this);
-        j_->removeAngle(this);
-        k_->removeAngle(this);
+        i_->removeAngle(*this);
+        j_->removeAngle(*this);
+        k_->removeAngle(*this);
     }
     i_ = nullptr;
     j_ = nullptr;

--- a/src/classes/speciesangle.h
+++ b/src/classes/speciesangle.h
@@ -37,7 +37,7 @@ class SpeciesAngle : public SpeciesIntra
     ~SpeciesAngle() = default;
     SpeciesAngle(SpeciesAngle &source);
     SpeciesAngle(SpeciesAngle &&source);
-    SpeciesAngle &operator=(const SpeciesAngle &source);
+    SpeciesAngle &operator=(SpeciesAngle &source);
     SpeciesAngle &operator=(SpeciesAngle &&source);
 
     /*

--- a/src/classes/speciesatom.cpp
+++ b/src/classes/speciesatom.cpp
@@ -145,89 +145,89 @@ OptionalReferenceWrapper<SpeciesBond> SpeciesAtom::hasBond(SpeciesAtom *partner)
 }
 
 // Add specified SpeciesAngle to Atom
-void SpeciesAtom::addAngle(SpeciesAngle *angle)
+void SpeciesAtom::addAngle(SpeciesAngle &angle)
 {
     angles_.push_back(angle);
 
     // Insert the pointers to the other Atoms into the exclusions_ list
-    if (angle->i() != this)
-        exclusions_.add(angle->i());
-    if (angle->j() != this)
-        exclusions_.add(angle->j());
-    if (angle->k() != this)
-        exclusions_.add(angle->k());
+    if (angle.i() != this)
+        exclusions_.add(angle.i());
+    if (angle.j() != this)
+        exclusions_.add(angle.j());
+    if (angle.k() != this)
+        exclusions_.add(angle.k());
 }
 
 // Remove angle reference
-void SpeciesAtom::removeAngle(SpeciesAngle *angle) { angles_.erase(find(angles_.begin(), angles_.end(), angle)); }
+void SpeciesAtom::removeAngle(SpeciesAngle &angle) { angles_.erase(find_if(angles_.begin(), angles_.end(), [&angle](const SpeciesAngle a){return &a == &angle;})); }
 
 // Return the number of Angles in which the Atom is involved
 int SpeciesAtom::nAngles() const { return angles_.size(); }
 
 // Return specified angle
-SpeciesAngle *SpeciesAtom::angle(int index) { return angles_.at(index); }
+SpeciesAngle &SpeciesAtom::angle(int index) { return angles_.at(index); }
 
 // Return array of Angles in which the Atom is involved
-const std::vector<SpeciesAngle *> &SpeciesAtom::angles() const { return angles_; }
+const std::vector<std::reference_wrapper<SpeciesAngle>> &SpeciesAtom::angles() const { return angles_; }
 
 // Add specified SpeciesTorsion to Atom
-void SpeciesAtom::addTorsion(SpeciesTorsion *torsion, double scaling14)
+void SpeciesAtom::addTorsion(SpeciesTorsion &torsion, double scaling14)
 {
     torsions_.push_back(torsion);
 
     // Insert the pointers to the other Atoms into the exclusions_ list
-    if (torsion->i() == this)
+    if (torsion.i() == this)
     {
-        exclusions_.add(torsion->j());
-        exclusions_.add(torsion->k());
-        exclusions_.add(torsion->l(), scaling14);
+        exclusions_.add(torsion.j());
+        exclusions_.add(torsion.k());
+        exclusions_.add(torsion.l(), scaling14);
     }
-    else if (torsion->l() == this)
+    else if (torsion.l() == this)
     {
-        exclusions_.add(torsion->i(), scaling14);
-        exclusions_.add(torsion->j());
-        exclusions_.add(torsion->k());
+        exclusions_.add(torsion.i(), scaling14);
+        exclusions_.add(torsion.j());
+        exclusions_.add(torsion.k());
     }
     else
     {
-        exclusions_.add(torsion->i());
-        exclusions_.add(torsion->l());
-        if (torsion->j() != this)
-            exclusions_.add(torsion->j());
-        if (torsion->k() != this)
-            exclusions_.add(torsion->k());
+        exclusions_.add(torsion.i());
+        exclusions_.add(torsion.l());
+        if (torsion.j() != this)
+            exclusions_.add(torsion.j());
+        if (torsion.k() != this)
+            exclusions_.add(torsion.k());
     }
 }
 
 // Remove torsion reference
-void SpeciesAtom::removeTorsion(SpeciesTorsion *torsion) { torsions_.erase(find(torsions_.begin(), torsions_.end(), torsion)); }
+void SpeciesAtom::removeTorsion(SpeciesTorsion &torsion) { torsions_.erase(find_if(torsions_.begin(), torsions_.end(), [&torsion](const SpeciesTorsion &t){return &t == &torsion;})); }
 
 // Return the number of Torsions in which the Atom is involved
 int SpeciesAtom::nTorsions() const { return torsions_.size(); }
 
 // Return specified torsion
-SpeciesTorsion *SpeciesAtom::torsion(int index) { return torsions_.at(index); }
+SpeciesTorsion &SpeciesAtom::torsion(int index) { return torsions_.at(index); }
 
 // Return array of Torsions in which the Atom is involved
-const std::vector<SpeciesTorsion *> &SpeciesAtom::torsions() const { return torsions_; }
+const std::vector<std::reference_wrapper<SpeciesTorsion>> &SpeciesAtom::torsions() const { return torsions_; }
 
 // Add specified SpeciesImproper to Atom
-void SpeciesAtom::addImproper(SpeciesImproper *improper) { impropers_.push_back(improper); }
+void SpeciesAtom::addImproper(SpeciesImproper &improper) { impropers_.push_back(improper); }
 
 // Remove improper reference
-void SpeciesAtom::removeImproper(SpeciesImproper *improper)
+void SpeciesAtom::removeImproper(SpeciesImproper &improper)
 {
-    impropers_.erase(find(impropers_.begin(), impropers_.end(), improper));
+  impropers_.erase(find_if(impropers_.begin(), impropers_.end(), [&improper](const SpeciesImproper &i){return &i == &improper;}));
 }
 
 // Return the number of Impropers in which the Atom is involved
 int SpeciesAtom::nImpropers() const { return impropers_.size(); }
 
 // Return specified improper
-SpeciesImproper *SpeciesAtom::improper(int index) { return impropers_.at(index); }
+SpeciesImproper &SpeciesAtom::improper(int index) { return impropers_.at(index); }
 
 // Return array of Impropers in which the Atom is involved
-const std::vector<SpeciesImproper *> &SpeciesAtom::impropers() const { return impropers_; }
+const std::vector<std::reference_wrapper<SpeciesImproper>> &SpeciesAtom::impropers() const { return impropers_; }
 
 // Return scaling factor to employ with specified Atom
 double SpeciesAtom::scaling(const SpeciesAtom *j) const

--- a/src/classes/speciesatom.cpp
+++ b/src/classes/speciesatom.cpp
@@ -117,12 +117,15 @@ bool SpeciesAtom::isSelected() const { return selected_; }
 // Add Bond reference
 void SpeciesAtom::addBond(SpeciesBond &bond)
 {
-    if (find_if(bonds_.begin(), bonds_.end(), [&bond](const SpeciesBond &b){return &b == &bond;}) == bonds_.end())
+    if (find_if(bonds_.begin(), bonds_.end(), [&bond](const SpeciesBond &b) { return &b == &bond; }) == bonds_.end())
         bonds_.push_back(bond);
 }
 
 // Remove Bond reference
-void SpeciesAtom::removeBond(SpeciesBond &b) { bonds_.erase(find_if(bonds_.begin(), bonds_.end(), [&b](const SpeciesBond &bond){return &b == &bond;})); }
+void SpeciesAtom::removeBond(SpeciesBond &b)
+{
+    bonds_.erase(find_if(bonds_.begin(), bonds_.end(), [&b](const SpeciesBond &bond) { return &b == &bond; }));
+}
 
 // Clear all Bond references
 void SpeciesAtom::clearBonds() { bonds_.clear(); }
@@ -140,7 +143,8 @@ const std::vector<std::reference_wrapper<SpeciesBond>> &SpeciesAtom::bonds() con
 OptionalReferenceWrapper<SpeciesBond> SpeciesAtom::hasBond(SpeciesAtom *partner)
 {
     auto result = find_if(bonds_.begin(), bonds_.end(), [&](const SpeciesBond &bond) { return bond.partner(this) == partner; });
-    if (result == bonds_.end()) return std::nullopt;
+    if (result == bonds_.end())
+        return std::nullopt;
     return *result;
 }
 
@@ -159,7 +163,10 @@ void SpeciesAtom::addAngle(SpeciesAngle &angle)
 }
 
 // Remove angle reference
-void SpeciesAtom::removeAngle(SpeciesAngle &angle) { angles_.erase(find_if(angles_.begin(), angles_.end(), [&angle](const SpeciesAngle &a){return &a == &angle;})); }
+void SpeciesAtom::removeAngle(SpeciesAngle &angle)
+{
+    angles_.erase(find_if(angles_.begin(), angles_.end(), [&angle](const SpeciesAngle &a) { return &a == &angle; }));
+}
 
 // Return the number of Angles in which the Atom is involved
 int SpeciesAtom::nAngles() const { return angles_.size(); }
@@ -200,7 +207,11 @@ void SpeciesAtom::addTorsion(SpeciesTorsion &torsion, double scaling14)
 }
 
 // Remove torsion reference
-void SpeciesAtom::removeTorsion(SpeciesTorsion &torsion) { torsions_.erase(find_if(torsions_.begin(), torsions_.end(), [&torsion](const SpeciesTorsion &t){return &t == &torsion;})); }
+void SpeciesAtom::removeTorsion(SpeciesTorsion &torsion)
+{
+    torsions_.erase(
+        find_if(torsions_.begin(), torsions_.end(), [&torsion](const SpeciesTorsion &t) { return &t == &torsion; }));
+}
 
 // Return the number of Torsions in which the Atom is involved
 int SpeciesAtom::nTorsions() const { return torsions_.size(); }
@@ -217,7 +228,8 @@ void SpeciesAtom::addImproper(SpeciesImproper &improper) { impropers_.push_back(
 // Remove improper reference
 void SpeciesAtom::removeImproper(SpeciesImproper &improper)
 {
-  impropers_.erase(find_if(impropers_.begin(), impropers_.end(), [&improper](const SpeciesImproper &i){return &i == &improper;}));
+    impropers_.erase(
+        find_if(impropers_.begin(), impropers_.end(), [&improper](const SpeciesImproper &i) { return &i == &improper; }));
 }
 
 // Return the number of Impropers in which the Atom is involved

--- a/src/classes/speciesatom.cpp
+++ b/src/classes/speciesatom.cpp
@@ -115,16 +115,14 @@ bool SpeciesAtom::isSelected() const { return selected_; }
  */
 
 // Add Bond reference
-void SpeciesAtom::addBond(SpeciesBond *bond)
+void SpeciesAtom::addBond(SpeciesBond &bond)
 {
-    if (find(bonds_.begin(), bonds_.end(), bond) == bonds_.end())
-    {
+    if (find_if(bonds_.begin(), bonds_.end(), [&bond](const SpeciesBond &b){return &b == &bond;}) == bonds_.end())
         bonds_.push_back(bond);
-    }
 }
 
 // Remove Bond reference
-void SpeciesAtom::removeBond(SpeciesBond *b) { bonds_.erase(find(bonds_.begin(), bonds_.end(), b)); }
+void SpeciesAtom::removeBond(SpeciesBond &b) { bonds_.erase(find_if(bonds_.begin(), bonds_.end(), [&b](const SpeciesBond &bond){return &b == &bond;})); }
 
 // Clear all Bond references
 void SpeciesAtom::clearBonds() { bonds_.clear(); }
@@ -133,16 +131,17 @@ void SpeciesAtom::clearBonds() { bonds_.clear(); }
 int SpeciesAtom::nBonds() const { return bonds_.size(); }
 
 // Return specified bond
-SpeciesBond *SpeciesAtom::bond(int index) { return bonds_.at(index); }
+SpeciesBond &SpeciesAtom::bond(int index) { return bonds_.at(index); }
 
 // Return bonds list
-const std::vector<SpeciesBond *> &SpeciesAtom::bonds() const { return bonds_; }
+const std::vector<std::reference_wrapper<SpeciesBond>> &SpeciesAtom::bonds() const { return bonds_; }
 
 // Return whether Bond to specified Atom exists
-SpeciesBond *SpeciesAtom::hasBond(SpeciesAtom *partner)
+OptionalReferenceWrapper<SpeciesBond> SpeciesAtom::hasBond(SpeciesAtom *partner)
 {
-    auto result = find_if(bonds_.begin(), bonds_.end(), [&](const auto *bond) { return bond->partner(this) == partner; });
-    return result == bonds_.end() ? nullptr : *result;
+    auto result = find_if(bonds_.begin(), bonds_.end(), [&](const SpeciesBond &bond) { return bond.partner(this) == partner; });
+    if (result == bonds_.end()) return std::nullopt;
+    return *result;
 }
 
 // Add specified SpeciesAngle to Atom

--- a/src/classes/speciesatom.cpp
+++ b/src/classes/speciesatom.cpp
@@ -159,7 +159,7 @@ void SpeciesAtom::addAngle(SpeciesAngle &angle)
 }
 
 // Remove angle reference
-void SpeciesAtom::removeAngle(SpeciesAngle &angle) { angles_.erase(find_if(angles_.begin(), angles_.end(), [&angle](const SpeciesAngle a){return &a == &angle;})); }
+void SpeciesAtom::removeAngle(SpeciesAngle &angle) { angles_.erase(find_if(angles_.begin(), angles_.end(), [&angle](const SpeciesAngle &a){return &a == &angle;})); }
 
 // Return the number of Angles in which the Atom is involved
 int SpeciesAtom::nAngles() const { return angles_.size(); }

--- a/src/classes/speciesatom.h
+++ b/src/classes/speciesatom.h
@@ -109,11 +109,11 @@ class SpeciesAtom : public ListItem<SpeciesAtom>
     // List of bonds which this atom participates in
     std::vector<std::reference_wrapper<SpeciesBond>> bonds_;
     // List of angles which this atom participates in
-    std::vector<SpeciesAngle *> angles_;
+    std::vector<std::reference_wrapper<SpeciesAngle>> angles_;
     // List of torsions which this atom participates in
-    std::vector<SpeciesTorsion *> torsions_;
+    std::vector<std::reference_wrapper<SpeciesTorsion>> torsions_;
     // List of torsions which this atom participates in
-    std::vector<SpeciesImproper *> impropers_;
+    std::vector<std::reference_wrapper<SpeciesImproper>> impropers_;
     // Ordered list of Atoms with scaled or excluded interactions
     OrderedPointerDataArray<SpeciesAtom, double> exclusions_;
 
@@ -133,35 +133,35 @@ class SpeciesAtom : public ListItem<SpeciesAtom>
     // Return whether bond to specified atom exists
     OptionalReferenceWrapper<SpeciesBond> hasBond(SpeciesAtom *j);
     // Add specified Angle to Atom
-    void addAngle(SpeciesAngle *angle);
+    void addAngle(SpeciesAngle &angle);
     // Remove angle reference
-    void removeAngle(SpeciesAngle *a);
+    void removeAngle(SpeciesAngle &a);
     // Return the number of SpeciesAngles in which the Atom is involved
     int nAngles() const;
     // Return specified angle
-    SpeciesAngle *angle(int index);
+    SpeciesAngle &angle(int index);
     // Return array of Angles in which the Atom is involved
-    const std::vector<SpeciesAngle *> &angles() const;
+    const std::vector<std::reference_wrapper<SpeciesAngle>> &angles() const;
     // Add specified SpeciesTorsion to Atom
-    void addTorsion(SpeciesTorsion *torsion, double scaling14);
+    void addTorsion(SpeciesTorsion &torsion, double scaling14);
     // Remove torsion reference
-    void removeTorsion(SpeciesTorsion *t);
+    void removeTorsion(SpeciesTorsion &t);
     // Return the number of SpeciesTorsions in which the Atom is involved
     int nTorsions() const;
     // Return specified torsion
-    SpeciesTorsion *torsion(int index);
+    SpeciesTorsion &torsion(int index);
     // Return array of Torsions in which the Atom is involved
-    const std::vector<SpeciesTorsion *> &torsions() const;
+    const std::vector<std::reference_wrapper<SpeciesTorsion>> &torsions() const;
     // Add specified SpeciesImproper to Atom
-    void addImproper(SpeciesImproper *improper);
+    void addImproper(SpeciesImproper &improper);
     // Remove improper reference
-    void removeImproper(SpeciesImproper *t);
+    void removeImproper(SpeciesImproper &t);
     // Return the number of SpeciesImpropers in which the Atom is involved
     int nImpropers() const;
     // Return specified improper
-    SpeciesImproper *improper(int index);
+    SpeciesImproper &improper(int index);
     // Return array of Impropers in which the Atom is involved
-    const std::vector<SpeciesImproper *> &impropers() const;
+    const std::vector<std::reference_wrapper<SpeciesImproper>> &impropers() const;
     // Return scaling factor to employ with specified Atom
     double scaling(const SpeciesAtom *j) const;
 

--- a/src/classes/speciesatom.h
+++ b/src/classes/speciesatom.h
@@ -23,8 +23,8 @@
 
 #include "templates/list.h"
 #include "templates/listitem.h"
-#include "templates/orderedpointerdataarray.h"
 #include "templates/optionalref.h"
+#include "templates/orderedpointerdataarray.h"
 #include "templates/reflist.h"
 #include "templates/vector3.h"
 #include <memory>

--- a/src/classes/speciesatom.h
+++ b/src/classes/speciesatom.h
@@ -24,6 +24,7 @@
 #include "templates/list.h"
 #include "templates/listitem.h"
 #include "templates/orderedpointerdataarray.h"
+#include "templates/optionalref.h"
 #include "templates/reflist.h"
 #include "templates/vector3.h"
 #include <memory>
@@ -106,7 +107,7 @@ class SpeciesAtom : public ListItem<SpeciesAtom>
      */
     private:
     // List of bonds which this atom participates in
-    std::vector<SpeciesBond *> bonds_;
+    std::vector<std::reference_wrapper<SpeciesBond>> bonds_;
     // List of angles which this atom participates in
     std::vector<SpeciesAngle *> angles_;
     // List of torsions which this atom participates in
@@ -118,19 +119,19 @@ class SpeciesAtom : public ListItem<SpeciesAtom>
 
     public:
     // Add bond reference
-    void addBond(SpeciesBond *b);
+    void addBond(SpeciesBond &b);
     // Remove bond reference
-    void removeBond(SpeciesBond *b);
+    void removeBond(SpeciesBond &b);
     // Clear all bond references
     void clearBonds();
     // Return number of bonds
     int nBonds() const;
     // Return specified bond
-    SpeciesBond *bond(int index);
+    SpeciesBond &bond(int index);
     // Return bonds list
-    const std::vector<SpeciesBond *> &bonds() const;
+    const std::vector<std::reference_wrapper<SpeciesBond>> &bonds() const;
     // Return whether bond to specified atom exists
-    SpeciesBond *hasBond(SpeciesAtom *j);
+    OptionalReferenceWrapper<SpeciesBond> hasBond(SpeciesAtom *j);
     // Add specified Angle to Atom
     void addAngle(SpeciesAngle *angle);
     // Remove angle reference

--- a/src/classes/speciesbond.cpp
+++ b/src/classes/speciesbond.cpp
@@ -43,8 +43,8 @@ void SpeciesBond::assign(SpeciesAtom *i, SpeciesAtom *j)
     // Add ourself to the list of bonds on each atom
     if (i_ && j_)
     {
-        i_->addBond(this);
-        j_->addBond(this);
+        i_->addBond(*this);
+        j_->addBond(*this);
     }
 }
 
@@ -53,8 +53,8 @@ SpeciesBond::SpeciesBond(SpeciesBond &&source) : SpeciesIntra(source)
     // Detach source bond referred to by the species atoms
     if (source.i_ && source.j_)
     {
-        source.i_->removeBond(&source);
-        source.j_->removeBond(&source);
+        source.i_->removeBond(source);
+        source.j_->removeBond(source);
     }
 
     // Copy data
@@ -74,8 +74,8 @@ SpeciesBond &SpeciesBond::operator=(const SpeciesBond &source)
     j_ = source.j_;
     if (i_ && j_)
     {
-        i_->addBond(this);
-        j_->addBond(this);
+        i_->addBond(*this);
+        j_->addBond(*this);
     }
     bondType_ = source.bondType_;
     form_ = source.form_;
@@ -181,8 +181,8 @@ void SpeciesBond::detach()
 {
     if (i_ && j_)
     {
-        i_->removeBond(this);
-        j_->removeBond(this);
+        i_->removeBond(*this);
+        j_->removeBond(*this);
     }
     i_ = nullptr;
     j_ = nullptr;

--- a/src/classes/speciesimproper.cpp
+++ b/src/classes/speciesimproper.cpp
@@ -84,13 +84,13 @@ void SpeciesImproper::assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, Spe
 #endif
 
     if (i_)
-        i_->addImproper(this);
+        i_->addImproper(*this);
     if (j_)
-        j_->addImproper(this);
+        j_->addImproper(*this);
     if (k_)
-        k_->addImproper(this);
+        k_->addImproper(*this);
     if (l_)
-        l_->addImproper(this);
+        l_->addImproper(*this);
 }
 
 // Return first SpeciesAtom

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -38,10 +38,10 @@ SpeciesTorsion::SpeciesTorsion(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, S
     // Add ourself to the list of bonds on each atom
     if (i_ && j_ && k_ && l_)
     {
-        i_->addTorsion(this, 0.5);
-        j_->addTorsion(this, 0.5);
-        k_->addTorsion(this, 0.5);
-        l_->addTorsion(this, 0.5);
+        i_->addTorsion(*this, 0.5);
+        j_->addTorsion(*this, 0.5);
+        k_->addTorsion(*this, 0.5);
+        l_->addTorsion(*this, 0.5);
     }
 }
 
@@ -58,10 +58,10 @@ SpeciesTorsion &SpeciesTorsion::operator=(const SpeciesTorsion &source)
 
     if (i_ && j_ && k_ && l_)
     {
-        i_->addTorsion(this, 0.5);
-        j_->addTorsion(this, 0.5);
-        k_->addTorsion(this, 0.5);
-        l_->addTorsion(this, 0.5);
+        i_->addTorsion(*this, 0.5);
+        j_->addTorsion(*this, 0.5);
+        k_->addTorsion(*this, 0.5);
+        l_->addTorsion(*this, 0.5);
     }
     form_ = source.form_;
     SpeciesIntra::operator=(source);
@@ -81,10 +81,10 @@ SpeciesTorsion &SpeciesTorsion::operator=(SpeciesTorsion &&source)
 
     if (i_ && j_ && k_ && l_)
     {
-        i_->addTorsion(this, 0.5);
-        j_->addTorsion(this, 0.5);
-        k_->addTorsion(this, 0.5);
-        l_->addTorsion(this, 0.5);
+        i_->addTorsion(*this, 0.5);
+        j_->addTorsion(*this, 0.5);
+        k_->addTorsion(*this, 0.5);
+        l_->addTorsion(*this, 0.5);
     }
     form_ = source.form_;
     SpeciesIntra::operator=(source);
@@ -97,10 +97,10 @@ void SpeciesTorsion::detach()
 {
     if (i_ && j_ && k_ && l_)
     {
-        i_->removeTorsion(this);
-        j_->removeTorsion(this);
-        k_->removeTorsion(this);
-        l_->removeTorsion(this);
+        i_->removeTorsion(*this);
+        j_->removeTorsion(*this);
+        k_->removeTorsion(*this);
+        l_->removeTorsion(*this);
     }
     i_ = nullptr;
     j_ = nullptr;
@@ -145,13 +145,13 @@ void SpeciesTorsion::assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, Spec
         Messenger::error("NULL_POINTER - NULL pointer passed for SpeciesAtom* l in SpeciesTorsion::set().\n");
 #endif
     if (i_)
-        i_->addTorsion(this, 0.5);
+        i_->addTorsion(*this, 0.5);
     if (j_)
-        j_->addTorsion(this, 0.5);
+        j_->addTorsion(*this, 0.5);
     if (k_)
-        k_->addTorsion(this, 0.5);
+        k_->addTorsion(*this, 0.5);
     if (l_)
-        l_->addTorsion(this, 0.5);
+        l_->addTorsion(*this, 0.5);
 }
 
 // Return first SpeciesAtom

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -701,8 +701,8 @@ bool Forcefield::isBondPattern(const SpeciesAtom *i, const int nSingle, const in
 // Return whether the specified atom is bound to a specific element (and count thereof)
 bool Forcefield::isBoundTo(const SpeciesAtom *i, Element *element, const int count, bool allowMoreThanCount) const
 {
-    auto found = std::count_if(i->bonds().begin(), i->bonds().end(), [i, element](const SpeciesBond &bond) {
-        return bond.partner(i)->element() == element;});
+    auto found = std::count_if(i->bonds().begin(), i->bonds().end(),
+                               [i, element](const SpeciesBond &bond) { return bond.partner(i)->element() == element; });
 
     return (found < count ? false : (found == count ? true : allowMoreThanCount));
 }

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -477,7 +477,7 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
             for (int indexJ = 0; indexJ < i->nBonds() - 2; ++indexJ)
             {
                 // Get SpeciesAtom 'j'
-                SpeciesAtom *j = i->bond(indexJ)->partner(i);
+                SpeciesAtom *j = i->bond(indexJ).partner(i);
                 auto optTypeJ = determineTypes ? determineAtomType(j) : atomTypeByName(j->atomType()->name(), j->element());
                 if (!optTypeJ)
                     return Messenger::error("Couldn't locate object for atom type named '{}'.\n", j->atomType()->name());
@@ -488,7 +488,7 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
                 for (int indexK = indexJ + 1; indexK < i->nBonds() - 1; ++indexK)
                 {
                     // Get SpeciesAtom 'k'
-                    SpeciesAtom *k = i->bond(indexK)->partner(i);
+                    SpeciesAtom *k = i->bond(indexK).partner(i);
                     auto optTypeK = determineTypes ? determineAtomType(k) : atomTypeByName(k->atomType()->name(), k->element());
                     if (!optTypeK)
                         return Messenger::error("Couldn't locate object for atom type named '{}'.\n", k->atomType()->name());
@@ -499,7 +499,7 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
                     for (int indexL = indexK + 1; indexL < i->nBonds(); ++indexL)
                     {
                         // Get SpeciesAtom 'l'
-                        SpeciesAtom *l = i->bond(indexL)->partner(i);
+                        SpeciesAtom *l = i->bond(indexL).partner(i);
                         auto optTypeL =
                             determineTypes ? determineAtomType(l) : atomTypeByName(l->atomType()->name(), l->element());
                         if (!optTypeL)
@@ -566,8 +566,8 @@ Forcefield::AtomGeometry Forcefield::geometryOfAtom(SpeciesAtom *i) const
             break;
         // For the remaining types, take averages of bond angles about the atom
         case (2):
-            h = i->bond(0)->partner(i);
-            j = i->bond(1)->partner(i);
+            h = i->bond(0).partner(i);
+            j = i->bond(1).partner(i);
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             if (angle > 150.0)
                 result = Forcefield::LinearGeometry;
@@ -593,15 +593,15 @@ Forcefield::AtomGeometry Forcefield::geometryOfAtom(SpeciesAtom *i) const
             // 			else if ((largest > 115.0) && (largest < 125.0)) result =
             // Forcefield::TrigPlanarGeometry; 			else if ((largest < 115.0) && (largest > 100.0))
             // result = Forcefield::TetrahedralGeometry; Get largest of the three angles around the central atom
-            h = i->bond(0)->partner(i);
-            j = i->bond(1)->partner(i);
+            h = i->bond(0).partner(i);
+            j = i->bond(1).partner(i);
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             largest = angle;
-            j = i->bond(2)->partner(i);
+            j = i->bond(2).partner(i);
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             if (angle > largest)
                 largest = angle;
-            h = i->bond(1)->partner(i);
+            h = i->bond(1).partner(i);
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             if (angle > largest)
                 largest = angle;
@@ -620,10 +620,10 @@ Forcefield::AtomGeometry Forcefield::geometryOfAtom(SpeciesAtom *i) const
             angle = 0.0;
             for (int n = 0; n < i->nBonds(); ++n)
             {
-                h = i->bond(n)->partner(i);
+                h = i->bond(n).partner(i);
                 for (int m = n + 1; m < i->nBonds(); ++m)
                 {
-                    j = i->bond(m)->partner(i);
+                    j = i->bond(m).partner(i);
                     angle += NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
                 }
             }
@@ -648,9 +648,9 @@ bool Forcefield::isBondPattern(const SpeciesAtom *i, const int nSingle, const in
                                const int nQuadruple, const int nAromatic) const
 {
     auto actualNSingle = 0, actualNDouble = 0, actualNTriple = 0, actualNQuadruple = 0, actualNAromatic = 0;
-    for (const auto *bond : i->bonds())
+    for (const SpeciesBond &bond : i->bonds())
     {
-        switch (bond->bondType())
+        switch (bond.bondType())
         {
             case (SpeciesBond::SingleBond):
                 if (nSingle == actualNSingle)
@@ -701,11 +701,8 @@ bool Forcefield::isBondPattern(const SpeciesAtom *i, const int nSingle, const in
 // Return whether the specified atom is bound to a specific element (and count thereof)
 bool Forcefield::isBoundTo(const SpeciesAtom *i, Element *element, const int count, bool allowMoreThanCount) const
 {
-    auto found = 0;
-
-    for (const auto *bond : i->bonds())
-        if (bond->partner(i)->element() == element)
-            ++found;
+    auto found = std::count_if(i->bonds().begin(), i->bonds().end(), [i, element](const SpeciesBond &bond) {
+        return bond.partner(i)->element() == element;});
 
     return (found < count ? false : (found == count ? true : allowMoreThanCount));
 }
@@ -725,10 +722,10 @@ int Forcefield::guessOxidationState(const SpeciesAtom *i) const
     // (OS == 0)
     auto nSameElement = 0;
 
-    const std::vector<SpeciesBond *> &bonds = i->bonds();
-    for (const auto *bond : bonds)
+    const auto &bonds = i->bonds();
+    for (const SpeciesBond &bond : bonds)
     {
-        Element *element = bond->partner(i)->element();
+        Element *element = bond.partner(i)->element();
         switch (element->Z())
         {
             // Group 1A - Alkali earth metals (includes Hydrogen)
@@ -752,7 +749,7 @@ int Forcefield::guessOxidationState(const SpeciesAtom *i) const
                 break;
             // Oxygen
             case (ELEMENT_O):
-                if (bond->bondType() == SpeciesBond::DoubleBond)
+                if (bond.bondType() == SpeciesBond::DoubleBond)
                     osBound -= 2;
                 else
                     osBound -= 1;

--- a/src/gui/render/renderableconfiguration.cpp
+++ b/src/gui/render/renderableconfiguration.cpp
@@ -201,11 +201,11 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
             else
             {
                 // Draw all bonds from this atom
-                for (const auto *bond : i->speciesAtom()->bonds())
+                for (const SpeciesBond &bond : i->speciesAtom()->bonds())
                 {
                     // Blindly get partner Atom 'j' - don't check if it is the true partner, only if it is
                     // the same as 'i' (in which case we skip it, ensuring we draw every bond only once)
-                    partner = i->molecule()->atom(bond->indexJ());
+                    partner = i->molecule()->atom(bond.indexJ());
                     if (i == partner)
                         continue;
 
@@ -217,9 +217,9 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
 
                     // Draw bond halves
                     lineConfigurationPrimitive_->line(ri.x, ri.y, ri.z, ri.x + dij.x, ri.y + dij.y, ri.z + dij.z,
-                                                      ElementColours::colour(bond->i()->element()));
+                                                      ElementColours::colour(bond.i()->element()));
                     lineConfigurationPrimitive_->line(rj.x, rj.y, rj.z, rj.x - dij.x, rj.y - dij.y, rj.z - dij.z,
-                                                      ElementColours::colour(bond->j()->element()));
+                                                      ElementColours::colour(bond.j()->element()));
                 }
             }
         }
@@ -244,11 +244,11 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
             configurationAssembly_.add(atomPrimitive_, A, colour[0], colour[1], colour[2], colour[3]);
 
             // Bonds from this atom
-            for (const auto *bond : i->speciesAtom()->bonds())
+            for (const SpeciesBond &bond : i->speciesAtom()->bonds())
             {
                 // Blindly get partner Atom 'j' - don't check if it is the true partner, only if it is the same
                 // as 'i' (in which case we skip it, ensuring we draw every bond only once)
-                partner = i->molecule()->atom(bond->indexJ());
+                partner = i->molecule()->atom(bond.indexJ());
                 if (i == partner)
                     continue;
 

--- a/src/gui/render/renderablespecies.cpp
+++ b/src/gui/render/renderablespecies.cpp
@@ -315,10 +315,10 @@ void RenderableSpecies::recreateSelectionPrimitive()
             else
             {
                 // Draw all bonds from this atom
-                for (const auto *bond : i->bonds())
+                for (const SpeciesBond &bond : i->bonds())
                 {
                     const auto ri = i->r();
-                    const auto dij = (bond->partner(i)->r() - ri) * 0.5;
+                    const auto dij = (bond.partner(i)->r() - ri) * 0.5;
 
                     // Draw bond halves
                     lineSelectionPrimitive_->line(ri.x, ri.y, ri.z, ri.x + dij.x, ri.y + dij.y, ri.z + dij.z, colour);

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -173,8 +173,8 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
         std::shared_ptr<const Molecule> mol = i->molecule();
 
         // Calculate forces from SpeciesBond terms
-        for (const auto *bond : spAtom->bonds())
-            kernel.forces(i, *bond, mol->atom(bond->indexI()), mol->atom(bond->indexJ()));
+        for (const SpeciesBond &bond : spAtom->bonds())
+            kernel.forces(i, bond, mol->atom(bond.indexI()), mol->atom(bond.indexJ()));
 
         // Calculate forces from SpeciesAngle terms
         for (const auto *angle : spAtom->angles())

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -187,8 +187,8 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
 
         // Calculate forces from SpeciesImproper terms
         for (const SpeciesImproper &improper : spAtom->impropers())
-            kernel.forces(i, improper, mol->atom(improper.indexI()), mol->atom(improper.indexJ()),
-                          mol->atom(improper.indexK()), mol->atom(improper.indexL()));
+            kernel.forces(i, improper, mol->atom(improper.indexI()), mol->atom(improper.indexJ()), mol->atom(improper.indexK()),
+                          mol->atom(improper.indexL()));
     }
 }
 

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -177,18 +177,18 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
             kernel.forces(i, bond, mol->atom(bond.indexI()), mol->atom(bond.indexJ()));
 
         // Calculate forces from SpeciesAngle terms
-        for (const auto *angle : spAtom->angles())
-            kernel.forces(i, *angle, mol->atom(angle->indexI()), mol->atom(angle->indexJ()), mol->atom(angle->indexK()));
+        for (const SpeciesAngle &angle : spAtom->angles())
+            kernel.forces(i, angle, mol->atom(angle.indexI()), mol->atom(angle.indexJ()), mol->atom(angle.indexK()));
 
         // Calculate forces from SpeciesTorsion terms
-        for (const auto *torsion : spAtom->torsions())
-            kernel.forces(i, *torsion, mol->atom(torsion->indexI()), mol->atom(torsion->indexJ()), mol->atom(torsion->indexK()),
-                          mol->atom(torsion->indexL()));
+        for (const SpeciesTorsion &torsion : spAtom->torsions())
+            kernel.forces(i, torsion, mol->atom(torsion.indexI()), mol->atom(torsion.indexJ()), mol->atom(torsion.indexK()),
+                          mol->atom(torsion.indexL()));
 
         // Calculate forces from SpeciesImproper terms
-        for (const auto *improper : spAtom->impropers())
-            kernel.forces(i, *improper, mol->atom(improper->indexI()), mol->atom(improper->indexJ()),
-                          mol->atom(improper->indexK()), mol->atom(improper->indexL()));
+        for (const SpeciesImproper &improper : spAtom->impropers())
+            kernel.forces(i, improper, mol->atom(improper.indexI()), mol->atom(improper.indexJ()),
+                          mol->atom(improper.indexK()), mol->atom(improper.indexL()));
     }
 }
 

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -918,7 +918,8 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
     {
         // Grab the name, replace hyphens with '-', and parse the string into arguments
         std::string dataName{data->name()};
-        std::replace_if(dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
+        std::replace_if(
+            dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
         parser.getArgsDelim(LineParser::Defaults, dataName);
 
         // Sanity check on number of arguments
@@ -949,7 +950,8 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
     {
         // Grab the name, replace hyphens with '-', and parse the string into arguments
         std::string dataName{data->name()};
-        std::replace_if(dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
+        std::replace_if(
+            dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
         parser.getArgsDelim(LineParser::Defaults, dataName);
 
         // Sanity check on number of arguments

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -918,8 +918,7 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
     {
         // Grab the name, replace hyphens with '-', and parse the string into arguments
         std::string dataName{data->name()};
-        std::replace_if(
-            dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
+        std::replace_if(dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
         parser.getArgsDelim(LineParser::Defaults, dataName);
 
         // Sanity check on number of arguments
@@ -950,8 +949,7 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
     {
         // Grab the name, replace hyphens with '-', and parse the string into arguments
         std::string dataName{data->name()};
-        std::replace_if(
-            dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
+        std::replace_if(dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
         parser.getArgsDelim(LineParser::Defaults, dataName);
 
         // Sanity check on number of arguments

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -218,7 +218,8 @@ int NETAConnectionNode::score(const SpeciesAtom *i, RefList<const SpeciesAtom> &
         if (nHydrogensValue_ >= 0)
         {
             // Count number of hydrogens attached to this atom
-	  auto nH = std::count_if(j->bonds().begin(), j->bonds().end(), [j](const SpeciesBond &bond){ return bond.partner(j)->element()->Z() == ELEMENT_H;});
+            auto nH = std::count_if(j->bonds().begin(), j->bonds().end(),
+                                    [j](const SpeciesBond &bond) { return bond.partner(j)->element()->Z() == ELEMENT_H; });
             if (!compareValues(nH, nHydrogensValueOperator_, nHydrogensValue_))
                 continue;
 

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -140,9 +140,9 @@ int NETAConnectionNode::score(const SpeciesAtom *i, RefList<const SpeciesAtom> &
 {
     // Get directly connected atoms about 'i', excluding any that have already been matched
     RefDataList<const SpeciesAtom, int> neighbours;
-    for (const auto *bond : i->bonds())
+    for (const SpeciesBond &bond : i->bonds())
     {
-        const auto *partner = bond->partner(i);
+        const auto *partner = bond.partner(i);
         if (partner == matchPath.firstItem())
         {
             // We may allow the path's root atom to be matched again, if the allowRootMatch_ is set...
@@ -218,10 +218,7 @@ int NETAConnectionNode::score(const SpeciesAtom *i, RefList<const SpeciesAtom> &
         if (nHydrogensValue_ >= 0)
         {
             // Count number of hydrogens attached to this atom
-            auto nH = 0;
-            for (const auto *bond : j->bonds())
-                if (bond->partner(j)->element()->Z() == ELEMENT_H)
-                    ++nH;
+	  auto nH = std::count_if(j->bonds().begin(), j->bonds().end(), [j](const SpeciesBond &bond){ return bond.partner(j)->element()->Z() == ELEMENT_H;});
             if (!compareValues(nH, nHydrogensValueOperator_, nHydrogensValue_))
                 continue;
 

--- a/src/neta/presence.cpp
+++ b/src/neta/presence.cpp
@@ -160,8 +160,8 @@ int NETAPresenceNode::score(const SpeciesAtom *i, RefList<const SpeciesAtom> &av
         if (nHydrogensValue_ >= 0)
         {
             // Count number of hydrogens attached to this atom
-	  auto nH = std::count_if(j->bonds().begin(), j->bonds().end(), [j](const SpeciesBond &bond){
-	      return bond.partner(j)->element()->Z() == ELEMENT_H;});
+            auto nH = std::count_if(j->bonds().begin(), j->bonds().end(),
+                                    [j](const SpeciesBond &bond) { return bond.partner(j)->element()->Z() == ELEMENT_H; });
             if (!compareValues(nH, nHydrogensValueOperator_, nHydrogensValue_))
                 return NETANode::NoMatch;
 

--- a/src/neta/presence.cpp
+++ b/src/neta/presence.cpp
@@ -160,10 +160,8 @@ int NETAPresenceNode::score(const SpeciesAtom *i, RefList<const SpeciesAtom> &av
         if (nHydrogensValue_ >= 0)
         {
             // Count number of hydrogens attached to this atom
-            auto nH = 0;
-            for (const auto *bond : j->bonds())
-                if (bond->partner(j)->element()->Z() == ELEMENT_H)
-                    ++nH;
+	  auto nH = std::count_if(j->bonds().begin(), j->bonds().end(), [j](const SpeciesBond &bond){
+	      return bond.partner(j)->element()->Z() == ELEMENT_H;});
             if (!compareValues(nH, nHydrogensValueOperator_, nHydrogensValue_))
                 return NETANode::NoMatch;
 

--- a/src/neta/ring.cpp
+++ b/src/neta/ring.cpp
@@ -96,14 +96,14 @@ void NETARingNode::findRings(const SpeciesAtom *currentAtom, List<SpeciesRing> &
     // Loop over bonds to the atom
     const SpeciesAtom *j;
     SpeciesRing *ring;
-    for (const auto *bond : currentAtom->bonds())
+    for (const SpeciesBond &bond : currentAtom->bonds())
     {
         /*
          * Get the partner atom and compare to first atom in the current path.
          * If it is the currentAtom then we have found a cyclic route back to the originating atom.
          * If not, check whether the atom is already elsewhere in the path - if so, continue with the next bond.
          */
-        j = bond->partner(currentAtom);
+        j = bond.partner(currentAtom);
         if ((path.size() >= minSize) && (j == path.at(0)))
         {
             // Special case - if NotEqualTo was specified as the comparison operator, check that against the maximum

--- a/src/neta/root.cpp
+++ b/src/neta/root.cpp
@@ -94,9 +94,8 @@ int NETARootNode::score(const SpeciesAtom *i, RefList<const SpeciesAtom> &matchP
     if (nHydrogensValue_ >= 0)
     {
         // Count number of hydrogens attached to this atom
-      auto nH = std::count_if(i->bonds().begin(), i->bonds().end(),
-			      [i](const SpeciesBond &bond) {
-				return bond.partner(i)->element()->Z() == ELEMENT_H;});
+        auto nH = std::count_if(i->bonds().begin(), i->bonds().end(),
+                                [i](const SpeciesBond &bond) { return bond.partner(i)->element()->Z() == ELEMENT_H; });
         if (!compareValues(nH, nHydrogensValueOperator_, nHydrogensValue_))
             return NETANode::NoMatch;
 

--- a/src/neta/root.cpp
+++ b/src/neta/root.cpp
@@ -94,10 +94,9 @@ int NETARootNode::score(const SpeciesAtom *i, RefList<const SpeciesAtom> &matchP
     if (nHydrogensValue_ >= 0)
     {
         // Count number of hydrogens attached to this atom
-        auto nH = 0;
-        for (const auto *bond : i->bonds())
-            if (bond->partner(i)->element()->Z() == ELEMENT_H)
-                ++nH;
+      auto nH = std::count_if(i->bonds().begin(), i->bonds().end(),
+			      [i](const SpeciesBond &bond) {
+				return bond.partner(i)->element()->Z() == ELEMENT_H;});
         if (!compareValues(nH, nHydrogensValueOperator_, nHydrogensValue_))
             return NETANode::NoMatch;
 


### PR DESCRIPTION
The pointers in SpeciesAtom have been converted into references.  References were chosen over safe pointers because the actual values are contained in a `std::vector` in `Species`, so the lifetime of the vector and of the pointer would conflict.