### PR TITLE
Refactor CLI option handling

### DIFF
--- a/.azure-pipelines/continuous.yml
+++ b/.azure-pipelines/continuous.yml
@@ -63,6 +63,7 @@ stages:
               ArtifactName: 'osx-artifacts'
             displayName: 'Publish OSX Artifacts'
       - job: 'windows_serialgui'
+        timeoutInMinutes: 120
         displayName: 'Build Windows (Serial/GUI, windows-latest)'
         pool:
           vmImage: 'windows-latest' 

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -19,7 +19,6 @@ stages:
     displayName: 'Build'
     jobs:
       - job: 'linux_serialgui'
-        condition: eq(0,1)
         displayName: 'Build Linux (Serial/GUI, ubuntu-18.04)'
         pool:
           vmImage: 'ubuntu-18.04' 
@@ -41,7 +40,6 @@ stages:
               ArtifactName: 'linux-tests-serial'
             displayName: 'Publish Serial Test Artifacts'
       - job: 'linux_parallel'
-        condition: eq(0,1)
         displayName: 'Build Linux (Parallel, ubuntu-18.04)'
         pool:
           vmImage: 'ubuntu-18.04' 
@@ -59,7 +57,6 @@ stages:
               ArtifactName: 'linux-tests-parallel'
             displayName: 'Publish Parallel Test Artifacts'
       - job: 'osx_serialgui'
-        condition: eq(0,1)
         displayName: 'Build OSX (Serial/GUI, macos-latest)'
         pool:
           vmImage: 'macos-latest' 
@@ -75,6 +72,7 @@ stages:
               ArtifactName: 'osx-artifacts'
             displayName: 'Publish OSX Artifacts'
       - job: 'windows_serialgui'
+        timeoutInMinutes: 120
         displayName: 'Build Windows (Serial/GUI, windows-latest)'
         pool:
           vmImage: 'windows-latest' 

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -19,6 +19,7 @@ stages:
     displayName: 'Build'
     jobs:
       - job: 'linux_serialgui'
+        condition: eq(0,1)
         displayName: 'Build Linux (Serial/GUI, ubuntu-18.04)'
         pool:
           vmImage: 'ubuntu-18.04' 
@@ -40,6 +41,7 @@ stages:
               ArtifactName: 'linux-tests-serial'
             displayName: 'Publish Serial Test Artifacts'
       - job: 'linux_parallel'
+        condition: eq(0,1)
         displayName: 'Build Linux (Parallel, ubuntu-18.04)'
         pool:
           vmImage: 'ubuntu-18.04' 
@@ -57,6 +59,7 @@ stages:
               ArtifactName: 'linux-tests-parallel'
             displayName: 'Publish Parallel Test Artifacts'
       - job: 'osx_serialgui'
+        condition: eq(0,1)
         displayName: 'Build OSX (Serial/GUI, macos-latest)'
         pool:
           vmImage: 'macos-latest' 

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -68,6 +68,7 @@ stages:
               ArtifactName: 'osx-artifacts'
             displayName: 'Publish OSX Artifacts'
       - job: 'windows_serialgui'
+        timeoutInMinutes: 120
         displayName: 'Build Windows (Serial/GUI, windows-latest)'
         pool:
           vmImage: 'windows-latest' 

--- a/.azure-pipelines/templates/build-windows-serial-gui.yml
+++ b/.azure-pipelines/templates/build-windows-serial-gui.yml
@@ -13,14 +13,11 @@ steps:
     inputs:
       versionSpec: '3.x'
   - script: |
-      choco install -y antlr4 ninja winflexbison unzip
+      choco install -y antlr4 winflexbison unzip
     displayName: 'Install Prerequisites'
   - script: |
       python -m pip install aqtinstall
       python -m aqt install --outputdir $(Build.BinariesDirectory)\\Qt ${{ parameters.qtver }} windows desktop win64_msvc2019_64 -m qtcore qtgui qtwidgets qtprintsupport
-      ls $(Build.BinariesDirectory)\Qt
-      ls $(Build.BinariesDirectory)\Qt\${{ parameters.qtver }}
-      ls $(Build.BinariesDirectory)\Qt\${{ parameters.qtver }}\msvc2019_64
     displayName: 'Install Qt'
   - powershell: |
       $ErrorActionPreference = 'Stop'
@@ -66,7 +63,7 @@ steps:
       mkdir build
       cd build
       conan install --remote=conan-center ../
-      #cmake -G "Visual Studio 16 2019" -A "x64" .. -DGUI:bool=true -DANTLRRUNTIME_DIR:path=$(System.DefaultWorkingDirectory)/antlr4-cpp-runtime ${{ parameters.extraflags }}
-      cmake -G "Visual Studio 16 2019" -A "x64" .. -DGUI:bool=true -DBUILD_ANTLR_RUNTIME:bool=true ${{ parameters.extraflags }}
+      cmake -G "Visual Studio 16 2019" -A "x64" .. -DGUI:bool=true -DANTLRRUNTIME_DIR:path=$(System.DefaultWorkingDirectory)/antlr4-cpp-runtime ${{ parameters.extraflags }}
+      cmake --build . --config Release --target keywordwidgets
       cmake --build . --config Release
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-windows-serial-gui.yml
+++ b/.azure-pipelines/templates/build-windows-serial-gui.yml
@@ -15,6 +15,38 @@ steps:
   - script: |
       choco install -y antlr4 ninja winflexbison unzip
     displayName: 'Install Prerequisites'
+  - script: |
+      python -m pip install aqtinstall
+      python -m aqt install --outputdir $(Build.BinariesDirectory)\\Qt ${{ parameters.qtver }} windows desktop win64_msvc2019_64 -m qtcore qtgui qtwidgets qtprintsupport
+      ls $(Build.BinariesDirectory)\Qt
+      ls $(Build.BinariesDirectory)\Qt\${{ parameters.qtver }}
+      ls $(Build.BinariesDirectory)\Qt\${{ parameters.qtver }}\msvc2019_64
+    displayName: 'Install Qt'
+  - powershell: |
+      $ErrorActionPreference = 'Stop'
+      cd $(Build.BinariesDirectory)
+      git clone ${{ parameters.ftrepo }} freetype-latest
+      mkdir freetype-build
+      cd freetype-build
+      cmake -G "Visual Studio 16 2019" -A "x64" ../freetype-latest -DBUILD_SHARED_LIBS:STRING=ON -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install
+      cmake --build . --target install --config Release
+    displayName: 'FreeType (Build / Install)'
+  - powershell: |
+      $ErrorActionPreference = 'Stop'
+      cd $(Build.BinariesDirectory)
+      git clone ${{ parameters.ftglrepo }} ftgl-latest
+      mkdir ftgl-build
+      cd ftgl-build
+      $env:FREETYPE_DIR = "$(Build.BinariesDirectory)\freetype-install"
+      cmake -G "Visual Studio 16 2019" -A "x64" ../ftgl-latest -DCMAKE_INSTALL_PREFIX:path=../ftgl-install
+      cmake --build . --target install --config Release
+    displayName: 'FTGL (Build / Install)'
+  - powershell: |
+      python -m pip install conan
+      conan profile new default --detect
+      conan profile update settings.compiler="Visual Studio" default
+      conan profile update settings.compiler.version=16 default
+    displayName: 'Install Conan' 
   - powershell: |
       cd $(System.DefaultWorkingDirectory)
       $url = "https://github.com/projectdissolve/antlr4/releases/download/continuous/antlr4-cpp-runtime-windows.zip"
@@ -22,47 +54,19 @@ steps:
       (New-Object System.Net.WebClient).DownloadFile($url, $output)
       unzip $output
     displayName: 'Retrieve ANTLR4 Runtime'
-  - script: |
-      cd $(Build.SourcesDirectory)
-      python -m pip install aqtinstall
-      python -m aqt install --outputdir $(Build.BinariesDirectory)\\Qt ${{ parameters.qtver }} windows desktop win64_mingw81 -m qtcore qtgui qtwidgets qtprintsupport
-    displayName: 'Install Qt'
-  - powershell: |
-      python -m pip install conan
-    displayName: 'Install Conan' 
   - powershell: |
       $ErrorActionPreference = 'Stop'
-      cd $(Build.BinariesDirectory)
-      git clone ${{ parameters.ftrepo }} freetype-latest
-      mkdir freetype-build
-      cd freetype-build
-      cmake -G "Ninja" ../freetype-latest -DBUILD_SHARED_LIBS:STRING=ON -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true
-      ninja
-    displayName: 'Build FreeType'
-  - powershell: |
-      $ErrorActionPreference = 'Stop'
-      cd $(Build.BinariesDirectory)
-      git clone ${{ parameters.ftglrepo }} ftgl-latest
-      mkdir ftgl-build
-      cd ftgl-build
-      $env:FREETYPE_DIR = "$(Build.BinariesDirectory)\freetype-build"
-      cmake -G "Ninja" ..\ftgl-latest
-      ninja
-    displayName: 'Build FTGL'
-  - powershell: |
-      $ErrorActionPreference = 'Stop'
-      $env:Qt5_DIR = "$(Build.BinariesDirectory)\Qt\${{ parameters.qtver }}\mingw81_64"
+      $env:Qt5_DIR = "$(Build.BinariesDirectory)\Qt\${{ parameters.qtver }}\msvc2019_64"
       $env:PATH += ";$env:Qt5_DIR" + "\bin"
       echo $env:Qt5_DIR
-      $env:MINGW_DIR = $env:Qt5_DIR
       $env:INCLUDE += "$(Build.BinariesDirectory)\freetype-latest;"
-      $env:LIB += "$(Build.BinariesDirectory)\freetype-build;"
+      $env:LIB += "$(Build.BinariesDirectory)\freetype-install\lib;"
       $env:INCLUDE += "$(Build.BinariesDirectory)\ftgl-latest\src;"
