### PR TITLE
Enable type safe early returns in custom for_each_pair

### DIFF
--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -77,7 +77,7 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::Exp
 
     i = 0;
     auto result = for_each_pair_early(
-        dissolve.atomTypes().begin(), dissolve.atomTypes().end(), [&](int i, auto at1, int j, auto at2) -> std::optional<bool> {
+        dissolve.atomTypes().begin(), dissolve.atomTypes().end(), [&](int i, auto at1, int j, auto at2) {
             Array<double> &potCoeff = coefficients.at(i, j);
 
             // Regenerate empirical potential from the stored coefficients
@@ -109,14 +109,14 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::Exp
             if (!pp)
             {
                 Messenger::error("Failed to find PairPotential for AtomTypes '{}' and '{}'.\n", at1->name(), at2->name());
-                return false;
+                return EarlyReturn(false);
             }
 
             pp->setUAdditional(ep);
-            return std::nullopt;
+            return EarlyReturn<bool>::Continue();
         });
 
-    return result.value_or(true).value_or(true);
+    return result.value_or(true);
 }
 
 // Generate and return single empirical potential function

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -77,7 +77,7 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::Exp
 
     i = 0;
     auto result = for_each_pair_early(
-        dissolve.atomTypes().begin(), dissolve.atomTypes().end(), [&](int i, auto at1, int j, auto at2) {
+				      dissolve.atomTypes().begin(), dissolve.atomTypes().end(), [&](int i, auto at1, int j, auto at2) -> EarlyReturn<bool> {
             Array<double> &potCoeff = coefficients.at(i, j);
 
             // Regenerate empirical potential from the stored coefficients
@@ -109,11 +109,11 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::Exp
             if (!pp)
             {
                 Messenger::error("Failed to find PairPotential for AtomTypes '{}' and '{}'.\n", at1->name(), at2->name());
-                return EarlyReturn(false);
+                return false;
             }
 
             pp->setUAdditional(ep);
-            return EarlyReturn<bool>::Continue();
+            return EarlyReturn<bool>::Continue;
         });
 
     return result.value_or(true);

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -77,7 +77,7 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::Exp
 
     i = 0;
     auto result = for_each_pair_early(
-				      dissolve.atomTypes().begin(), dissolve.atomTypes().end(), [&](int i, auto at1, int j, auto at2) -> EarlyReturn<bool> {
+        dissolve.atomTypes().begin(), dissolve.atomTypes().end(), [&](int i, auto at1, int j, auto at2) -> EarlyReturn<bool> {
             Array<double> &potCoeff = coefficients.at(i, j);
 
             // Regenerate empirical potential from the stored coefficients

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -600,7 +600,7 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
                                 if (!scatteringMatrix.addPartialReferenceData(data, at1, at2, 1.0, (1.0 - feedback)))
                                     return Messenger::error("EPSR: Failed to augment scattering matrix with partial {}-{}.\n",
                                                             at1->name(), at2->name());
-                                return EarlyReturn<bool>::Continue();
+                                return EarlyReturn<bool>::Continue;
                             });
 
         scatteringMatrix.finalise();
@@ -643,20 +643,21 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // Test Mode
         if (testMode)
         {
-            for_each_pair_early(
-                dissolve.atomTypes().begin(), dissolve.atomTypes().end(), [&](int i, auto at1, int j, auto at2) {
-                    testDataName = fmt::format("EstimatedSQ-{}-{}", at1->name(), at2->name());
-                    if (testData_.containsData(testDataName))
-                    {
-                        double error = Error::percent(estimatedSQ.at(i, j), testData_.data(testDataName));
-                        Messenger::print("Generated S(Q) reference data '{}' has error of {:7.3f}% with "
-                                         "calculated data and is {} (threshold is {:6.3f}%)\n\n",
-                                         testDataName, error, error <= testThreshold ? "OK" : "NOT OK", testThreshold);
-                        if (error > testThreshold)
-                            return EarlyReturn(false);
-                    }
-                    return EarlyReturn<bool>::Continue();
-                });
+            for_each_pair_early(dissolve.atomTypes().begin(), dissolve.atomTypes().end(),
+                                [&](int i, auto at1, int j, auto at2) -> EarlyReturn<bool> {
+                                    testDataName = fmt::format("EstimatedSQ-{}-{}", at1->name(), at2->name());
+                                    if (testData_.containsData(testDataName))
+                                    {
+                                        double error = Error::percent(estimatedSQ.at(i, j), testData_.data(testDataName));
+                                        Messenger::print("Generated S(Q) reference data '{}' has error of {:7.3f}% with "
+                                                         "calculated data and is {} (threshold is {:6.3f}%)\n\n",
+                                                         testDataName, error, error <= testThreshold ? "OK" : "NOT OK",
+                                                         testThreshold);
+                                        if (error > testThreshold)
+                                            return false;
+                                    }
+                                    return EarlyReturn<bool>::Continue;
+                                });
         }
 
         /*

--- a/src/modules/refine/process.cpp
+++ b/src/modules/refine/process.cpp
@@ -361,7 +361,7 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     if (!scatteringMatrix_.addPartialReferenceData(data, at1, at2, factor, (1.0 - augmentationParam)))
                         return Messenger::error("Refine: Failed to augment scattering matrix with partial {}-{}.\n",
                                                 at1->name(), at2->name());
-                    return EarlyReturn<bool>::Continue();
+                    return EarlyReturn<bool>::Continue;
                 });
         }
         else if (augmentationStyle != RefineModule::NoAugmentation)

--- a/src/modules/refine/process.cpp
+++ b/src/modules/refine/process.cpp
@@ -344,7 +344,7 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
             simulatedReferenceData_.createEmpty(combinedUnweightedSQ.linearArraySize());
             for_each_pair_early(
                 dissolve.atomTypes().begin(), dissolve.atomTypes().end(),
-                [&](int i, auto at1, int j, auto at2) -> std::optional<bool> {
+                [&](int i, auto at1, int j, auto at2) -> EarlyReturn<bool> {
                     // Weight in the matrix will be based on the natural isotope and the summed
                     // concentration weight
                     double factor = Isotopes::naturalIsotope(at1->element())->boundCoherent() *
@@ -361,7 +361,7 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     if (!scatteringMatrix_.addPartialReferenceData(data, at1, at2, factor, (1.0 - augmentationParam)))
                         return Messenger::error("Refine: Failed to augment scattering matrix with partial {}-{}.\n",
                                                 at1->name(), at2->name());
-                    return std::nullopt;
+                    return EarlyReturn<bool>::Continue();
                 });
         }
         else if (augmentationStyle != RefineModule::NoAugmentation)

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -37,9 +37,31 @@ template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, Lam la
     }
 }
 
+enum class EarlyReturnType
+{
+    Return,  // Give an early return value
+    Break,   // Move to the next outer loop
+    Continue // Continue the inner loop
+};
+
+template <typename T> class EarlyReturn
+{
+    private:
+    EarlyReturnType type_;
+    std::optional<T> value_;
+
+    public:
+    EarlyReturn(EarlyReturnType t = EarlyReturnType::Continue, std::optional<T> v = std::nullopt) : type_(t), value_(v){};
+    EarlyReturn(const T &val) : type_(EarlyReturnType::Return), value_(val){};
+    static EarlyReturn Break() { return EarlyReturn(EarlyReturnType::Break); }
+    static EarlyReturn Continue() { return EarlyReturn(EarlyReturnType::Break); }
+    EarlyReturnType type() const { return type_; }
+    std::optional<T> value() const { return value_; }
+};
+
 // Perform an operation on every pair of elements in a container
 template <class Iter, class Lam>
-auto for_each_pair_early(Iter begin, Iter end, Lam lambda) -> std::optional<decltype(lambda(0, *begin, 0, *end))>
+auto for_each_pair_early(Iter begin, Iter end, Lam lambda) -> decltype(lambda(0, *begin, 0, *end).value())
 {
     int i = 0;
     for (auto elem1 = begin; elem1 != end; ++elem1, ++i)
@@ -48,8 +70,15 @@ auto for_each_pair_early(Iter begin, Iter end, Lam lambda) -> std::optional<decl
         for (auto elem2 = elem1; elem2 != end; ++elem2, ++j)
         {
             auto result = lambda(i, *elem1, j, *elem2);
-            if (result)
-                return result;
+            switch (result.type())
+            {
+                case EarlyReturnType::Return:
+                    return result.value();
+                case EarlyReturnType::Break:
+                    break;
+                case EarlyReturnType::Continue:
+                    continue;
+            }
         }
     }
     return std::nullopt;

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -37,25 +37,24 @@ template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, Lam la
     }
 }
 
-enum class EarlyReturnType
-{
-    Return,  // Give an early return value
-    Break,   // Move to the next outer loop
-    Continue // Continue the inner loop
-};
-
 template <typename T> class EarlyReturn
 {
+    public:
+    enum Type
+    {
+        Return,  // Return immediately with the given value
+        Break,   // Move to the next step in the outer loop
+        Continue // Move to the next step in the inner loop
+    };
+
     private:
-    EarlyReturnType type_;
+    Type type_;
     std::optional<T> value_;
 
     public:
-    EarlyReturn(EarlyReturnType t = EarlyReturnType::Continue, std::optional<T> v = std::nullopt) : type_(t), value_(v){};
-    EarlyReturn(const T &val) : type_(EarlyReturnType::Return), value_(val){};
-    static EarlyReturn Break() { return EarlyReturn(EarlyReturnType::Break); }
-    static EarlyReturn Continue() { return EarlyReturn(EarlyReturnType::Break); }
-    EarlyReturnType type() const { return type_; }
+    EarlyReturn(Type t = Type::Continue, std::optional<T> v = std::nullopt) : type_(t), value_(v){};
+    EarlyReturn(const T &val) : type_(Type::Return), value_(val){};
+    Type type() const { return type_; }
     std::optional<T> value() const { return value_; }
 };
 
@@ -72,11 +71,11 @@ auto for_each_pair_early(Iter begin, Iter end, Lam lambda) -> decltype(lambda(0,
             auto result = lambda(i, *elem1, j, *elem2);
             switch (result.type())
             {
-                case EarlyReturnType::Return:
+                case EarlyReturn<decltype(lambda(0, *begin, 0, *end).value())>::Return:
                     return result.value();
-                case EarlyReturnType::Break:
+                case EarlyReturn<decltype(lambda(0, *begin, 0, *end).value())>::Break:
                     break;
-                case EarlyReturnType::Continue:
+                case EarlyReturn<decltype(lambda(0, *begin, 0, *end).value())>::Continue:
                     continue;
             }
         }


### PR DESCRIPTION
This creates a second version of `for_each_pair` called `for_each_pair_early`.  Using this algorithm requires a bit more overhead, in that

1) The lambda must be given an explicit return type of EarlyReturn<T>, where T is the return type
2) The lambda must return EarlyReturn<T>::Continue at the end of the function to continue to the next step.

In return for the extra overhead and hassle, this version both allows for skipping sections of the inner loop and also performing early returns.