### PR TITLE
Catch std::stod out_of_range exception

### DIFF
--- a/src/base/lineparser.cpp
+++ b/src/base/lineparser.cpp
@@ -25,8 +25,6 @@
 #include "base/sysfunc.h"
 #include "templates/enumhelpers.h"
 #include <limits>
-#include <stdarg.h>
-#include <string.h>
 
 LineParser::LineParser(ProcessPool *procPool)
 {

--- a/src/base/lineparser.cpp
+++ b/src/base/lineparser.cpp
@@ -24,6 +24,7 @@
 #include "base/processpool.h"
 #include "base/sysfunc.h"
 #include "templates/enumhelpers.h"
+#include <limits>
 #include <stdarg.h>
 #include <string.h>
 
@@ -879,7 +880,28 @@ double LineParser::argd(int i)
         Messenger::warn("LineParser::argd() - Argument {} is out of range - returning 0.0...\n", i);
         return 0.0;
     }
-    return std::stod(arguments_[i]);
+
+    // Attempt to convert the current argument
+    try
+    {
+        return std::stod(arguments_[i]);
+    }
+    catch (std::out_of_range &rangeError)
+    {
+        std::string exponent{DissolveSys::afterChar(arguments_[i], "eE")};
+        if (exponent.empty())
+            Messenger::warn(
+                "LineParser::argd() : String '{}' causes an out-of-range exception on conversion - returning 0.0...",
+                arguments_[i]);
+        else if (std::stoi(exponent) >= std::numeric_limits<int>::max_exponent)
+            Messenger::warn("LineParser::argd() : String '{}' causes an overflow on conversion - returning 0.0...",
+                            arguments_[i]);
+        else if (std::stoi(exponent) <= std::numeric_limits<int>::min_exponent)
+            Messenger::warn("LineParser::argd() : String '{}' causes an underflow on conversion - returning 0.0...",
+                            arguments_[i]);
+    }
+
+    return 0.0;
 }
 
 // Returns the specified argument as a bool


### PR DESCRIPTION
This PR adds a try/catch around the `std::stod()` call in `LineParser::argd()` in order to avoid bailouts when reading in small, but legitimate, floating point numbers.

The new behaviour is to raise a warning to the user, but return `0.0` as the result (no exception is raised).

Closes #376.

**Uses the system test introduced in PR #377 - not to be merged until #377 is merged.**