-      $env:LIB += "$(Build.BinariesDirectory)\ftgl-build\src;"
+      $env:LIB += "$(Build.BinariesDirectory)\ftgl-install\lib;"
       mkdir build
       cd build
-      conan install -s compiler="gcc" --remote=conan-center ../
-      cmake -G "Ninja" -DGUI:bool=true -DANTLRRUNTIME_DIR:path=$(System.DefaultWorkingDirectory)/antlr4-cpp-runtime ${{ parameters.extraflags }} ../
-      ninja libkeywordwidgets.a
-      ninja
+      conan install --remote=conan-center ../
+      #cmake -G "Visual Studio 16 2019" -A "x64" .. -DGUI:bool=true -DANTLRRUNTIME_DIR:path=$(System.DefaultWorkingDirectory)/antlr4-cpp-runtime ${{ parameters.extraflags }}
+      cmake -G "Visual Studio 16 2019" -A "x64" .. -DGUI:bool=true -DBUILD_ANTLR_RUNTIME:bool=true ${{ parameters.extraflags }}
+      cmake --build . --config Release
     displayName: 'Build'

--- a/.azure-pipelines/templates/package-windows-serial-gui.yml
+++ b/.azure-pipelines/templates/package-windows-serial-gui.yml
@@ -9,12 +9,12 @@ steps:
   - powershell: |
       $ErrorActionPreference = 'Stop'
       # Set paths
-      $env:Qt5_DIR = "$(Build.BinariesDirectory)\Qt\${{ parameters.qtver }}\mingw81_64"
+      $env:Qt5_DIR = "$(Build.BinariesDirectory)\Qt\${{ parameters.qtver }}\msvc2019_64"
       $env:PATH += ";$env:Qt5_DIR" + "\bin"
       echo $env:Qt5_DIR
       $env:MINGW_DIR = $env:Qt5_DIR
-      $env:FREETYPE_DIR += "$(Build.BinariesDirectory)\freetype-build"
-      $env:FTGL_DIR += "$(Build.BinariesDirectory)\ftgl-build"
+      $env:FREETYPE_DIR += "$(Build.BinariesDirectory)\freetype-install\bin"
+      $env:FTGL_DIR += "$(Build.BinariesDirectory)\ftgl-install\bin"
       $env:ANTLR_DIR += "$(System.DefaultWorkingDirectory)\antlr4-cpp-runtime\lib"
       $env:DISSOLVE_DIR = $(Get-Location).path + "\build\bin"
       # Run Inno Setup Compiler

--- a/.azure-pipelines/templates/system-tests.yml
+++ b/.azure-pipelines/templates/system-tests.yml
@@ -54,7 +54,7 @@ jobs:
       - bash: |
           cd $(System.ArtifactsDirectory)/linux-tests-parallel
           chmod u+x ./go ./dissolve-mpi
-          ./go -a -p ./dissolve-mpi
+          ./go -a -m mpirun.openmpi -p ./dissolve-mpi
         displayName: 'Run Parallel System Tests'
       - bash: |
           mkdir test-output

--- a/.azure-pipelines/templates/system-tests.yml
+++ b/.azure-pipelines/templates/system-tests.yml
@@ -58,7 +58,7 @@ jobs:
         displayName: 'Run Parallel System Tests'
       - bash: |
           mkdir test-output
