### PR TITLE
Add averaging to other partials

### DIFF
--- a/src/classes/partialset.cpp
+++ b/src/classes/partialset.cpp
@@ -105,21 +105,27 @@ void PartialSet::setUpHistograms(double rdfRange, double binWidth)
 // Reset partial arrays
 void PartialSet::reset()
 {
-    auto nTypes = atomTypes_.nItems();
-    for (int n = 0; n < nTypes; ++n)
-    {
-        for (int m = n; m < nTypes; ++m)
+    // Zero histogram bins if present
+    for (auto n = 0; n < fullHistograms_.nRows(); ++n)
+        for (auto m = n; m < fullHistograms_.nColumns(); ++m)
         {
             fullHistograms_.at(n, m).zeroBins();
             boundHistograms_.at(n, m).zeroBins();
             unboundHistograms_.at(n, m).zeroBins();
+        }
 
+    // Zero partials
+    auto nTypes = atomTypes_.nItems();
+    for (auto n = 0; n < nTypes; ++n)
+        for (auto m = n; m < nTypes; ++m)
+        {
             partials_.at(n, m).values() = 0.0;
             boundPartials_.at(n, m).values() = 0.0;
             unboundPartials_.at(n, m).values() = 0.0;
             emptyBoundPartials_.at(n, m) = true;
         }
-    }
+
+    // Zero total
     total_.values() = 0.0;
 
     fingerprint_ = "NO_FINGERPRINT";

--- a/src/math/averaging.h
+++ b/src/math/averaging.h
@@ -67,10 +67,8 @@ class Averaging
     {
         // Find the 'root' data of type T, which should currently contain the most recently-calculated data
         if (!moduleData.contains(name, prefix))
-        {
-            Messenger::error("Couldn't find root data '{}' (prefix = '{}') in order to perform averaging.\n", name, prefix);
-            return false;
-        }
+            return Messenger::error("Couldn't find root data '{}' (prefix = '{}') in order to perform averaging.\n", name,
+                                    prefix);
         T &currentData = GenericListHelper<T>::retrieve(moduleData, name, prefix);
 
         // Establish the number of existing datasets, and perform management on them

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -357,9 +357,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
             // Get the set...
             auto topeSetData = isotopologues_.getIsotopologueSet(cfg);
             if (!topeSetData)
-            {
                 return Messenger::error("Could not locate IsotopologueSet");
-            }
             const IsotopologueSet &topeSet = *topeSetData;
 
             // Iterate over Species present in the set

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -25,8 +25,6 @@ bool RDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     const auto averaging = keywords_.asInt("Averaging");
-    if (!Averaging::averagingSchemes().isValid(keywords_.asString("AveragingScheme")))
-        return Averaging::averagingSchemes().errorAndPrintValid(keywords_.asString("AveragingScheme"));
     auto averagingScheme = keywords_.enumeration<Averaging::AveragingScheme>("AveragingScheme");
     auto &intraBroadening = keywords_.retrieve<PairBroadeningFunction>("IntraBroadening", PairBroadeningFunction());
     auto method = keywords_.enumeration<RDFModule::PartialsMethod>("Method");


### PR DESCRIPTION
This PR adds averaging over multiple datasets to the structure factor modules SQ, NeutronSQ, and XRaySQ, basically copy/pasting the relevant module variables and code snippet from RDF.

Some other minor modifications to the naming of stored data were made in order to avoid potential clashes when, e.g., both neutron and x-ray partials were calculated for the same configuration.

Closes #389.