### PR TITLE
Download / install signing key for LLVM

### DIFF
--- a/.azure-pipelines/templates/code-quality-checks.yml
+++ b/.azure-pipelines/templates/code-quality-checks.yml
@@ -10,6 +10,7 @@ stages:
         steps:
           - bash: |
               set -ex
+              wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
               sudo add-apt-repository --yes 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main'
               sudo apt-get update
               sudo apt-get install --yes clang-format-7


### PR DESCRIPTION
Download / install GPG signing key from LLVM prior to adding / updating repo.