-          cp -rv $(System.ArtifactsDirectory)/linux-tests-parallel/*.out test-output/
+          cp -rv $(System.ArtifactsDirectory)/linux-tests-parallel/*.out* test-output/
         displayName: 'Copy Test Output'
         condition: always()
       - task: PublishBuildArtifacts@1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,18 +57,25 @@ find_package(ANTLR REQUIRED)
 
 # Find / build ANTLR4 runtime dependency
 if(BUILD_ANTLR_RUNTIME)
+
   if(BUILD_ANTLR_ZIPFILE)
     set(ANTLR_SOURCE_URL "${BUILD_ANTLR_ZIPFILE}")
   else(BUILD_ANTLR_ZIPFILE)
     set(ANTLR_SOURCE_URL "https://www.antlr.org/download/antlr4-cpp-runtime-4.8-source.zip")
   endif(BUILD_ANTLR_ZIPFILE)
 
+  if(BUILD_ANTLR_LINK_LIB)
+    set(ANTLR_LINK_LIB "${BUILD_ANTLR_LINK_LIB}")
+  else(BUILD_ANTLR_LINK_LIB)
+    set(ANTLR_LINK_LIB "dist/libantlr4-runtime.a")
+  endif(BUILD_ANTLR_LINK_LIB)
+
   include(ExternalProject)
   ExternalProject_Add(antlr_runtime
     PREFIX            antlr4runtime
     URL               "${ANTLR_SOURCE_URL}"
     BUILD_ALWAYS      ON
-    BUILD_BYPRODUCTS  "antlr4runtime/src/antlr_runtime/dist/libantlr4-runtime.a"
+    BUILD_BYPRODUCTS  "antlr4runtime/src/antlr_runtime/${ANTLR_LINK_LIB}"
     INSTALL_COMMAND   ""
     )
   ExternalProject_Get_Property(antlr_runtime source_dir)
@@ -76,7 +83,7 @@ if(BUILD_ANTLR_RUNTIME)
   # Tell CMake that the ExternalProject generated a library
   add_library(antlr4-runtime STATIC IMPORTED GLOBAL)
   set_property(TARGET antlr4-runtime PROPERTY
-     IMPORTED_LOCATION "${source_dir}/dist/libantlr4-runtime.a"
+     IMPORTED_LOCATION "${source_dir}/${ANTLR_LINK_LIB}"
   )
   set(ANTLRRUNTIME_INCLUDE_DIRS "${source_dir}/runtime/src")
 else(BUILD_ANTLR_RUNTIME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,7 @@ target_link_libraries( ${target_name}
   INTERFACE
 
   CONAN_PKG::fmt
+  CONAN_PKG::CLI11
 )
 
 # Build GUI target executables
@@ -402,5 +403,6 @@ if(GUI)
     INTERFACE
 
     CONAN_PKG::fmt
+    CONAN_PKG::CLI11
   )
 endif(GUI)

--- a/ci/windows/dissolve-gui.iss
+++ b/ci/windows/dissolve-gui.iss
@@ -13,7 +13,7 @@
 #define ANTLRDir GetEnv('ANTLR_DIR')
 #define FTGLDir GetEnv('FTGL_DIR')
 #define QtDir GetEnv('Qt5_DIR')
-#define MinGWDir GetEnv('MINGW_DIR')
+;#define MinGWDir GetEnv('MINGW_DIR')
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
@@ -47,12 +47,12 @@ Source: "{#DissolveDir}\Dissolve.exe"; DestDir: "{app}\bin"; Flags: ignoreversio
 Source: "{#DissolveDir}\Dissolve-GUI.exe"; DestDir: "{app}\bin"; Flags: ignoreversion
 Source: "Dissolve.ico"; DestDir: "{app}\bin"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
-Source: "{#FreetypeDir}\libfreetype.dll"; DestDir: "{app}\bin"
-Source: "{#ANTLRDir}\libantlr4-runtime.dll"; DestDir: "{app}\bin"
-Source: "{#FTGLDir}\src\libftgl.dll"; DestDir: "{app}\bin"
-Source: "{#MinGWDir}\bin\libgcc_s_seh-1.dll"; DestDir: "{app}\bin"
-Source: "{#MinGWDir}\bin\libstdc++-6.dll"; DestDir: "{app}\bin"
-Source: "{#MinGWDir}\bin\libwinpthread-1.dll"; DestDir: "{app}\bin"
+Source: "{#FreetypeDir}\freetype.dll"; DestDir: "{app}\bin"
+Source: "{#ANTLRDir}\antlr4-runtime.dll"; DestDir: "{app}\bin"
+Source: "{#FTGLDir}\ftgl.dll"; DestDir: "{app}\bin"
+;Source: "{#MinGWDir}\bin\libgcc_s_seh-1.dll"; DestDir: "{app}\bin"
+;Source: "{#MinGWDir}\bin\libstdc++-6.dll"; DestDir: "{app}\bin"
+;Source: "{#MinGWDir}\bin\libwinpthread-1.dll"; DestDir: "{app}\bin"
 Source: "{#QtDir}\bin\Qt5Gui.dll"; DestDir: "{app}\bin"; Flags: ignoreversion
 Source: "{#QtDir}\bin\Qt5Core.dll"; DestDir: "{app}\bin"; Flags: ignoreversion
 Source: "{#QtDir}\bin\Qt5OpenGL.dll"; DestDir: "{app}\bin"; Flags: ignoreversion

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,6 @@
 [requires]
 fmt/7.0.3
+CLI11/1.9.1@cliutils/stable
 
 [generators]
 cmake

--- a/src/base/messenger.cpp
+++ b/src/base/messenger.cpp
@@ -91,7 +91,7 @@ void Messenger::outputText(std::string_view s)
     {
         // If we are redirecting to files, use the parser_
         if (redirect_)
-            parser_.writeLineF("{}", std::string(s));
+            parser_.writeLineF("{}\n", std::string(s));
         else
         {
             // Not redirecting - has an OutputHandler been defined?
@@ -105,7 +105,7 @@ void Messenger::outputText(std::string_view s)
     {
         // If we are redirecting to files, use the parser_
         if (redirect_)
-            parser_.writeLineF("{} {}", outputPrefix_, s);
+            parser_.writeLineF("{} {}\n", outputPrefix_, s);
         else
         {
             // Not redirecting - has an OutputHandler been defined?

--- a/src/base/messenger.cpp
+++ b/src/base/messenger.cpp
@@ -14,7 +14,7 @@ bool Messenger::quiet_ = false;
 bool Messenger::muted_ = false;
 bool Messenger::verbose_ = false;
 bool Messenger::redirect_ = false;
-bool Messenger::masterOnly_ = false;
+bool Messenger::masterOnly_ = true;
 LineParser Messenger::parser_; //= new LineParser;
 OutputHandler *Messenger::outputHandler_ = nullptr;
 std::string Messenger::outputPrefix_;

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -14,7 +14,7 @@ SpeciesAngle::SpeciesAngle(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k) : Spe
     k_ = k;
     form_ = SpeciesAngle::NoForm;
 
-    // Add ourself to the list of bonds on each atom
+    // Add ourself to the list of angles on each atom
     if (i_ && j_ && k_)
     {
         i_->addAngle(*this);
@@ -27,7 +27,7 @@ SpeciesAngle::SpeciesAngle(SpeciesAngle &source) : SpeciesIntra(source) { this->
 
 SpeciesAngle::SpeciesAngle(SpeciesAngle &&source) : SpeciesIntra(source)
 {
-    // Detach source bond referred to by the species atoms
+    // Detach source angle referred to by the species atoms
     if (source.i_ && source.j_ && source.k_)
     {
         source.i_->removeAngle(source);

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -27,7 +27,39 @@ SpeciesTorsion::SpeciesTorsion(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, S
     }
 }
 
-SpeciesTorsion::SpeciesTorsion(const SpeciesTorsion &source) { this->operator=(source); }
+SpeciesTorsion::SpeciesTorsion(SpeciesTorsion &source) { this->operator=(source); }
+
+SpeciesTorsion::SpeciesTorsion(SpeciesTorsion &&source) : SpeciesIntra(source)
+{
+    // Detach source torsion referred to by the species atoms
+    if (source.i_ && source.j_ && source.k_ && source.l_)
+    {
+        source.i_->removeTorsion(source);
+        source.j_->removeTorsion(source);
+        source.k_->removeTorsion(source);
+        source.l_->removeTorsion(source);
+    }
+
+    // Copy data
+    i_ = source.i_;
+    j_ = source.j_;
+    k_ = source.k_;
+    l_ = source.l_;
+    if (i_ && j_ && k_ && l_)
+    {
+        i_->addTorsion(*this, 0.5);
+        j_->addTorsion(*this, 0.5);
+        k_->addTorsion(*this, 0.5);
+        l_->addTorsion(*this, 0.5);
+    }
+    form_ = source.form_;
+
+    // Reset source data
+    source.i_ = nullptr;
+    source.j_ = nullptr;
+    source.k_ = nullptr;
+    source.l_ = nullptr;
+}
 
 SpeciesTorsion::~SpeciesTorsion() { detach(); }
 

--- a/src/classes/speciestorsion.h
+++ b/src/classes/speciestorsion.h
@@ -16,8 +16,8 @@ class ProcessPool;
 class SpeciesTorsion : public SpeciesIntra
 {
     public:
-    SpeciesTorsion(const SpeciesTorsion &source);
-    SpeciesTorsion(const SpeciesTorsion &&source);
+    SpeciesTorsion(SpeciesTorsion &source);
+    SpeciesTorsion(SpeciesTorsion &&source);
     SpeciesTorsion(SpeciesAtom *i = nullptr, SpeciesAtom *j = nullptr, SpeciesAtom *k = nullptr, SpeciesAtom *l = nullptr);
     ~SpeciesTorsion();
     SpeciesTorsion &operator=(const SpeciesTorsion &source);

--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -30,7 +30,7 @@ int main(int args, char **argv)
         return 1;
 
     // Print GPL license information
-    Messenger::print("Dissolve-GUI version {}, Copyright (C) 2012-2020 T. Youngs.\n", Version::info());
+    Messenger::print("Dissolve-GUI version {}, Copyright (C) 2020 Team Dissolve and contributors.\n", Version::info());
     Messenger::print("Source repository: {}.\n", Version::repoUrl());
     Messenger::print("Dissolve comes with ABSOLUTELY NO WARRANTY.\n");
     Messenger::print("This is free software, and you are welcome to redistribute it under certain conditions.\n");

--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -26,7 +26,7 @@ int main(int args, char **argv)
 
     // Parse CLI options
     CLIOptions options;
-    if (options.parse(args, argv, true) != 1)
+    if (options.parse(args, argv, true) != CLIOptions::Success)
         return 1;
 
     // Print GPL license information

--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -4,6 +4,7 @@
 #include "base/messenger.h"
 #include "base/processpool.h"
 #include "gui/gui.h"
+#include "main/cli.h"
 #include "main/dissolve.h"
 #include "main/version.h"
 #include <QSurfaceFormat>
@@ -12,131 +13,21 @@
 #include <stdlib.h>
 #include <time.h>
 
-int main(int args, char **argv)
+int main(int nArgs, char **args)
 {
 #ifdef PARALLEL
     // Initialise parallel communication
-    ProcessPool::initialiseMPI(&args, &argv);
+    ProcessPool::initialiseMPI(&nArgs, &args);
 #endif
 
     // Instantiate main classes
     CoreData coreData;
     Dissolve dissolve(coreData);
 
-    // Parse CLI options...
-    auto n = 1;
-    std::string inputFile, restartFile;
-    auto nIterations = 0;
-    auto ignoreRestart = false, ignoreLayout = false;
-    while (n < args)
-    {
-        if (argv[n][0] == '-')
-        {
-            // Command-line switch
-            switch (argv[n][1])
-            {
-                case ('h'):
-                    Messenger::print("Dissolve version {}\n\nAvailable CLI options are:\n\n", Version::info());
-                    Messenger::print("\t-h\t\tPrint what you're reading now\n");
-                    Messenger::print("\t-i\t\tIgnore restart file\n");
-                    Messenger::print("\t-I\t\tIgnore GUI state file\n");
-                    Messenger::print("\t-q\t\tQuiet mode - print no output\n");
-                    Messenger::print("\t-r <N>\t\tSet restart file frequency (default = 10)\n");
-                    Messenger::print("\t-t <file>\tLoad restart data from specified file (but still write to "
-                                     "standard "
-                                     "restart file)\n");
-                    Messenger::print("\t-v\t\tVerbose mode - be a little more descriptive throughout\n");
-                    Messenger::print("\t-x\t\tDon't write restart or heartbeat files (but still read in the restart "
-                                     "file if "
-                                     "present)\n");
-                    ProcessPool::finalise();
-                    return 0;
-                    break;
-                case ('i'):
-                    Messenger::print("Restart file (if it exists) will be ignored.\n");
-                    ignoreRestart = true;
-                    break;
-                case ('I'):
-                    Messenger::print("GUI layout file (if it exists) will be ignored.\n");
-                    ignoreLayout = true;
-                    break;
-                case ('n'):
-                    ++n;
-                    if (n == args)
-                    {
-                        Messenger::error("Expected number of iterations.\n");
-                        Messenger::ceaseRedirect();
-                        return 1;
-                    }
-                    nIterations = atoi(argv[n]);
-                    Messenger::print("{} main-loop iterations will be performed, then the GUI will be launched.\n",
-                                     nIterations);
-                    break;
-                case ('q'):
-                    Messenger::setQuiet(true);
-                    break;
-                case ('r'):
-                    // Next argument is integer restart file frequency
-                    ++n;
-                    if (n == args)
-                    {
-                        Messenger::error("Expected restart file frequency.\n");
-                        Messenger::ceaseRedirect();
-                        return 1;
-                    }
-                    dissolve.setRestartFileFrequency(atoi(argv[n]));
-                    if (dissolve.restartFileFrequency() <= 0)
-                        Messenger::print("Restart file will not be written.\n");
-                    else if (dissolve.restartFileFrequency() == 1)
-                        Messenger::print("Restart file will be written after every iteration.\n",
-                                         dissolve.restartFileFrequency());
-                    else
-                        Messenger::print("Restart file will be written after every {} iterations.\n",
-                                         dissolve.restartFileFrequency());
-                    break;
-                case ('t'):
-                    // Next argument is filename
-                    ++n;
-                    if (n == args)
-                    {
-                        Messenger::error("Expected restart data filename.\n");
-                        Messenger::ceaseRedirect();
-                        return 1;
-                    }
-                    restartFile = argv[n];
-                    Messenger::print("Restart data will be loaded from '{}'.\n", restartFile);
-                    break;
-                case ('v'):
-                    Messenger::setVerbose(true);
-                    Messenger::printVerbose("Verbose mode enabled.\n");
-                    break;
-                case ('x'):
-                    dissolve.setRestartFileFrequency(0);
-                    dissolve.setWriteHeartBeat(false);
-                    Messenger::print("No restart or heartbeat files will be written.\n");
-                    break;
-                default:
-                    Messenger::print("Unrecognised command-line switch '{}'.\n", argv[n]);
-                    Messenger::print("Run with -h to see available switches.\n");
-                    ProcessPool::finalise();
-                    return 1;
-                    break;
-            }
-        }
-        else
-        {
-            // Input filename?
-            if (inputFile.empty())
-                inputFile = argv[n];
-            else
-            {
-                Messenger::print("Error: More than one input file specified?\n");
-                return 1;
-            }
-        }
-
-        ++n;
-    }
+    // Parse CLI options
+    CLIOptions options;
+    if (options.parse(nArgs, args, true) != 1)
+        return 1;
 
     // Print GPL license information
     Messenger::print("Dissolve-GUI version {}, Copyright (C) 2012-2020 T. Youngs.\n", Version::info());
@@ -158,7 +49,7 @@ int main(int args, char **argv)
      */
 
     // Create the main QApplication */
-    QApplication app(args, argv);
+    QApplication app(nArgs, args);
     QCoreApplication::setOrganizationName("ProjectAten");
     QCoreApplication::setOrganizationDomain("www.projectaten.com");
     QCoreApplication::setApplicationName("Dissolve-GUI");
@@ -177,21 +68,22 @@ int main(int args, char **argv)
     DissolveWindow dissolveWindow(dissolve);
 
     // If an input file was specified, load it here
-    if ((!inputFile.empty()) && (!dissolveWindow.openLocalFile(inputFile, restartFile, ignoreRestart, ignoreLayout)))
+    if (!dissolveWindow.openLocalFile(options.inputFile().value_or(""), options.restartFilename().value_or(""),
+                                      options.ignoreRestartFile(), options.ignoreStateFile()))
     {
         ProcessPool::finalise();
         return 1;
     }
 
     // Iterate before launching the GUI?
-    if (nIterations > 0)
+    if (options.nIterations() > 0)
     {
         // Prepare for run
         if (!dissolve.prepare())
             return 1;
 
         // Run main simulation
-        auto result = dissolve.iterate(nIterations);
+        auto result = dissolve.iterate(options.nIterations());
         if (!result)
             return 1;
     }

--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -13,11 +13,11 @@
 #include <stdlib.h>
 #include <time.h>
 
-int main(int nArgs, char **args)
+int main(int args, char **argv)
 {
 #ifdef PARALLEL
     // Initialise parallel communication
-    ProcessPool::initialiseMPI(&nArgs, &args);
+    ProcessPool::initialiseMPI(&args, &argv);
 #endif
 
     // Instantiate main classes
@@ -26,7 +26,7 @@ int main(int nArgs, char **args)
 
     // Parse CLI options
     CLIOptions options;
-    if (options.parse(nArgs, args, true) != 1)
+    if (options.parse(args, argv, true) != 1)
         return 1;
 
     // Print GPL license information
@@ -49,7 +49,7 @@ int main(int nArgs, char **args)
      */
 
     // Create the main QApplication */
-    QApplication app(nArgs, args);
+    QApplication app(args, argv);
     QCoreApplication::setOrganizationName("ProjectAten");
     QCoreApplication::setOrganizationDomain("www.projectaten.com");
     QCoreApplication::setApplicationName("Dissolve-GUI");

--- a/src/keywords/node.h
+++ b/src/keywords/node.h
@@ -141,7 +141,7 @@ template <class N> class NodeKeyword : public NodeKeywordBase, public KeywordDat
      */
     protected:
     // Prune any references to the supplied ProcedureNode in the contained data
-    void removeReferencesTo(ProcedureNode *node)
+    void removeReferencesTo(N *node)
     {
         if (KeywordData<N *>::data_ == node)
             KeywordData<N *>::data_ = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,10 +24,10 @@ int main(int args, char **argv)
     // Parse CLI options
     CLIOptions options;
 #ifdef PARALLEL
-    if (options.parse(args, argv, false, true) != 1)
+    if (options.parse(args, argv, false, true) != CLIOptions::Success)
         return 1;
 #else
-    if (options.parse(args, argv) != 1)
+    if (options.parse(args, argv) != CLIOptions::Success)
         return 1;
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,11 @@ int main(int args, char **argv)
 
     // If were just checking the input and restart files, exit now
     if (options.checkInputOnly())
+    {
+        ProcessPool::finalise();
+        Messenger::ceaseRedirect();
         return 0;
+    }
 
     // Prepare for run
     if (!dissolve.prepare())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,9 +36,9 @@ int main(int args, char **argv)
         Messenger::enableRedirect(fmt::format("{}.{}", options.redirectionBasename().value(), ProcessPool::worldRank()));
 
 #ifdef PARALLEL
-    Messenger::print("Dissolve PARALLEL version {}, Copyright (C) 2012-2020 T. Youngs.\n", Version::info());
+    Messenger::print("Dissolve PARALLEL version {}, Copyright (C) 2020 Team Dissolve and contributors.\n", Version::info());
 #else
-    Messenger::print("Dissolve SERIAL version {}, Copyright (C) 2012-2020 T. Youngs.\n", Version::info());
+    Messenger::print("Dissolve SERIAL version {}, Copyright (C) 2020 Team Dissolve and contributors.\n", Version::info());
 #endif
     Messenger::print("Source repository: {}.\n", Version::repoUrl());
     Messenger::print("Dissolve comes with ABSOLUTELY NO WARRANTY.\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ int main(int args, char **argv)
     // Load restart file if it exists
     Messenger::banner("Parse Restart File");
     if (options.ignoreRestartFile())
-        Messenger::print("Restart file (if it exists) will be ignored).\n");
+        Messenger::print("Restart file (if it exists) will be ignored.\n");
     else
     {
         // We may have been provided the name of a restart file to read in...
@@ -112,7 +112,7 @@ int main(int args, char **argv)
             Messenger::print("Restart file '{}' does not exist.\n", restartFile);
     }
 
-    // Iwe were just checking the input and restart files, exit now
+    // If were just checking the input and restart files, exit now
     if (options.checkInputOnly())
         return 0;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,188 +3,38 @@
 
 #include "base/messenger.h"
 #include "base/processpool.h"
+#include "main/cli.h"
 #include "main/dissolve.h"
 #include "main/version.h"
 #include <ctime>
 #include <stdlib.h>
 #include <time.h>
 
-int main(int args, char **argv)
+int main(int nArgs, char **argv)
 {
 #ifdef PARALLEL
     // Initialise parallel communication
-    ProcessPool::initialiseMPI(&args, &argv);
+    ProcessPool::initialiseMPI(&nArgs, &argv);
 #endif
 
     // Instantiate main classes
     CoreData coreData;
     Dissolve dissolve(coreData);
 
-    // Parse CLI options...
-    auto n = 1;
-    std::string inputFile, redirectFileName, restartDataFile, outputInputFile;
-    auto nIterations = 5;
-    auto ignoreRestart = false;
-    while (n < args)
-    {
-        if (argv[n][0] == '-')
-        {
-            // Command-line switch
-            switch (argv[n][1])
-            {
-                case ('h'):
+    // Parse CLI options
+    CLIOptions options;
 #ifdef PARALLEL
-                    Messenger::print("Dissolve PARALLEL version {}, Copyright (C) 2012-2020 T. Youngs.\n\n", Version::info());
+    if (options.parse(nArgs, argv, false, true) != 1)
+        return 1;
 #else
-                    Messenger::print("Dissolve SERIAL version {}, Copyright (C) 2012-2020 T. Youngs.\n\n", Version::info());
+    if (options.parse(nArgs, argv) != 1)
+        return 1;
 #endif
-                    Messenger::print("Recognised CLI options are:\n\n");
-                    Messenger::print("\t-c\t\tCheck input and set-up only - don't perform any main-loop "
-                                     "iterations\n");
-                    Messenger::print("\t-h\t\tPrint what you're reading now\n");
-                    Messenger::print("\t-f <file>\tRedirect output from all process to 'file.N', where N is the "
-                                     "process "
-                                     "rank\n");
-                    Messenger::print("\t-i\t\tIgnore restart file\n");
-                    Messenger::print("\t-m\t\tRestrict output to be from the master process alone (parallel code "
-                                     "only)\n");
-                    Messenger::print("\t-n <iterations>\tRun for the specified number of main loop iterations, then "
-                                     "stop\n");
-                    Messenger::print("\t-q\t\tQuiet mode - print no output\n");
-                    Messenger::print("\t-r <N>\tSet restart file frequency (default = 10)\n");
-                    Messenger::print("\t-s\t\tPerform single main loop iteration and then quit\n");
-                    Messenger::print("\t-t <file>\tLoad restart data from specified file (but still write to "
-                                     "standard "
-                                     "restart file)\n");
-                    Messenger::print("\t-v\t\tVerbose mode - be a little more descriptive throughout\n");
-                    Messenger::print("\t-w <file>\tWrite input to specified file after reading it, and then quit\n");
-                    Messenger::print("\t-x\t\tDon't write restart or heartbeat files (but still read in the restart "
-                                     "file if "
-                                     "present)\n");
-                    ProcessPool::finalise();
-                    Messenger::ceaseRedirect();
-                    return 1;
-                    break;
-                case ('c'):
-                    nIterations = 0;
-                    Messenger::print("System input and set-up will be checked, then Dissolve will exit.\n");
-                    break;
-                case ('f'):
-                    // Next argument is filename
-                    ++n;
-                    if (n == args)
-                    {
-                        Messenger::error("Expected redirection filename.\n");
-                        Messenger::ceaseRedirect();
-                        return 1;
-                    }
-                    redirectFileName = fmt::format("{}.{}", argv[n], ProcessPool::worldRank());
-                    Messenger::enableRedirect(redirectFileName);
-                    break;
-                case ('i'):
-                    Messenger::print("Restart file (if it exists) will be ignored.\n");
-                    ignoreRestart = true;
-                    break;
-                case ('m'):
-                    Messenger::setMasterOnly(true);
-                    break;
-                case ('n'):
-                    ++n;
-                    if (n == args)
-                    {
-                        Messenger::error("Expected number of iterations.\n");
-                        Messenger::ceaseRedirect();
-                        return 1;
-                    }
-                    nIterations = atoi(argv[n]);
-                    Messenger::print("{} main-loop iterations will be performed, then Dissolve will exit.\n", nIterations);
-                    break;
-                case ('q'):
-                    Messenger::setQuiet(true);
-                    break;
-                case ('r'):
-                    // Next argument is integer restart file frequency
-                    ++n;
-                    if (n == args)
-                    {
-                        Messenger::error("Expected restart file frequency.\n");
-                        Messenger::ceaseRedirect();
-                        return 1;
-                    }
-                    dissolve.setRestartFileFrequency(atoi(argv[n]));
-                    if (dissolve.restartFileFrequency() <= 0)
-                        Messenger::print("Restart file will not be written.\n");
-                    else if (dissolve.restartFileFrequency() == 1)
-                        Messenger::print("Restart file will be written after every iteration.\n",
-                                         dissolve.restartFileFrequency());
-                    else
-                        Messenger::print("Restart file will be written after every {} iterations.\n",
-                                         dissolve.restartFileFrequency());
-                    break;
-                case ('s'):
-                    Messenger::print("Single main-loop iteration will be performed, then Dissolve will exit.\n");
-                    nIterations = 1;
-                    break;
-                case ('t'):
-                    // Next argument is filename
-                    ++n;
-                    if (n == args)
-                    {
-                        Messenger::error("Expected restart data filename.\n");
-                        Messenger::ceaseRedirect();
-                        return 1;
-                    }
-                    restartDataFile = argv[n];
-                    Messenger::print("Restart data will be loaded from '{}'.\n", restartDataFile);
-                    break;
-                case ('v'):
-                    Messenger::setVerbose(true);
-                    Messenger::printVerbose("Verbose mode enabled.\n");
-                    break;
-                case ('w'):
-                    // Next argument is filename
-                    ++n;
-                    if (n == args)
-                    {
-                        Messenger::error("Expected input filename to write.\n");
-                        Messenger::ceaseRedirect();
-                        return 1;
-                    }
-                    outputInputFile = argv[n];
-                    Messenger::print("Input file will be written to '{}' once read.\n", outputInputFile);
-                    break;
-                case ('x'):
-                    dissolve.setRestartFileFrequency(0);
-                    dissolve.setWriteHeartBeat(false);
-                    Messenger::print("No restart or heartbeat files will be written.\n");
-                    break;
-                default:
-                    Messenger::print("Unrecognised command-line switch '{}'.\n", argv[n]);
-                    Messenger::print("Run with -h to see available switches.\n");
-                    Messenger::ceaseRedirect();
-                    ProcessPool::finalise();
-                    return 1;
-                    break;
-            }
-        }
-        else
-        {
-            // Input filename?
-            if (inputFile.empty())
-                inputFile = argv[n];
-            else
-            {
-                Messenger::error("Please specify exactly one input file.");
-                ProcessPool::finalise();
-                Messenger::ceaseRedirect();
-                return 1;
-            }
-        }
 
-        ++n;
-    }
+    // Enable redirect if requested
+    if (options.redirectionBasename())
+        Messenger::enableRedirect(fmt::format("{}.{}", options.redirectionBasename().value(), ProcessPool::worldRank()));
 
-    // Print GPL license information
 #ifdef PARALLEL
     Messenger::print("Dissolve PARALLEL version {}, Copyright (C) 2012-2020 T. Youngs.\n", Version::info());
 #else
@@ -204,16 +54,9 @@ int main(int args, char **argv)
         return 1;
     }
 
-    // Load input file - if no input file was provided, exit here
+    // Load input file
     Messenger::banner("Parse Input File");
-    if (inputFile.empty())
-    {
-        Messenger::print("No input file provided. Nothing more to do.\n");
-        ProcessPool::finalise();
-        Messenger::ceaseRedirect();
-        return 1;
-    }
-    if (!dissolve.loadInput(inputFile))
+    if (!dissolve.loadInput(options.inputFile().value()))
     {
         ProcessPool::finalise();
         Messenger::ceaseRedirect();
@@ -221,13 +64,13 @@ int main(int args, char **argv)
     }
 
     // Save input file to new output filename and quit?
-    if (!outputInputFile.empty())
+    if (options.writeInputFilename())
     {
-        Messenger::print("Saving input file to '{}'...\n", outputInputFile);
+        Messenger::print("Saving input file to '{}'...\n", options.writeInputFilename().value());
         bool result;
         if (dissolve.worldPool().isMaster())
         {
-            result = dissolve.saveInput(outputInputFile);
+            result = dissolve.saveInput(options.writeInputFilename().value());
             if (result)
                 dissolve.worldPool().decideTrue();
             else
@@ -236,7 +79,7 @@ int main(int args, char **argv)
         else
             result = dissolve.worldPool().decision();
         if (!result)
-            Messenger::error("Failed to save input file to '{}'.\n", outputInputFile);
+            Messenger::error("Failed to save input file to '{}'.\n", options.writeInputFilename().value());
         ProcessPool::finalise();
         Messenger::ceaseRedirect();
         return result ? 0 : 1;
@@ -244,10 +87,12 @@ int main(int args, char **argv)
 
     // Load restart file if it exists
     Messenger::banner("Parse Restart File");
-    if (!ignoreRestart)
+    if (options.ignoreRestartFile())
+        Messenger::print("Restart file (if it exists) will be ignored).\n");
+    else
     {
         // We may have been provided the name of a restart file to read in...
-        std::string restartFile = restartDataFile.empty() ? fmt::format("{}.restart", inputFile) : restartDataFile;
+        std::string restartFile = options.restartFilename().value_or(fmt::format("{}.restart", options.inputFile().value()));
 
         if (DissolveSys::fileExists(restartFile))
         {
@@ -261,13 +106,15 @@ int main(int args, char **argv)
             }
 
             // Reset the restart filename to be the standard one
-            dissolve.setRestartFilename(fmt::format("{}.restart", inputFile));
+            dissolve.setRestartFilename(fmt::format("{}.restart", options.inputFile().value()));
         }
         else
             Messenger::print("Restart file '{}' does not exist.\n", restartFile);
     }
-    else
-        Messenger::print("Restart file (if it exists) will be ignored.\n");
+
+    // Iwe were just checking the input and restart files, exit now
+    if (options.checkInputOnly())
+        return 0;
 
     // Prepare for run
     if (!dissolve.prepare())
@@ -277,13 +124,29 @@ int main(int args, char **argv)
         return 1;
     }
 
+    // Set restart file frequency and whether to write heartbeat file
+    if (options.writeNoFiles())
+    {
+        dissolve.setRestartFileFrequency(0);
+        dissolve.setWriteHeartBeat(false);
+    }
+    else
+        dissolve.setRestartFileFrequency(options.restartFileFrequency());
+
+    if (dissolve.restartFileFrequency() <= 0)
+        Messenger::print("Restart file will not be written.\n");
+    else if (dissolve.restartFileFrequency() == 1)
+        Messenger::print("Restart file will be written after every iteration.\n", dissolve.restartFileFrequency());
+    else
+        Messenger::print("Restart file will be written after every {} iterations.\n", dissolve.restartFileFrequency());
+
 #ifdef PARALLEL
     Messenger::print("This is process rank {} of {} processes total.\n", ProcessPool::worldRank(),
                      ProcessPool::nWorldProcesses());
 #endif
 
     // Run main simulation
-    auto result = dissolve.iterate(nIterations);
+    auto result = dissolve.iterate(options.nIterations());
 
     // Print timing information
     dissolve.printTiming();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,11 +10,11 @@
 #include <stdlib.h>
 #include <time.h>
 
-int main(int nArgs, char **argv)
+int main(int args, char **argv)
 {
 #ifdef PARALLEL
     // Initialise parallel communication
-    ProcessPool::initialiseMPI(&nArgs, &argv);
+    ProcessPool::initialiseMPI(&args, &argv);
 #endif
 
     // Instantiate main classes
@@ -24,10 +24,10 @@ int main(int nArgs, char **argv)
     // Parse CLI options
     CLIOptions options;
 #ifdef PARALLEL
-    if (options.parse(nArgs, argv, false, true) != 1)
+    if (options.parse(args, argv, false, true) != 1)
         return 1;
 #else
-    if (options.parse(nArgs, argv) != 1)
+    if (options.parse(args, argv) != 1)
         return 1;
 #endif
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(main
   atomtypes.cpp
   comms.cpp
   configurations.cpp
+  cli.cpp
   dissolve.cpp
   io.cpp
   keywords.cpp
@@ -20,6 +21,7 @@ add_library(main
   species.cpp
   version.cpp
 
+  cli.h
   dissolve.h
   keywords.h
   version.h

--- a/src/main/cli.cpp
+++ b/src/main/cli.cpp
@@ -8,7 +8,6 @@
 #include <CLI/App.hpp>
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
-#include <limits>
 
 // Parse CLI options
 int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)

--- a/src/main/cli.cpp
+++ b/src/main/cli.cpp
@@ -14,9 +14,9 @@ int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
 {
     // Create CLI object
 #ifdef PARALLEL
-    CLI::App app{fmt::format("Dissolve PARALLEL version {}, Copyright (C) 2012-2020 T. Youngs.", Version::info())};
+    CLI::App app{fmt::format("Dissolve PARALLEL version {}, 2020 Team Dissolve and contributors.", Version::info())};
 #else
-    CLI::App app{fmt::format("Dissolve SERIAL version {}, Copyright (C) 2012-2020 T. Youngs.", Version::info())};
+    CLI::App app{fmt::format("Dissolve SERIAL version {}, 2020 Team Dissolve and contributors.", Version::info())};
 #endif
 
     // Add positionals

--- a/src/main/cli.cpp
+++ b/src/main/cli.cpp
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "main/cli.h"
+#include "base/messenger.h"
+#include "base/processpool.h"
+#include "main/version.h"
+#include <CLI/App.hpp>
+#include <CLI/Config.hpp>
+#include <CLI/Formatter.hpp>
+#include <limits>
+
+// Parse CLI options
+int CLIOptions::parse(const int nArgs, char **args, bool isGUI, bool isParallel)
+{
+    // Create CLI object
+#ifdef PARALLEL
+    CLI::App app{fmt::format("Dissolve PARALLEL version {}, Copyright (C) 2012-2020 T. Youngs.", Version::info())};
+#else
+    CLI::App app{fmt::format("Dissolve SERIAL version {}, Copyright (C) 2012-2020 T. Youngs.", Version::info())};
+#endif
+
+    // Add positionals
+    auto inputFileOption = app.add_option("inputFile", inputFile_, "Input file to load");
+
+    // Basic Control
+    app.add_option("-n,--iterations", nIterations_, "Number of iterations to run (default = 5)")->group("Basic Control");
+    app.add_flag("-q,--quiet", [](int count) { Messenger::setQuiet(true); },
+                 "Be quiet - don't output any messages whatsoever (output files are still written)")
+        ->group("Basic Control");
+    app.add_flag("-v,--verbose", [](int count) { Messenger::setVerbose(true); },
+                 "Print lots of additional output, useful for debugging")
+        ->group("Basic Control");
+
+    // Input Files
+    if (!isGUI)
+        app.add_flag("-c,--check", checkInputOnly_, "Only check input and restart files for validity, then quit")
+            ->group("Input Files");
+    app.add_flag("-i,--ignore-restart", ignoreRestartFile_, "Ignore restart file (if it exists)")->group("Input Files");
+    if (!isGUI)
+        app.add_option("-w,--write-input", writeInputFilename_,
+                       "Write out the current simulation input to the file specified and then quit")
+            ->group("Input Files");
+
+    // Output Files
+    app.add_option("-f,--frequency", restartFileFrequency_, "Frequency at which to write restart file (default = 10)")
+        ->group("Output Files");
+    app.add_option("--restart", restartFilename_,
+                   "Read restart file specified instead of the default one (but still write to the default one)")
+        ->group("Output Files");
+    app.add_flag("-x,--no-files", writeNoFiles_, "Don't write restart or heartbeat files while running")->group("Output Files");
+
+    // Add GUI-specific options - if this is not the GUI, make the input file a required parameter
+    if (isGUI)
+        app.add_flag("-I,--ignore-state", ignoreStateFile_, "Ignore GUI state file (if it exists)")->group("GUI Options");
+    else
+        inputFileOption->required();
+
+    // Add parallel-specific options
+    if (isParallel)
+    {
+        app.add_flag("-a,--all", [](int count) { Messenger::setMasterOnly(false); },
+                     "Write output from all processes, not just master")
+            ->group("Parallel Code Options");
+        app.add_option("--redirect", redirectionBasename_,
+                       "Redirect output from individual processes to files based on the supplied name")
+            ->group("Parallel Code Options");
+    }
+
+    // Tweak formatting
+    app.get_formatter()->label("TEXT", "<filename>");
+    app.get_formatter()->label("INT", "<n>");
+
+    // Parse the supplied options.
+    // The CLI11_PARSE macro expands to a simple try/catch block, returning non-zero on error.
+    // However, early exits from -h or --help return zero, and a successful parse does not return at all.
+    // So, we return 1 on a "non-help" success to inform the calling function that it should proceed.
+    CLI11_PARSE(app, nArgs, args);
+
+    return 1;
+}
+
+// Return input file to load
+std::optional<std::string> CLIOptions::inputFile() const { return inputFile_; }
+
+// Return number of iterations to perform
+int CLIOptions::nIterations() const { return nIterations_; }
+
+// Return frequency at which to write restart file
+int CLIOptions::restartFileFrequency() const { return restartFileFrequency_; }
+
+// Return redirection basename (for per-process output)
+std::optional<std::string> CLIOptions::redirectionBasename() const { return redirectionBasename_; }
+
+// Return restart file to load, overriding default
+std::optional<std::string> CLIOptions::restartFilename() const { return restartFilename_; }
+
+// Return new input file to write (after reading supplied file)
+std::optional<std::string> CLIOptions::writeInputFilename() const { return writeInputFilename_; }
+
+// Return whether to just check the input file, and then quit
+bool CLIOptions::checkInputOnly() const { return checkInputOnly_; }
+
+// Return whether to ignore restart file if it exists
+bool CLIOptions::ignoreRestartFile() const { return ignoreRestartFile_; }
+
+// Return whether to ignore GUI state file (if it exists)
+bool CLIOptions::ignoreStateFile() const { return ignoreStateFile_; }
+
+// Return whether to prevent writing of all output files
+bool CLIOptions::writeNoFiles() const { return writeNoFiles_; };

--- a/src/main/cli.cpp
+++ b/src/main/cli.cpp
@@ -9,6 +9,8 @@
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
 
+CLIOptions::CLIOptions() : checkInputOnly_(false), ignoreRestartFile_(false), ignoreStateFile_(false), writeNoFiles_(false) {}
+
 // Parse CLI options
 int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
 {

--- a/src/main/cli.cpp
+++ b/src/main/cli.cpp
@@ -11,7 +11,7 @@
 #include <limits>
 
 // Parse CLI options
-int CLIOptions::parse(const int nArgs, char **args, bool isGUI, bool isParallel)
+int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
 {
     // Create CLI object
 #ifdef PARALLEL
@@ -75,7 +75,7 @@ int CLIOptions::parse(const int nArgs, char **args, bool isGUI, bool isParallel)
     // The CLI11_PARSE macro expands to a simple try/catch block, returning non-zero on error.
     // However, early exits from -h or --help return zero, and a successful parse does not return at all.
     // So, we return 1 on a "non-help" success to inform the calling function that it should proceed.
-    CLI11_PARSE(app, nArgs, args);
+    CLI11_PARSE(app, args, argv);
 
     return 1;
 }

--- a/src/main/cli.cpp
+++ b/src/main/cli.cpp
@@ -76,7 +76,7 @@ int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
     // So, we return 1 on a "non-help" success to inform the calling function that it should proceed.
     CLI11_PARSE(app, args, argv);
 
-    return 1;
+    return CLIOptions::Success;
 }
 
 // Return input file to load

--- a/src/main/cli.h
+++ b/src/main/cli.h
@@ -39,6 +39,11 @@ class CLIOptions
     bool writeNoFiles_;
 
     public:
+    // Parse Result enum
+    enum ParseResult
+    {
+        Success = 1
+    };
     // Parse supplied options
     int parse(int args, char **argv, bool isGUI = false, bool isParallel = false);
     // Return input file to load

--- a/src/main/cli.h
+++ b/src/main/cli.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+// CLI Options Parser
+class CLIOptions
+{
+    public:
+    CLIOptions() = default;
+    ~CLIOptions() = default;
+
+    /*
+     * Options
+     */
+    private:
+    // Input file to load
+    std::optional<std::string> inputFile_;
+    // Number of iterations to perform
+    int nIterations_;
+    // Frequency at which to write restart file
+    int restartFileFrequency_;
+    // Redirection basename (for per-process output)
+    std::optional<std::string> redirectionBasename_;
+    // Restart file to load, overriding default
+    std::optional<std::string> restartFilename_;
+    // New input file to write (after reading supplied file)
+    std::optional<std::string> writeInputFilename_;
+    // Whether to just check the input file, and then quit
+    bool checkInputOnly_;
+    // Whether to ignore restart file (if it exists)
+    bool ignoreRestartFile_;
+    // Whether to ignore GUI state file (if it exists)
+    bool ignoreStateFile_;
+    // Whether to prevent writing of all output files
+    bool writeNoFiles_;
+
+    public:
+    // Parse supplied options
+    int parse(int nArgs, char **args, bool isGUI = false, bool isParallel = false);
+    // Return input file to load
+    std::optional<std::string> inputFile() const;
+    // Return number of iterations to perform
+    int nIterations() const;
+    // Return frequency at which to write restart file
+    int restartFileFrequency() const;
+    // Return redirection basename (for per-process output)
+    std::optional<std::string> redirectionBasename() const;
+    // Return restart file to load, overriding default
+    std::optional<std::string> restartFilename() const;
+    // Return new input file to write (after reading supplied file)
+    std::optional<std::string> writeInputFilename() const;
+    // Return whether to just check the input file, and then quit
+    bool checkInputOnly() const;
+    // Return whether to ignore restart file if it exists
+    bool ignoreRestartFile() const;
+    // Return whether to ignore GUI state file (if it exists)
+    bool ignoreStateFile() const;
+    // Return whether to prevent writing of all output files
+    bool writeNoFiles() const;
+};

--- a/src/main/cli.h
+++ b/src/main/cli.h
@@ -10,7 +10,7 @@
 class CLIOptions
 {
     public:
-    CLIOptions() = default;
+    CLIOptions();
     ~CLIOptions() = default;
 
     /*

--- a/src/main/cli.h
+++ b/src/main/cli.h
@@ -40,7 +40,7 @@ class CLIOptions
 
     public:
     // Parse supplied options
-    int parse(int nArgs, char **args, bool isGUI = false, bool isParallel = false);
+    int parse(int args, char **argv, bool isGUI = false, bool isParallel = false);
     // Return input file to load
     std::optional<std::string> inputFile() const;
     // Return number of iterations to perform

--- a/src/math/data2d.cpp
+++ b/src/math/data2d.cpp
@@ -75,10 +75,10 @@ void Data2D::initialise(const Data2D &source)
 // Initialise from supplied axis ranges
 void Data2D::initialise(double xMin, double xMax, double xBin, double yMin, double yMax, double yBin, bool withError)
 {
-    double xRange = xMax - xMin;
-    double yRange = yMax - yMin;
-    auto nXBins = xRange / xBin;
-    auto nYBins = yRange / yBin;
+    auto xRange = xMax - xMin;
+    auto yRange = yMax - yMin;
+    int nXBins = xRange / xBin;
+    int nYBins = yRange / yBin;
 
     // We will clamp the maxima to the nearest bin boundary (not less than the supplied axis maxima)
     if ((xMin + nXBins * xBin) < xMax)
@@ -88,13 +88,13 @@ void Data2D::initialise(double xMin, double xMax, double xBin, double yMin, doub
 
     // Create x_ axis array
     x_.initialise(nXBins);
-    double xCentre = xMin + xBin * 0.5;
+    auto xCentre = xMin + xBin * 0.5;
     for (int n = 0; n < nXBins; ++n, xCentre += xBin)
         x_[n] = xCentre;
 
     // Create y_ axis array
     y_.initialise(nYBins);
-    double yCentre = yMin + yBin * 0.5;
+    auto yCentre = yMin + yBin * 0.5;
     for (int n = 0; n < nYBins; ++n, yCentre += yBin)
         y_[n] = yCentre;
 

--- a/src/math/doubleexp.cpp
+++ b/src/math/doubleexp.cpp
@@ -10,7 +10,7 @@
 DoubleExp::DoubleExp()
 {
     mantissa_ = 0.0;
-    exponent_ = 0.0;
+    exponent_ = 0;
     recalculate();
 }
 

--- a/src/math/filters.cpp
+++ b/src/math/filters.cpp
@@ -94,7 +94,8 @@ void Filters::median(Data1D &data, int length)
     // Grab y array
     Array<double> &y = data.values();
 
-    double window[length], avg, result;
+    std::vector<double> window(length);
+    double avg, result;
     int m, i = length / 2, n = length / 2, miny, maxy;
     Array<double> newY(data.nValues());
 

--- a/src/math/gj.cpp
+++ b/src/math/gj.cpp
@@ -22,9 +22,9 @@ bool GaussJordan::invert(Array2D<double> &A)
     const auto rank = A.nRows();
     double *array = A.linearArray();
 
-    int pivotrows[rank], pivotcols[rank], pivotrow = 0, pivotcol = 0;
-    bool pivoted[rank];
-    int row, col, n, m;
+    std::vector<int> pivotrows(rank), pivotcols(rank);
+    std::vector<bool> pivoted(rank);
+    int row, col, n, m, pivotrow = 0, pivotcol = 0;
     double large, element;
     for (n = 0; n < rank; ++n)
     {

--- a/src/math/histogram1d.cpp
+++ b/src/math/histogram1d.cpp
@@ -85,7 +85,7 @@ void Histogram1D::setUpAxis(double axisMin, double &axisMax, double binWidth, in
     // Min, max, and bin width should be set to requested values initially
     // We will clamp the maximum to the nearest bin boundary (not less than the supplied axisMax)
     double range = axisMax - axisMin;
-    nBins = range / binWidth;
+    nBins = int(range / binWidth);
     if ((axisMin + nBins * binWidth) < axisMax)
     {
         ++nBins;
@@ -115,7 +115,7 @@ int Histogram1D::nBins() const { return nBins_; }
 bool Histogram1D::bin(double x)
 {
     // Calculate target bin
-    auto bin = (x - minimum_) / binWidth_;
+    auto bin = int((x - minimum_) / binWidth_);
 
     // Check bin range
     if ((bin < 0) || (bin >= nBins_))

--- a/src/math/histogram2d.cpp
+++ b/src/math/histogram2d.cpp
@@ -111,7 +111,7 @@ int Histogram2D::nYBins() const { return nYBins_; }
 bool Histogram2D::bin(double x, double y)
 {
     // Calculate target bin along x
-    auto xBin = (x - xMinimum_) / xBinWidth_;
+    auto xBin = int((x - xMinimum_) / xBinWidth_);
     if ((xBin < 0) || (xBin >= nXBins_))
     {
         ++nMissed_;
@@ -119,7 +119,7 @@ bool Histogram2D::bin(double x, double y)
     }
 
     // Calculate target bin along y
-    auto yBin = (y - yMinimum_) / yBinWidth_;
+    auto yBin = int((y - yMinimum_) / yBinWidth_);
     if ((yBin < 0) || (yBin >= nYBins_))
     {
         ++nMissed_;

--- a/src/math/histogram3d.cpp
+++ b/src/math/histogram3d.cpp
@@ -147,7 +147,7 @@ int Histogram3D::nYBins() const { return nYBins_; }
 bool Histogram3D::bin(double x, double y, double z)
 {
     // Calculate target bin along x
-    auto xBin = (x - xMinimum_) / xBinWidth_;
+    auto xBin = int((x - xMinimum_) / xBinWidth_);
     if ((xBin < 0) || (xBin >= nXBins_))
     {
         ++nMissed_;
@@ -155,7 +155,7 @@ bool Histogram3D::bin(double x, double y, double z)
     }
 
     // Calculate target bin along y
-    auto yBin = (y - yMinimum_) / yBinWidth_;
+    auto yBin = int((y - yMinimum_) / yBinWidth_);
     if ((yBin < 0) || (yBin >= nYBins_))
     {
         ++nMissed_;
@@ -163,7 +163,7 @@ bool Histogram3D::bin(double x, double y, double z)
     }
 
     // Calculate target bin along z
-    auto zBin = (z - zMinimum_) / zBinWidth_;
+    auto zBin = int((z - zMinimum_) / zBinWidth_);
     if ((zBin < 0) || (zBin >= nZBins_))
     {
         ++nMissed_;

--- a/src/math/mc.h
+++ b/src/math/mc.h
@@ -122,7 +122,7 @@ template <class T> class MonteCarloMinimiser : public MinimiserBase<T>
             trialValues = values;
 
             // Perform a Monte Carlo move on a random parameter
-            int i = trialValues.nItems() * DissolveMath::random();
+            auto i = int(trialValues.nItems() * DissolveMath::random());
             if (i >= trialValues.nItems())
                 i = trialValues.nItems() - 1;
 

--- a/src/math/praxis.h
+++ b/src/math/praxis.h
@@ -724,7 +724,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
         int ok;
         double s;
         double sf1;
-        double small;
+        double smallValue;
         double sx1;
         double t2;
         double temp;
@@ -732,7 +732,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
         double xm;
 
         machep = std::numeric_limits<double>::epsilon();
-        small = machep * machep;
+        smallValue = machep * machep;
         m2 = sqrt(machep);
         m4 = sqrt(m2);
         sf1 = f1;
@@ -763,7 +763,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
             t2 = s;
         }
 
-        t2 = std::max(t2, small);
+        t2 = std::max(t2, smallValue);
         t2 = std::min(t2, 0.01 * h);
 
         if (fk && f1 <= fm)
@@ -826,7 +826,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
             //
             //  Predict the minimum.
             //
-            if (d2 <= small)
+            if (d2 <= smallValue)
             {
                 if (0.0 <= d1)
                 {
@@ -898,7 +898,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
         //
         //  Get a new estimate of the second derivative.
         //
-        if (small < fabs(x2 * (x2 - x1)))
+        if (smallValue < fabs(x2 * (x2 - x1)))
         {
             d2 = (x2 * (f1 - f0) - x1 * (fm - f0)) / ((x1 * x2) * (x1 - x2));
         }
@@ -910,7 +910,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
             }
         }
 
-        d2 = std::max(d2, small);
+        d2 = std::max(d2, smallValue);
 
         x1 = x2;
         fx = fm;
@@ -1973,7 +1973,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
         int seed;
         double sf;
         double sl;
-        double small;
+        double smallValue;
         double t;
         double temp;
         double t2;
@@ -1997,9 +1997,9 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
         //  Initialization.
         //
         machep = std::numeric_limits<double>::epsilon();
-        small = machep * machep;
-        vsmall = small * small;
-        large = 1.0 / small;
+        smallValue = machep * machep;
+        vsmall = smallValue * smallValue;
+        large = 1.0 / smallValue;
         vlarge = 1.0 / vsmall;
         m2 = sqrt(machep);
         m4 = sqrt(m2);
@@ -2036,9 +2036,9 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
         fx = MinimiserBase<T>::cost(x);
 
         qf1 = fx;
-        t = small + fabs(t0);
+        t = smallValue + fabs(t0);
         t2 = t;
-        dmin = small;
+        dmin = smallValue;
         h = h0;
         h = std::max(h, 100.0 * t);
         ldt = h;
@@ -2230,7 +2230,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
                 //  If no random step was taken, V(*,KL) is the "non-conjugate"
                 //  direction along which the greatest improvement was made.
                 //
-                if (small < lds)
+                if (smallValue < lds)
                 {
                     for (j = kl - 1; k <= j; j--)
                     {
@@ -2422,7 +2422,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
                 {
                     d[i] = vsmall;
                 }
-                else if (dni < small)
+                else if (dni < smallValue)
                 {
                     d[i] = vlarge;
                 }
@@ -2438,7 +2438,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
             //
             //  Determine the smallest eigenvalue.
             //
-            dmin = std::max(d[nAlpha - 1], small);
+            dmin = std::max(d[nAlpha - 1], smallValue);
             //
             //  The ratio of the smallest to largest eigenvalue determines whether
             //  the system is ill conditioned.

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -57,9 +57,9 @@ bool RDFModule::calculateGRSimple(ProcessPool &procPool, Configuration *cfg, Par
     nTypes = partialSet.nAtomTypes();
     Messenger::printVerbose("Constructing local partial working arrays for {} types.\n", nTypes);
     const Box *box = cfg->box();
-    std::vector< Vec3<double>* > r(nTypes);
+    std::vector<Vec3<double> *> r(nTypes);
     std::vector<int> maxr(nTypes), nr(nTypes);
-    std::vector<int*> binss(nTypes);
+    std::vector<int *> binss(nTypes);
     int *bins;
 
     n = 0;

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -57,9 +57,10 @@ bool RDFModule::calculateGRSimple(ProcessPool &procPool, Configuration *cfg, Par
     nTypes = partialSet.nAtomTypes();
     Messenger::printVerbose("Constructing local partial working arrays for {} types.\n", nTypes);
     const Box *box = cfg->box();
-    Vec3<double> *r[nTypes];
-    int maxr[nTypes], nr[nTypes];
-    int *binss[nTypes], *bins;
+    std::vector< Vec3<double>* > r(nTypes);
+    std::vector<int> maxr(nTypes), nr(nTypes);
+    std::vector<int*> binss(nTypes);
+    int *bins;
 
     n = 0;
     for (auto &atd : cfg->usedAtomTypesList())

--- a/src/procedure/nodes/calculatebase.cpp
+++ b/src/procedure/nodes/calculatebase.cpp
@@ -4,6 +4,7 @@
 #include "procedure/nodes/calculatebase.h"
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
+#include "procedure/nodes/select.h"
 
 CalculateProcedureNodeBase::CalculateProcedureNodeBase(ProcedureNode::NodeType nodeType, SelectProcedureNode *site0,
                                                        SelectProcedureNode *site1, SelectProcedureNode *site2,

--- a/tests/go
+++ b/tests/go
@@ -164,7 +164,7 @@ do
 				output=../${test}.${input%.txt}.${nprocs}.out
 				echo -e "\nRunning test \"${input}\" (${nprocs} processes)..."
 				echo "Arguments are: $ARGS"
-				mpirun -np $nprocs ../$PARALLELBINARY $ARGS $input -r $output > $output
+				mpirun -np $nprocs ../$PARALLELBINARY $ARGS $input -a --redirect=$output > $output
 			fi
 
 			if [ "$?" -eq "0" ]

--- a/tests/go
+++ b/tests/go
@@ -6,11 +6,12 @@ NFAILED=0
 EXITONFAIL="TRUE"
 SERIALBINARY=../src/dissolve
 PARALLELBINARY=../src/dissolve-mpi
+MPIRUN="mpirun"
 TESTS=""
 NTESTS="0"
 COMMONARGS="-x -i -n 1"
 
-while getopts "as:p:" op
+while getopts "as:p:m:" op
 do
 	case $op in
 		a)
@@ -25,13 +26,17 @@ do
 			PARALLELBINARY=${OPTARG}
 			echo "Parallel binary to use is '${PARALLELBINARY}'"
 			;;
+		m)
+			MPIRUN=${OPTARG}
+			echo "MPI launch command to use is '${MPIRUN}'"
+			;;
 		\?)
 			echo "Error: Unrecognised switch '$op'"
 			exit 1
 			;;
 		*)
 			echo "Error: Extra operands given."
-			echo "Usage: $0 [-a] [-s <serial binary>] [-p <parallel binary>]"
+			echo "Usage: $0 [-a] [-s <serial binary>] [-p <parallel binary>] [-m <mpirun command>]"
 			exit 1
 			;;
 	esac
@@ -164,7 +169,7 @@ do
 				output=../${test}.${input%.txt}.${nprocs}.out
 				echo -e "\nRunning test \"${input}\" (${nprocs} processes)..."
 				echo "Arguments are: $ARGS"
-				mpirun -np $nprocs ../$PARALLELBINARY $ARGS $input -a --redirect=$output > $output
+				$MPIRUN -np $nprocs ../$PARALLELBINARY $ARGS $input -a --redirect=$output > $output
 			fi
 
 			if [ "$?" -eq "0" ]

--- a/tests/md/benzene.args
+++ b/tests/md/benzene.args
@@ -1,1 +1,1 @@
--n 1 -x -t reference.config
+-n 1 -x --restart reference.config

--- a/tests/restart/benzene.args
+++ b/tests/restart/benzene.args
@@ -1,1 +1,1 @@
--n 1 -x -t benzene.txt.restart.test
+-n 1 -x --restart benzene.txt.restart.test

--- a/web/content/docs/developers/compilation.md
+++ b/web/content/docs/developers/compilation.md
@@ -20,6 +20,7 @@ You may also consider using the excellent [`Ninja`](https://ninja-build.org/) to
 Regardless of which version is being built, several external libraries are always required:
 
 - [`libfmt`](https://github.com/fmtlib/fmt) >= v7, to provide flexible and type-safe output formatting
+- [`CLI11`](https://github.com/CLIUtils/CLI11) >= v1.9.1, to provide coherent handling of command line arguments
 - [`bison`](https://www.gnu.org/software/bison/), required to implement various grammars (e.g. equation parsing)
 - [`ANTLR4`](https://www.antlr.org/) >= v4.7.2, required to implement various grammars (e.g. NETA)
 

--- a/web/content/docs/userguide/run/cli.md
+++ b/web/content/docs/userguide/run/cli.md
@@ -1,22 +1,66 @@
 ---
 title: CLI Options
-description: All of Dissolve's command-line options explained
+description: Dissolve's command-line options
 ---
 
-| Switch (&lt;arg&gt;)  | CLI?   | GUI?   | Description |
-|:----------------------|:-------|:-------|:------------|
-|    -c                 |&#10004;|        | Check input and set-up only - don't perform any main-loop iterations |
-|    -f &lt;file&gt;    |&#10004;|        | Redirect output from individual processes to `file.N`, where N is the process rank |
-|    -h                 |&#10004;|&#10004;| Print available CLI options |
-|    -i                 |&#10004;|&#10004;| Ignore restart file if present |
-|    -I                 |        |&#10004;| Ignore GUI state file if present |
-|    -m                 |&#10004;|        | Restrict output to be from the master process alone (parallel code only) |
-|    -n &lt;n&gt;       |&#10004;|        | Run `n` main loop iterations, then stop |
-|    -q                 |&#10004;|&#10004;| Quiet mode - print no output |
-|    -i &lt;n&gt;       |&#10004;|&#10004;| Set restart file frequency to every `n` iterations |
-|    -s                 |&#10004;|        | Perform single main loop iteration and then quit (equivalent to `-n 1`) |
-|    -t &lt;file&gt;    |&#10004;|        | Load restart data from specified `file` (but still write to associated restart file) |
-|    -v                 |&#10004;|&#10004;| Verbose mode - be a little more descriptive throughout |
-|    -w &lt;file&gt;    |&#10004;|        | Write input to specified `file` after reading it, and then quit. Mostly used for testing consistency between read / written input files |
-|    -x                 |&#10004;|&#10004;| Don't write restart or heartbeat files (but still read in the restart file if present) |
+Dissolve takes a small number of command-line options in order to allow some fine control over what it's doing, and also allows for some additional functionality (e.g. input file checking) that doesn't involve running a simulation.
 
+Most options are common to all three flavours of Dissolve (serial, parallel, and the GUI) but some are specific to one in particular. These are listed in separate tables below.
+
+Note that an input file must be provided for the serial and parallel codes - it is optional for the GUI.
+
+### Basic Control
+
+The following options are recognised by the serial and parallel codes, as well as the GUI.
+
+#### `-n <n>`, `--niterations <n>`
+Run Dissolve for the specified number of iterations, and then quit. The default number of iterations if the `-n` flag is not specified is 5. For the GUI version, the specified number of iterations will be run, and then the GUI launched.
+
+#### `-q`, `--quiet`
+Don't print any output to the console whatsoever. Output files such as the restart file, heartbeat, and any data output requested in individual modules will still be written. Use the [`-x`](#-x---no-files) flag to prevent the restart and heartbeat files being written.
+
+#### `-v`, `--verbose`
+Print lots more output, mostly useful for debugging
+
+### Input Files
+
+#### `-c`, `--check`
+Dissolve will read in the supplied input file, and the restart file if it exists, and then exit without performing any simulation. Mostly useful for checking the validity of an input file before committing to a production run.
+
+Not available in the GUI code.
+
+#### `-i`, `--ignore-restart`
+Ignore the restart file (i.e. don't read it in) if it exists. The name of the expected restart file is the input file name suffixed with `.restart`.
+
+#### `-w <filename>`, `--write-input <filename>`
+Write the specified input file out to the file specified. Again, mostly useful for debugging.
+
+Not available in the GUI code.
+
+### Output Files
+
+#### `-f <n>`, `--frequency <n>`
+Specify the frequency (in terms of main loop iterations) that the restart file should be written at. The default value is 10.
+
+#### `--restart <filename>`
+Read restart file data from the file specified, rather than the default. Note that this only affects the initial target for reading the restart file - restart data written by the simulation will still be saved to the default restart file name.
+
+#### `-x`, `--no-files`
+Inhibit writing of the restart and heartbeat files. Data exported from individual modules will still be written.
+
+### GUI Options
+
+The following options are specific to the GUI.
+
+#### `-I`, `--ignore-state`
+Ignore the GUI state file (i.e. don't read it in) if it exists. The name of the expected state file is the input file name suffixed with `.state`.
+
+### Parallel Version Options
+
+The following options are specific to the parallel version of the code.
+
+#### `-a`, `--all`
+Write output from all parallel processes, rather than just the master process. Each line of output will be prefixed by the relevant process ID.
+
+#### `--redirect <basename>`
+Redirect all output from `stdout` to individual files, one for each process. The provided `basename` is suffixed by the relevant process ID.


### PR DESCRIPTION
This PR removes custom code handling CLI option parsing, and replaces it with one utilising the CLI11 library. Benefits of this change are less duplication of code (serial/parallel and GUI versions all now use the same class to parse options), better maintainability through use of a standard library, the ability to use stacked short as well as long options, and more consistent / expected handling of arguments.

Summary of work:
- New class `CLIOptions` to handle option parsing for any executable target in the codebase.
- Existing options reimplemented for the most part, but some have been harmonised or changed to different, more descriptive names.
- Updated docs and system tests.
