### PR TITLE
Code Tidy November 2019

### DIFF
--- a/src/base/enumoptions.h
+++ b/src/base/enumoptions.h
@@ -25,7 +25,7 @@ template <class T> class EnumOptions : public EnumOptionsBase
     // Return enumeration in T
     T enumeration(std::string_view keyword) const
     {
-        for (int n = 0; n < options_.size(); ++n)
+        for (auto n = 0; n < options_.size(); ++n)
             if (DissolveSys::sameString(keyword, options_[n].keyword()))
                 return (T)options_[n].enumeration();
 
@@ -37,13 +37,13 @@ template <class T> class EnumOptions : public EnumOptionsBase
     T enumeration() const
     {
         // Use local index to return enumeration
-        if (currentOptionIndex_ == -1)
+        if (!currentOptionIndex_.has_value())
         {
             Messenger::warn("No current option set in EnumOptions, so can't return an enumeration.\n");
             return (T)-1;
         }
 
-        return (T)options_[currentOptionIndex_].enumeration();
+        return (T)options_[currentOptionIndex_.value()].enumeration();
     }
     // Return enumerated keyword
     std::string_view keyword(T enumeration) const

--- a/src/base/enumoptionsbase.cpp
+++ b/src/base/enumoptionsbase.cpp
@@ -6,19 +6,12 @@
 #include "base/sysfunc.h"
 #include <stddef.h>
 
-EnumOptionsBase::EnumOptionsBase()
-{
-    name_ = "DummyOptions";
-
-    currentOptionIndex_ = -1;
-}
+EnumOptionsBase::EnumOptionsBase() { name_ = "DummyOptions"; }
 
 EnumOptionsBase::EnumOptionsBase(std::string_view name, const EnumOptionsList &options)
 {
     name_ = name;
     options_ = options.options();
-
-    currentOptionIndex_ = -1;
 }
 
 EnumOptionsBase::EnumOptionsBase(std::string_view name, const EnumOptionsList &options, int defaultEnumeration)
@@ -26,8 +19,7 @@ EnumOptionsBase::EnumOptionsBase(std::string_view name, const EnumOptionsList &o
     name_ = name;
     options_ = options.options();
 
-    currentOptionIndex_ = -1;
-    for (int n = 0; n < options_.size(); ++n)
+    for (auto n = 0; n < options_.size(); ++n)
         if (options_[n].enumeration() == defaultEnumeration)
         {
             currentOptionIndex_ = n;
@@ -44,7 +36,7 @@ int EnumOptionsBase::nOptions() const { return options_.size(); }
 // Return nth keyword in the list
 std::string_view EnumOptionsBase::keywordByIndex(int index) const
 {
-    if ((index < 0) || (index >= options_.size()))
+    if (index >= options_.size())
     {
         Messenger::error("Keyword index {} out of range for EnumOptions '{}'.\n", index, name_);
         return unrecognisedOption_.keyword();
@@ -56,7 +48,7 @@ std::string_view EnumOptionsBase::keywordByIndex(int index) const
 // Return description for the nth keyword in the list
 std::string_view EnumOptionsBase::descriptionByIndex(int index) const
 {
-    if ((index < 0) || (index >= options_.size()))
+    if (index >= options_.size())
     {
         Messenger::error("Keyword index {} out of range for EnumOptions '{}'.\n", index, name_);
         return unrecognisedOption_.keyword();
@@ -68,7 +60,7 @@ std::string_view EnumOptionsBase::descriptionByIndex(int index) const
 // Return option by keyword
 const EnumOption &EnumOptionsBase::option(std::string_view keyword) const
 {
-    for (int n = 0; n < options_.size(); ++n)
+    for (auto n = 0; n < options_.size(); ++n)
         if (DissolveSys::sameString(keyword, options_[n].keyword()))
             return options_[n];
     return unrecognisedOption_;
@@ -77,28 +69,28 @@ const EnumOption &EnumOptionsBase::option(std::string_view keyword) const
 // Return current option keyword
 std::string_view EnumOptionsBase::currentOptionKeyword() const
 {
-    if (currentOptionIndex_ == -1)
+    if (!currentOptionIndex_.has_value())
         return "UNDEFINED";
 
-    return options_[currentOptionIndex_].keyword();
+    return options_[currentOptionIndex_.value()].keyword();
 }
 
 // Return current option
 const EnumOption &EnumOptionsBase::currentOption() const
 {
-    if (currentOptionIndex_ == -1)
+    if (!currentOptionIndex_.has_value())
         return unrecognisedOption_;
 
-    return options_[currentOptionIndex_];
+    return options_[currentOptionIndex_.value()];
 }
 
 // Return current option index
-int EnumOptionsBase::currentOptionIndex() const { return currentOptionIndex_; }
+int EnumOptionsBase::currentOptionIndex() const { return currentOptionIndex_.value_or(0); }
 
 // Set current option index
 bool EnumOptionsBase::setCurrentOptionIndex(int index)
 {
-    if ((index < 0) || (index >= options_.size()))
+    if (index >= options_.size())
         return Messenger::error("EnumOptions index {} is out of range for '{}'.\n", index, name());
 
     currentOptionIndex_ = index;
@@ -109,7 +101,7 @@ bool EnumOptionsBase::setCurrentOptionIndex(int index)
 // Set current option from keyword
 bool EnumOptionsBase::setCurrentOption(std::string_view keyword)
 {
-    for (int n = 0; n < options_.size(); ++n)
+    for (auto n = 0; n < options_.size(); ++n)
         if (DissolveSys::sameString(keyword, options_[n].keyword()))
         {
             currentOptionIndex_ = n;
@@ -122,7 +114,7 @@ bool EnumOptionsBase::setCurrentOption(std::string_view keyword)
 // Return whether specified option keyword is valid
 bool EnumOptionsBase::isValid(std::string_view keyword) const
 {
-    for (int n = 0; n < options_.size(); ++n)
+    for (auto n = 0; n < options_.size(); ++n)
         if (DissolveSys::sameString(keyword, options_[n].keyword()))
             return true;
     return false;
@@ -132,7 +124,7 @@ bool EnumOptionsBase::isValid(std::string_view keyword) const
 bool EnumOptionsBase::errorAndPrintValid(std::string_view badKeyword) const
 {
     std::string validValueString;
-    for (int n = 0; n < options_.size(); ++n)
+    for (auto n = 0; n < options_.size(); ++n)
         validValueString += fmt::format(n == 0 ? "{}" : ", {}", options_[n].keyword());
     Messenger::error("'{}' is not a valid {}.\nValid options are:  {}", badKeyword, name_, validValueString);
 

--- a/src/base/enumoptionsbase.h
+++ b/src/base/enumoptionsbase.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "base/enumoptionslist.h"
+#include <optional>
 
 // Enum Options Base
 class EnumOptionsBase
@@ -35,7 +36,7 @@ class EnumOptionsBase
     // Options
     std::vector<EnumOption> options_;
     // Current option index in local options_ array
-    int currentOptionIndex_;
+    std::optional<int> currentOptionIndex_;
 
     public:
     // Return number of options available

--- a/src/base/parameters.cpp
+++ b/src/base/parameters.cpp
@@ -6,7 +6,7 @@
 
 InteractionParameters::InteractionParameters()
 {
-    for (int n = 0; n < MAXSRPARAMETERS; ++n)
+    for (auto n = 0; n < MAXSRPARAMETERS; ++n)
         parameters_[n] = 0.0;
     charge_ = 0.0;
     empty_ = true;

--- a/src/base/processpool.cpp
+++ b/src/base/processpool.cpp
@@ -190,7 +190,7 @@ bool ProcessPool::isMe(int poolIndex) const { return (poolRank_ == poolIndex); }
 // Return whether this pool involves this process
 bool ProcessPool::involvesMe() const
 {
-    for (int n = 0; n < worldRanks_.nItems(); ++n)
+    for (auto n = 0; n < worldRanks_.nItems(); ++n)
         if (worldRanks_.constAt(n) == worldRank_)
             return true;
     return false;
@@ -238,7 +238,7 @@ bool ProcessPool::setUp(std::string_view name, Array<int> worldRanks, int groupP
     worldRanks_ = worldRanks;
 
     // See if our rank is in the list
-    for (int n = 0; n < worldRanks_.nItems(); ++n)
+    for (auto n = 0; n < worldRanks_.nItems(); ++n)
     {
         if (worldRank_ == worldRanks_[n])
         {
@@ -302,7 +302,7 @@ bool ProcessPool::assignProcessesToGroups()
     int baseAlloc = worldRanks_.nItems() / maxProcessGroups_;
     int remainder = worldRanks_.nItems() % maxProcessGroups_;
     std::string rankString;
-    for (int n = 0; n < maxProcessGroups_; ++n)
+    for (auto n = 0; n < maxProcessGroups_; ++n)
     {
         // Create nth process group and add a (currently null) entry to the groupLeaders_ array
         ProcessGroup group;
@@ -313,7 +313,7 @@ bool ProcessPool::assignProcessesToGroups()
         auto firstRank = baseAlloc * n + (n < remainder ? n : remainder);
         auto lastRank = firstRank + baseAlloc - (n >= remainder ? 1 : 0);
         rankString.clear();
-        for (int localRank = firstRank; localRank <= lastRank; ++localRank)
+        for (auto localRank = firstRank; localRank <= lastRank; ++localRank)
         {
             auto wr = worldRanks_[localRank];
             group.addProcess(localRank, wr);
@@ -347,10 +347,10 @@ bool ProcessPool::assignProcessesToGroups()
         Messenger::printVerbose("Process world rank {} is the master of pool '{}', and will assemble group leaders...\n",
                                 worldRank_, name_);
         // Loop over process groups
-        for (int group = 0; group < processGroups_.nItems(); ++group)
+        for (auto group = 0; group < processGroups_.nItems(); ++group)
         {
             // Query each process in the group to see if it is the leader...
-            for (int n = 0; n < nProcessesInGroup(group); ++n)
+            for (auto n = 0; n < nProcessesInGroup(group); ++n)
             {
                 auto prank = processGroups_[group].poolRank(n);
 
@@ -386,13 +386,13 @@ bool ProcessPool::assignProcessesToGroups()
     if (!broadcast(groupLeaders_))
         return false;
     Messenger::printVerbose("Group leader processes are :\n");
-    for (int group = 0; group < processGroups_.nItems(); ++group)
+    for (auto group = 0; group < processGroups_.nItems(); ++group)
         Messenger::printVerbose("   Group {:3d} : process rank {}\n", group, groupLeaders_[group]);
 
     // Create group leader communicator
     // Must first convert local pool ranks of the group leaders into world ranks, before passing this to MPI_Group_incl
     Array<int> groupLeadersW;
-    for (int n = 0; n < groupLeaders_.nItems(); ++n)
+    for (auto n = 0; n < groupLeaders_.nItems(); ++n)
         groupLeadersW.add(worldRanks_[groupLeaders_[n]]);
     MPI_Comm_group(MPI_COMM_WORLD, &origGroup);
     if (MPI_Group_incl(origGroup, groupLeadersW.nItems(), groupLeadersW.array(), &leaderGroup_) != MPI_SUCCESS)
@@ -638,7 +638,7 @@ int ProcessPool::twoBodyLoopStart(int nItems) const
     int startAtom = 0, finishAtom = -1;
 
     // Loop over processes
-    for (int process = 0; process < worldRanks_.nItems(); ++process)
+    for (auto process = 0; process < worldRanks_.nItems(); ++process)
     {
         // If this is the last process, make sure we avoid doing sqrt of zero or delta-neg value
         if (process == (worldRanks_.nItems() - 1))
@@ -677,7 +677,7 @@ int ProcessPool::twoBodyLoopEnd(int nItems) const
     int finishAtom;
 
     // Loop over processes
-    for (int process = 0; process < worldRanks_.nItems(); ++process)
+    for (auto process = 0; process < worldRanks_.nItems(); ++process)
     {
         // If this is the last process, make sure we avoid doing sqrt of zero or delta-neg value
         if (process == (worldRanks_.nItems() - 1))
@@ -1350,7 +1350,7 @@ bool ProcessPool::broadcast(Array<Vec3<int>> &array, int rootRank, ProcessPool::
             tempx.initialise(length);
             tempy.initialise(length);
             tempz.initialise(length);
-            for (int n = 0; n < length; ++n)
+            for (auto n = 0; n < length; ++n)
             {
                 tempx[n] = array[n].x;
                 tempy[n] = array[n].y;
@@ -1416,7 +1416,7 @@ bool ProcessPool::broadcast(Array<Vec3<int>> &array, int rootRank, ProcessPool::
             }
 
             // Store received data in array
-            for (int n = 0; n < length; ++n)
+            for (auto n = 0; n < length; ++n)
             {
                 array[n].x = tempx[n];
                 array[n].y = tempy[n];
@@ -1459,7 +1459,7 @@ bool ProcessPool::broadcast(Array<Vec3<double>> &array, int rootRank, ProcessPoo
             tempx.initialise(length);
             tempy.initialise(length);
             tempz.initialise(length);
-            for (int n = 0; n < length; ++n)
+            for (auto n = 0; n < length; ++n)
             {
                 tempx[n] = array[n].x;
                 tempy[n] = array[n].y;
@@ -1525,7 +1525,7 @@ bool ProcessPool::broadcast(Array<Vec3<double>> &array, int rootRank, ProcessPoo
             }
 
             // Store received data in array
-            for (int n = 0; n < length; ++n)
+            for (auto n = 0; n < length; ++n)
             {
                 array[n].x = tempx[n];
                 array[n].y = tempy[n];
@@ -1727,7 +1727,7 @@ bool ProcessPool::sum(double *source, int count, int rootRank, ProcessPool::Comm
         if (MPI_Reduce(source, buffer, count, MPI_DOUBLE, MPI_SUM, rootRank, communicator(commType)) != MPI_SUCCESS)
             return false;
         // Put reduced data back into original buffer
-        for (int n = 0; n < count; ++n)
+        for (auto n = 0; n < count; ++n)
             source[n] = buffer[n];
     }
     else
@@ -1755,7 +1755,7 @@ bool ProcessPool::sum(int *source, int count, int rootRank, ProcessPool::Communi
         if (MPI_Reduce(source, buffer, count, MPI_INTEGER, MPI_SUM, rootRank, communicator(commType)) != MPI_SUCCESS)
             return false;
         // Put reduced data back into original buffer
-        for (int n = 0; n < count; ++n)
+        for (auto n = 0; n < count; ++n)
             source[n] = buffer[n];
     }
     else
@@ -1780,7 +1780,7 @@ bool ProcessPool::allSum(double *source, int count, ProcessPool::CommunicatorTyp
     if (MPI_Allreduce(source, &buffer, count, MPI_DOUBLE, MPI_SUM, communicator(commType)) != MPI_SUCCESS)
         return false;
     // Put reduced data back into original buffer
-    for (int n = 0; n < count; ++n)
+    for (auto n = 0; n < count; ++n)
         source[n] = buffer[n];
     timer_.accumulate();
 #endif
@@ -1793,7 +1793,7 @@ bool ProcessPool::allSum(int *source, int count, ProcessPool::CommunicatorType c
 #ifdef PARALLEL
     timer_.start();
     int buffer[count];
-    for (int n = 0; n < count; ++n)
+    for (auto n = 0; n < count; ++n)
         buffer[n] = 0;
 
     if ((commType == ProcessPool::GroupLeadersCommunicator) && (!groupLeader()))
@@ -1802,7 +1802,7 @@ bool ProcessPool::allSum(int *source, int count, ProcessPool::CommunicatorType c
         return false;
 
     // Put reduced data back into original buffer
-    for (int n = 0; n < count; ++n)
+    for (auto n = 0; n < count; ++n)
         source[n] = buffer[n];
     timer_.accumulate();
 #endif
@@ -1821,7 +1821,7 @@ bool ProcessPool::allSum(long int *source, int count, ProcessPool::CommunicatorT
         return false;
 
     // Put reduced data back into original buffer
-    for (int n = 0; n < count; ++n)
+    for (auto n = 0; n < count; ++n)
         source[n] = buffer[n];
     timer_.accumulate();
 #endif
@@ -1908,7 +1908,7 @@ bool ProcessPool::assemble(int *array, int nData, int *rootDest, int rootMaxData
 
         // Now get data from other processes, appending each chunk to the rootDest array
         int slaveNData;
-        for (int n = 0; n < worldRanks_.nItems(); ++n)
+        for (auto n = 0; n < worldRanks_.nItems(); ++n)
         {
             if (poolRank_ == n)
                 continue;
@@ -1958,12 +1958,12 @@ bool ProcessPool::assemble(double *array, int nLocalData, double *rootDest, int 
     if (poolRank_ == rootRank)
     {
         // The root's data must be copied into the local array
-        for (int n = 0; n < nLocalData; ++n)
+        for (auto n = 0; n < nLocalData; ++n)
             rootDest[n] = array[n];
 
         // Now get data from other processes, appending each chunk to the rootDest array
         int slaveNData;
-        for (int n = 0; n < worldRanks_.nItems(); ++n)
+        for (auto n = 0; n < worldRanks_.nItems(); ++n)
         {
             if (poolRank_ == n)
                 continue;
@@ -2113,7 +2113,7 @@ bool ProcessPool::equality(int i, ProcessPool::CommunicatorType commType)
     else
     {
         int j;
-        for (int n = 1; n < nProcesses(); ++n)
+        for (auto n = 1; n < nProcesses(); ++n)
         {
             if (!receive(j, n, commType))
                 return false;
@@ -2144,7 +2144,7 @@ bool ProcessPool::equality(long int i, ProcessPool::CommunicatorType commType)
     else
     {
         long int j;
-        for (int n = 1; n < nProcesses(); ++n)
+        for (auto n = 1; n < nProcesses(); ++n)
         {
             if (!receive(j, n, commType))
                 return false;
@@ -2175,7 +2175,7 @@ bool ProcessPool::equality(double x, ProcessPool::CommunicatorType commType)
     else
     {
         double y;
-        for (int n = 1; n < nProcesses(); ++n)
+        for (auto n = 1; n < nProcesses(); ++n)
         {
             if (!receive(y, n, commType))
                 return false;
@@ -2257,7 +2257,7 @@ bool ProcessPool::equality(Vec3<int> v, ProcessPool::CommunicatorType commType)
 bool ProcessPool::equality(long int *array, int nx, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
-    for (int n = 0; n < nx; ++n)
+    for (auto n = 0; n < nx; ++n)
         if (!equality(array[n], commType))
             return Messenger::error("Value {} of long int array is not equivalent (process {} has {}).\n", n, poolRank_,
                                     array[n]);
@@ -2269,7 +2269,7 @@ bool ProcessPool::equality(long int *array, int nx, ProcessPool::CommunicatorTyp
 bool ProcessPool::equality(double *array, int nx, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
-    for (int n = 0; n < nx; ++n)
+    for (auto n = 0; n < nx; ++n)
         if (!equality(array[n], commType))
             return Messenger::error("Value {} of double array is not equivalent (process {} has {:e}).\n", n, poolRank_,
                                     array[n]);
@@ -2286,7 +2286,7 @@ bool ProcessPool::equality(const Array<int> &array, ProcessPool::CommunicatorTyp
         return Messenger::error("Array<int> sizes are not equal (process {} has {}).\n", poolRank_, array.nItems());
 
     // Keep it simple (and slow) and check/send one value at a time
-    for (int n = 0; n < array.nItems(); ++n)
+    for (auto n = 0; n < array.nItems(); ++n)
         if (!equality(array.constAt(n), commType))
             return Messenger::error("Array<int> value {} is not equivalent (process {} has {:e}).\n", n, poolRank_,
                                     array.constAt(n));
@@ -2303,7 +2303,7 @@ bool ProcessPool::equality(const Array<double> &array, ProcessPool::Communicator
         return Messenger::error("Array<double> sizes are not equal (process {} has {}).\n", poolRank_, array.nItems());
 
     // Keep it simple (and slow) and check/send one value at a time
-    for (int n = 0; n < array.nItems(); ++n)
+    for (auto n = 0; n < array.nItems(); ++n)
         if (!equality(array.constAt(n), commType))
             return Messenger::error("Array<double> value {} is not equivalent (process {} has {:e}).\n", n, poolRank_,
                                     array.constAt(n));
@@ -2325,7 +2325,7 @@ bool ProcessPool::equality(const Array2D<int> &array, ProcessPool::CommunicatorT
                                 array.halved());
 
     // Keep it simple (and slow) and check/send one value at a time
-    for (int n = 0; n < array.linearArraySize(); ++n)
+    for (auto n = 0; n < array.linearArraySize(); ++n)
         if (!equality(array.constLinearValue(n), commType))
             return Messenger::error("Array2D<int> value {} is not equivalent (process {} has {:e}).\n", n, poolRank_,
                                     array.constLinearValue(n));
@@ -2347,7 +2347,7 @@ bool ProcessPool::equality(const Array2D<double> &array, ProcessPool::Communicat
                                 array.halved());
 
     // Keep it simple (and slow) and check/send one value at a time
-    for (int n = 0; n < array.linearArraySize(); ++n)
+    for (auto n = 0; n < array.linearArraySize(); ++n)
         if (!equality(array.constLinearValue(n), commType))
             return Messenger::error("Array2D<double> value {} is not equivalent (process {} has {:e}).\n", n, poolRank_,
                                     array.constLinearValue(n));
@@ -2369,7 +2369,7 @@ bool ProcessPool::equality(const Array2D<bool> &array, ProcessPool::Communicator
                                 array.halved());
 
     // Keep it simple (and slow) and check/send one value at a time
-    for (int n = 0; n < array.linearArraySize(); ++n)
+    for (auto n = 0; n < array.linearArraySize(); ++n)
         if (!equality(array.constLinearValue(n), commType))
             return Messenger::error("Array2D<bool> value {} is not equivalent (process {} has {}).\n", n, poolRank_,
                                     array.constLinearValue(n));
@@ -2396,7 +2396,7 @@ void ProcessPool::refillRandomBuffer()
                                 isMaster() ? "me" : "not me");
         if (isMaster())
         {
-            for (int n = 0; n < RANDBUFFERSIZE; ++n)
+            for (auto n = 0; n < RANDBUFFERSIZE; ++n)
                 randomBuffer_[n] = DissolveMath::random();
             broadcast(randomBuffer_, RANDBUFFERSIZE, 0, randomBufferCommGroup_);
         }
@@ -2410,7 +2410,7 @@ void ProcessPool::refillRandomBuffer()
                                 isMaster() ? "me" : "not me");
         if (isMaster())
         {
-            for (int n = 0; n < RANDBUFFERSIZE; ++n)
+            for (auto n = 0; n < RANDBUFFERSIZE; ++n)
                 randomBuffer_[n] = DissolveMath::random();
             broadcast(randomBuffer_, RANDBUFFERSIZE, 0, randomBufferCommGroup_);
         }
@@ -2424,7 +2424,7 @@ void ProcessPool::refillRandomBuffer()
                                 groupLeader() ? "me" : "not me");
         if (groupLeader())
         {
-            for (int n = 0; n < RANDBUFFERSIZE; ++n)
+            for (auto n = 0; n < RANDBUFFERSIZE; ++n)
                 randomBuffer_[n] = DissolveMath::random();
             broadcast(randomBuffer_, RANDBUFFERSIZE, 0, randomBufferCommGroup_);
         }
@@ -2435,7 +2435,7 @@ void ProcessPool::refillRandomBuffer()
     {
         // Create own random buffer
         Messenger::printVerbose("Random Buffer - Solo parallel, so will create own array.\n");
-        for (int n = 0; n < RANDBUFFERSIZE; ++n)
+        for (auto n = 0; n < RANDBUFFERSIZE; ++n)
             randomBuffer_[n] = DissolveMath::random();
     }
 #endif

--- a/src/base/processpool.cpp
+++ b/src/base/processpool.cpp
@@ -2103,7 +2103,6 @@ bool ProcessPool::equality(bool b, ProcessPool::CommunicatorType commType)
 bool ProcessPool::equality(int i, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
-    bool result;
     if (poolRank_ != 0)
     {
         if (!send(i, 0, commType))
@@ -2135,7 +2134,6 @@ bool ProcessPool::equality(int i, ProcessPool::CommunicatorType commType)
 bool ProcessPool::equality(long int i, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
-    bool result;
     if (poolRank_ != 0)
     {
         if (!send(i, 0, commType))
@@ -2167,7 +2165,6 @@ bool ProcessPool::equality(long int i, ProcessPool::CommunicatorType commType)
 bool ProcessPool::equality(double x, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
-    bool result;
     if (poolRank_ != 0)
     {
         if (!send(x, 0, commType))

--- a/src/base/processpool.cpp
+++ b/src/base/processpool.cpp
@@ -713,11 +713,11 @@ bool ProcessPool::wait(ProcessPool::CommunicatorType commType)
 }
 
 // Send single integer value to target process
-bool ProcessPool::send(int value, int targetWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::send(int value, int targetRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
-    if (MPI_Send(&value, 1, MPI_INTEGER, targetWorldRank, 0, communicator(commType)) != MPI_SUCCESS)
+    if (MPI_Send(&value, 1, MPI_INTEGER, targetRank, 0, communicator(commType)) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif
@@ -725,12 +725,12 @@ bool ProcessPool::send(int value, int targetWorldRank, ProcessPool::Communicator
 }
 
 // Receive single integer value from source process
-bool ProcessPool::receive(int &value, int sourceWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::receive(int &value, int sourceRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
     MPI_Status status;
-    if (MPI_Recv(&value, 1, MPI_INTEGER, sourceWorldRank, 0, communicator(commType), &status) != MPI_SUCCESS)
+    if (MPI_Recv(&value, 1, MPI_INTEGER, sourceRank, 0, communicator(commType), &status) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif
@@ -738,11 +738,11 @@ bool ProcessPool::receive(int &value, int sourceWorldRank, ProcessPool::Communic
 }
 
 // Send single long integer value to target process
-bool ProcessPool::send(long int value, int targetWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::send(long int value, int targetRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
-    if (MPI_Send(&value, 1, MPI_LONG, targetWorldRank, 0, communicator(commType)) != MPI_SUCCESS)
+    if (MPI_Send(&value, 1, MPI_LONG, targetRank, 0, communicator(commType)) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif
@@ -750,12 +750,12 @@ bool ProcessPool::send(long int value, int targetWorldRank, ProcessPool::Communi
 }
 
 // Receive single long integer value from source process
-bool ProcessPool::receive(long int &value, int sourceWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::receive(long int &value, int sourceRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
     MPI_Status status;
-    if (MPI_Recv(&value, 1, MPI_LONG, sourceWorldRank, 0, communicator(commType), &status) != MPI_SUCCESS)
+    if (MPI_Recv(&value, 1, MPI_LONG, sourceRank, 0, communicator(commType), &status) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif
@@ -763,11 +763,11 @@ bool ProcessPool::receive(long int &value, int sourceWorldRank, ProcessPool::Com
 }
 
 // Send single double value to target process
-bool ProcessPool::send(double value, int targetWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::send(double value, int targetRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
-    if (MPI_Send(&value, 1, MPI_DOUBLE, targetWorldRank, 0, communicator(commType)) != MPI_SUCCESS)
+    if (MPI_Send(&value, 1, MPI_DOUBLE, targetRank, 0, communicator(commType)) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif
@@ -775,12 +775,12 @@ bool ProcessPool::send(double value, int targetWorldRank, ProcessPool::Communica
 }
 
 // Receive single double value from source process
-bool ProcessPool::receive(double &value, int sourceWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::receive(double &value, int sourceRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
     MPI_Status status;
-    if (MPI_Recv(&value, 1, MPI_DOUBLE, sourceWorldRank, 0, communicator(commType), &status) != MPI_SUCCESS)
+    if (MPI_Recv(&value, 1, MPI_DOUBLE, sourceRank, 0, communicator(commType), &status) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif
@@ -788,12 +788,12 @@ bool ProcessPool::receive(double &value, int sourceWorldRank, ProcessPool::Commu
 }
 
 // Send single bool value to target process
-bool ProcessPool::send(bool value, int targetWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::send(bool value, int targetRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
     int data = value;
-    if (MPI_Send(&data, 1, MPI_INTEGER, targetWorldRank, 0, communicator(commType)) != MPI_SUCCESS)
+    if (MPI_Send(&data, 1, MPI_INTEGER, targetRank, 0, communicator(commType)) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif
@@ -801,13 +801,13 @@ bool ProcessPool::send(bool value, int targetWorldRank, ProcessPool::Communicato
 }
 
 // Receive single bool value from source process
-bool ProcessPool::receive(bool &value, int sourceWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::receive(bool &value, int sourceRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
     MPI_Status status;
     int result;
-    if (MPI_Recv(&result, 1, MPI_INTEGER, sourceWorldRank, 0, communicator(commType), &status) != MPI_SUCCESS)
+    if (MPI_Recv(&result, 1, MPI_INTEGER, sourceRank, 0, communicator(commType), &status) != MPI_SUCCESS)
         return false;
     value = result;
     timer_.accumulate();
@@ -816,11 +816,11 @@ bool ProcessPool::receive(bool &value, int sourceWorldRank, ProcessPool::Communi
 }
 
 // Send integer array data to target process
-bool ProcessPool::send(int *source, int nData, int targetWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::send(int *source, int nData, int targetRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
-    if (MPI_Send(source, nData, MPI_INTEGER, targetWorldRank, 0, communicator(commType)) != MPI_SUCCESS)
+    if (MPI_Send(source, nData, MPI_INTEGER, targetRank, 0, communicator(commType)) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif
@@ -828,12 +828,12 @@ bool ProcessPool::send(int *source, int nData, int targetWorldRank, ProcessPool:
 }
 
 // Receive integer array data from target process
-bool ProcessPool::receive(int *source, int nData, int sourceWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::receive(int *source, int nData, int sourceRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
     MPI_Status status;
-    if (MPI_Recv(source, nData, MPI_INTEGER, sourceWorldRank, 0, communicator(commType), &status) != MPI_SUCCESS)
+    if (MPI_Recv(source, nData, MPI_INTEGER, sourceRank, 0, communicator(commType), &status) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif
@@ -841,11 +841,11 @@ bool ProcessPool::receive(int *source, int nData, int sourceWorldRank, ProcessPo
 }
 
 // Send double array data to target process
-bool ProcessPool::send(double *source, int nData, int targetWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::send(double *source, int nData, int targetRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
-    if (MPI_Send(source, nData, MPI_DOUBLE, targetWorldRank, 0, communicator(commType)) != MPI_SUCCESS)
+    if (MPI_Send(source, nData, MPI_DOUBLE, targetRank, 0, communicator(commType)) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif
@@ -853,12 +853,12 @@ bool ProcessPool::send(double *source, int nData, int targetWorldRank, ProcessPo
 }
 
 // Receive double array data from target process
-bool ProcessPool::receive(double *source, int nData, int sourceWorldRank, ProcessPool::CommunicatorType commType)
+bool ProcessPool::receive(double *source, int nData, int sourceRank, ProcessPool::CommunicatorType commType)
 {
 #ifdef PARALLEL
     timer_.start();
     MPI_Status status;
-    if (MPI_Recv(source, nData, MPI_DOUBLE, sourceWorldRank, 0, communicator(commType), &status) != MPI_SUCCESS)
+    if (MPI_Recv(source, nData, MPI_DOUBLE, sourceRank, 0, communicator(commType), &status) != MPI_SUCCESS)
         return false;
     timer_.accumulate();
 #endif

--- a/src/base/sysfunc.cpp
+++ b/src/base/sysfunc.cpp
@@ -228,7 +228,7 @@ bool DissolveSys::isNumber(std::string_view text, bool &isFloatingPoint)
     // Assume integer to start with
     isFloatingPoint = false;
 
-    auto exponentIndex = -1;
+    std::optional<int> exponentIndex;
 
     const auto length = text.size();
     for (int n = 0; n < length; ++n)
@@ -244,7 +244,7 @@ bool DissolveSys::isNumber(std::string_view text, bool &isFloatingPoint)
             case ('-'):
             case ('+'):
                 // Only allow as first character or immediately following an exponent
-                if (n != (exponentIndex + 1))
+                if (n != (exponentIndex.value_or(-1) + 1))
                     return false;
                 break;
             // Exponentiation
@@ -255,7 +255,7 @@ bool DissolveSys::isNumber(std::string_view text, bool &isFloatingPoint)
                     return false;
 
                 // Can't have more than one
-                if (exponentIndex > 0)
+                if (exponentIndex.has_value())
                     return false;
 
                 // Store position

--- a/src/classes/atomtypedata.cpp
+++ b/src/classes/atomtypedata.cpp
@@ -28,21 +28,6 @@ AtomTypeData::AtomTypeData(const AtomTypeData &source) : atomType_(source.atomTy
     (*this) = source;
 }
 
-// Read data through specified LineParser
-AtomTypeData::AtomTypeData(LineParser &parser, const CoreData &coreData, int listIndex)
-    : atomType_(coreData.findAtomType(parser.argsv(0))), listIndex_(listIndex)
-{
-    population_ = parser.argd(1);
-    fraction_ = parser.argd(2);
-    boundCoherent_ = parser.argd(3);
-    isotopes_.clear();
-    int nIso = parser.argi(4);
-    for (int n = 0; n < nIso; ++n)
-    {
-        IsotopeData *tope = isotopes_.add();
-    }
-}
-
 AtomTypeData::AtomTypeData(int listIndex, std::shared_ptr<AtomType> type, double population)
     : atomType_(type), listIndex_(listIndex), population_(population)
 {

--- a/src/classes/atomtypedata.cpp
+++ b/src/classes/atomtypedata.cpp
@@ -27,11 +27,8 @@ AtomTypeData::AtomTypeData(const AtomTypeData &source) : listIndex_(source.listI
 }
 
 AtomTypeData::AtomTypeData(int listIndex, std::shared_ptr<AtomType> type, double population)
-    : atomType_(type), listIndex_(listIndex), population_(population)
+    : listIndex_(listIndex), atomType_(type), exchangeable_(false), population_(population), fraction_(0.0), boundCoherent_(0.0)
 {
-    exchangeable_ = false;
-    fraction_ = 0.0;
-    boundCoherent_ = 0.0;
 }
 
 void AtomTypeData::operator=(const AtomTypeData &source)

--- a/src/classes/atomtypedata.cpp
+++ b/src/classes/atomtypedata.cpp
@@ -21,7 +21,7 @@ AtomTypeData::AtomTypeData(std::shared_ptr<AtomType> type, double population, do
         isotopes_.add();
 }
 
-AtomTypeData::AtomTypeData(const AtomTypeData &source) : atomType_(source.atomType_), listIndex_(source.listIndex())
+AtomTypeData::AtomTypeData(const AtomTypeData &source) : listIndex_(source.listIndex()), atomType_(source.atomType_)
 {
     (*this) = source;
 }

--- a/src/classes/atomtypedata.cpp
+++ b/src/classes/atomtypedata.cpp
@@ -17,10 +17,8 @@ AtomTypeData::AtomTypeData(std::shared_ptr<AtomType> type, double population, do
     : atomType_(type), exchangeable_(false), population_(population), fraction_(fraction), boundCoherent_(boundCoherent)
 {
     isotopes_.clear();
-    for (int n = 0; n < nIso; ++n)
-    {
+    for (auto n = 0; n < nIso; ++n)
         isotopes_.add();
-    }
 }
 
 AtomTypeData::AtomTypeData(const AtomTypeData &source) : atomType_(source.atomType_), listIndex_(source.listIndex())

--- a/src/classes/atomtypedata.h
+++ b/src/classes/atomtypedata.h
@@ -22,11 +22,7 @@ class AtomTypeData
     AtomTypeData(std::shared_ptr<AtomType> type, double population = 0, double fraction = 0, double boundCoherent = 0,
                  int nIso = 0);
     AtomTypeData(const AtomTypeData &source);
-    // Read data through specified LineParser
-    AtomTypeData(LineParser &parser, const CoreData &coreData, int listIndex);
-    // Old Initialise
     AtomTypeData(int listIndex, std::shared_ptr<AtomType> atomType, double population);
-    // Assignment Operator
     void operator=(const AtomTypeData &source);
 
     /*

--- a/src/classes/atomtypelist.cpp
+++ b/src/classes/atomtypelist.cpp
@@ -288,7 +288,7 @@ bool AtomTypeList::read(LineParser &parser, CoreData &coreData)
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     auto nItems = parser.argi(0);
-    for (int n = 0; n < nItems; ++n)
+    for (auto n = 0; n < nItems; ++n)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
@@ -303,7 +303,7 @@ bool AtomTypeList::read(LineParser &parser, CoreData &coreData)
         // types_.emplace_back(types_.size(), atomType, population);
         types_.emplace_back(atomType, population, fraction, boundCoherent);
         auto &atd = types_.back();
-        for (int i = 0; i < nIsotopes; ++i)
+        for (auto i = 0; i < nIsotopes; ++i)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
@@ -359,7 +359,7 @@ bool AtomTypeList::broadcast(ProcessPool &procPool, const int root, const CoreDa
 
         // Clear list and reconstruct
         types_.clear();
-        for (int n = 0; n < count; ++n)
+        for (auto n = 0; n < count; ++n)
         {
             // Slaves must create a suitable structure first, and then join the broadcast
             std::string typeName;

--- a/src/classes/atomtypelist.cpp
+++ b/src/classes/atomtypelist.cpp
@@ -23,7 +23,7 @@ AtomTypeList::AtomTypeList(const AtomTypeList &source) { (*this) = source; }
 void AtomTypeList::operator=(const AtomTypeList &source) { types_ = source.types_; }
 
 // Array access operator
-AtomTypeData &AtomTypeList::operator[](unsigned int n)
+AtomTypeData &AtomTypeList::operator[](int n)
 {
 #ifdef CHECKS
     if ((n < 0) || (n >= types_.size()))

--- a/src/classes/atomtypelist.h
+++ b/src/classes/atomtypelist.h
@@ -22,7 +22,7 @@ class AtomTypeList : public GenericItemBase
     ~AtomTypeList();
     AtomTypeList(const AtomTypeList &source);
     void operator=(const AtomTypeList &source);
-    AtomTypeData &operator[](unsigned int n);
+    AtomTypeData &operator[](int n);
 
     /*
      * Type List

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -244,7 +244,7 @@ bool Box::calculateRDFNormalisation(ProcessPool &procPool, Data1D &boxNorm, doub
     Data1D normData;
     normData.initialise(nBins);
     Array<double> &y = normData.values();
-    for (int n = 0; n < nBins; ++n)
+    for (auto n = 0; n < nBins; ++n)
         normData.xAxis(n) = (n + 0.5) * binWidth;
 
     auto centre = axes_ * Vec3<double>(0.5, 0.5, 0.5);
@@ -255,12 +255,12 @@ bool Box::calculateRDFNormalisation(ProcessPool &procPool, Data1D &boxNorm, doub
                      nPointsPerProcess * procPool.nProcesses());
 
     // Pre-waste random numbers so that the random number generators in all processes line up
-    for (int n = 0; n < nPointsPerProcess * procPool.poolRank(); ++n)
+    for (auto n = 0; n < nPointsPerProcess * procPool.poolRank(); ++n)
         randomCoordinate();
 
     // Calculate the function
     y = 0.0;
-    for (int n = 0; n < nPointsPerProcess; ++n)
+    for (auto n = 0; n < nPointsPerProcess; ++n)
     {
         bin = (randomCoordinate() - centre).magnitude() * rBinWidth;
         if (bin < nBins)
@@ -270,7 +270,7 @@ bool Box::calculateRDFNormalisation(ProcessPool &procPool, Data1D &boxNorm, doub
         return false;
 
     // Post-waste random numbers so that the random number generators in all processes line up
-    for (int n = 0; n < nPointsPerProcess * (procPool.nProcesses() - 1 - procPool.poolRank()); ++n)
+    for (auto n = 0; n < nPointsPerProcess * (procPool.nProcesses() - 1 - procPool.poolRank()); ++n)
         randomCoordinate();
 
     // Normalise histogram data, and scale by volume and binWidth ratio
@@ -284,7 +284,7 @@ bool Box::calculateRDFNormalisation(ProcessPool &procPool, Data1D &boxNorm, doub
 
     // Rescale against expected volume for spherical shells
     double shellVolume, r = 0.0, maxHalf = inscribedSphereRadius(), x = 0.5 * rdfBinWidth;
-    for (int n = 0; n < nBins; ++n)
+    for (auto n = 0; n < nBins; ++n)
     {
         // We know that up to the maximum (orthogonal) half-cell width the normalisation should be exactly 1.0...
         if (x < maxHalf)

--- a/src/classes/braggreflection.cpp
+++ b/src/classes/braggreflection.cpp
@@ -79,7 +79,7 @@ void BraggReflection::addIntensity(int typeI, int typeJ, double intensity) { int
 // Scale intensities between all atom types by factor provided
 void BraggReflection::scaleIntensities(double factor)
 {
-    for (int n = 0; n < intensities_.linearArraySize(); ++n)
+    for (auto n = 0; n < intensities_.linearArraySize(); ++n)
         intensities_.linearArray()[n] *= factor;
 }
 

--- a/src/classes/cell.cpp
+++ b/src/classes/cell.cpp
@@ -113,8 +113,6 @@ bool Cell::removeAtom(Atom *i)
 // Add Cell neighbours
 void Cell::addCellNeighbours(OrderedVector<Cell *> &nearNeighbours, OrderedVector<Cell *> &mimNeighbours)
 {
-    int n;
-
     // Create near-neighbour array of Cells not requiring minimum image to be applied
     nCellNeighbours_ = nearNeighbours.size();
     cellNeighbours_.resize(nCellNeighbours_);

--- a/src/classes/cellarray.cpp
+++ b/src/classes/cellarray.cpp
@@ -211,12 +211,12 @@ bool CellArray::generate(const Box *box, double cellSize, double pairPotentialRa
                 // Check a nominal central cell at (0,0,0) and this grid reference to see if any pairs of
                 // corners are in range
                 auto close = false;
-                for (int iCorner = 0; iCorner < 8; ++iCorner)
+                for (auto iCorner = 0; iCorner < 8; ++iCorner)
                 {
                     // Set integer vertex of corner on 'central' box
                     i.set(iCorner & 1 ? 1 : 0, iCorner & 2 ? 1 : 0, iCorner & 4 ? 1 : 0);
 
-                    for (int jCorner = 0; jCorner < 8; ++jCorner)
+                    for (auto jCorner = 0; jCorner < 8; ++jCorner)
                     {
                         // Set integer vertex of corner on 'other' box
                         j.set(x + (jCorner & 1 ? 1 : 0), y + (jCorner & 2 ? 1 : 0), z + (jCorner & 4 ? 1 : 0));
@@ -404,13 +404,13 @@ bool CellArray::minimumImageRequired(const Cell *a, const Cell *b, double distan
     // required
     Vec3<int> i, j;
     Vec3<double> r;
-    for (int iCorner = 0; iCorner < 8; ++iCorner)
+    for (auto iCorner = 0; iCorner < 8; ++iCorner)
     {
         // Set integer vertex of corner on 'central' box
         i.set(a->gridReference().x + (iCorner & 1 ? 1 : 0), a->gridReference().y + (iCorner & 2 ? 1 : 0),
               a->gridReference().z + (iCorner & 4 ? 1 : 0));
 
-        for (int jCorner = 0; jCorner < 8; ++jCorner)
+        for (auto jCorner = 0; jCorner < 8; ++jCorner)
         {
             // Set integer vertex of corner on 'other' box
             j.set(b->gridReference().x + (jCorner & 1 ? 1 : 0), b->gridReference().y + (jCorner & 2 ? 1 : 0),

--- a/src/classes/changestore.cpp
+++ b/src/classes/changestore.cpp
@@ -28,7 +28,7 @@ void ChangeStore::add(Atom *i)
 // Add Molecule to watch
 void ChangeStore::add(std::shared_ptr<Molecule> mol)
 {
-    for (int n = 0; n < mol->nAtoms(); ++n)
+    for (auto n = 0; n < mol->nAtoms(); ++n)
         add(mol->atom(n));
 }
 
@@ -60,7 +60,7 @@ void ChangeStore::updateAll()
 // Update Atom positions using list indices
 void ChangeStore::updateAtomsLocal(int nAtoms, int *indices)
 {
-    for (int n = 0; n < nAtoms; ++n)
+    for (auto n = 0; n < nAtoms; ++n)
     {
 #ifdef CHECKS
         if ((indices[n] < 0) || (indices[n] >= targetAtoms_.nItems()))
@@ -157,7 +157,7 @@ bool ChangeStore::distributeAndApply(Configuration *cfg)
     indices_.initialise(nTotalChanges);
 
     // Copy local change data into arrays
-    for (int n = 0; n < changes_.nItems(); ++n)
+    for (auto n = 0; n < changes_.nItems(); ++n)
     {
         indices_[n] = changes_[n]->atomArrayIndex();
         x_[n] = changes_[n]->r().x;
@@ -187,7 +187,7 @@ bool ChangeStore::distributeAndApply(Configuration *cfg)
 
     // Apply atom changes
     Atom **atoms = cfg->atoms().array();
-    for (int n = 0; n < nTotalChanges; ++n)
+    for (auto n = 0; n < nTotalChanges; ++n)
     {
 #ifdef CHECKS
         if ((indices_[n] < 0) || (indices_[n] >= cfg->nAtoms()))

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -238,7 +238,7 @@ bool Configuration::broadcastCoordinates(ProcessPool &procPool, int rootRank)
     if (procPool.poolRank() == rootRank)
     {
         Messenger::printVerbose("Process rank {} is assembling coordinate data...\n", procPool.poolRank());
-        for (int n = 0; n < atoms_.nItems(); ++n)
+        for (auto n = 0; n < atoms_.nItems(); ++n)
         {
             x[n] = atoms_[n]->r().x;
             y[n] = atoms_[n]->r().y;
@@ -255,7 +255,7 @@ bool Configuration::broadcastCoordinates(ProcessPool &procPool, int rootRank)
 
     // Slaves then store values into Atoms, updating related info as we go
     if (procPool.isSlave())
-        for (int n = 0; n < atoms_.nItems(); ++n)
+        for (auto n = 0; n < atoms_.nItems(); ++n)
             atoms_[n]->setCoordinates(x[n], y[n], z[n]);
 
     delete[] x;

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -130,10 +130,10 @@ std::shared_ptr<Molecule> Configuration::addMolecule(Species *sp, CoordinateSet 
     // Add Atoms from Species to the Molecule, using either species coordinates or those from the source CoordinateSet
     SpeciesAtom *spi = sp->firstAtom();
     if (sourceCoordinates)
-        for (int n = 0; n < sp->nAtoms(); ++n, spi = spi->next())
+        for (auto n = 0; n < sp->nAtoms(); ++n, spi = spi->next())
             addAtom(spi, newMolecule, sourceCoordinates->r(n));
     else
-        for (int n = 0; n < sp->nAtoms(); ++n, spi = spi->next())
+        for (auto n = 0; n < sp->nAtoms(); ++n, spi = spi->next())
             addAtom(spi, newMolecule, spi->r());
 
     return newMolecule;
@@ -205,7 +205,7 @@ void Configuration::scaleMoleculeCentres(double factor)
         newCog = oldCog * factor;
 
         // Loop over Atoms in Molecule, setting new coordinates as we go
-        for (int m = 0; m < mol->nAtoms(); ++m)
+        for (auto m = 0; m < mol->nAtoms(); ++m)
         {
             // Get Atom pointer
             Atom *i = mol->atom(m);

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -52,7 +52,7 @@ bool Configuration::write(LineParser &parser) const
     // Write all Atoms - for each write index and coordinates
     if (!parser.writeLineF("{}  # nAtoms\n", atoms_.nItems()))
         return false;
-    for (int n = 0; n < atoms_.nItems(); ++n)
+    for (auto n = 0; n < atoms_.nItems(); ++n)
     {
         const Atom *i = atoms_.constValue(n);
         if (!parser.writeLineF("{} {:e} {:e} {:e}\n", i->molecule()->arrayIndex(), i->x(), i->y(), i->z()))
@@ -113,7 +113,7 @@ bool Configuration::read(LineParser &parser, const List<Species> &availableSpeci
 
         // Set Species pointers for this range of Molecules
         auto nMols = parser.argi(0);
-        for (int n = 0; n < nMols; ++n)
+        for (auto n = 0; n < nMols; ++n)
             addMolecule(sp);
 
         // Increase our counter
@@ -124,7 +124,7 @@ bool Configuration::read(LineParser &parser, const List<Species> &availableSpeci
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     auto nAtoms = parser.argi(0);
-    for (int n = 0; n < nAtoms; ++n)
+    for (auto n = 0; n < nAtoms; ++n)
     {
         // Each line contains molecule ID and coordinates only
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -11,8 +11,6 @@
 // Write through specified LineParser
 bool Configuration::write(LineParser &parser) const
 {
-    int molId;
-
     if (!parser.writeLineF("'{}'  {}  # nMolecules\n", name(), molecules_.size()))
         return false;
 

--- a/src/classes/configuration_upkeep.cpp
+++ b/src/classes/configuration_upkeep.cpp
@@ -12,7 +12,7 @@ void Configuration::updateCellContents()
 {
     // Fold the coordinates of each atom into the box, and then check its Cell location, moving if necessary.
     Atom **atoms = atoms_.array();
-    for (int n = 0; n < atoms_.nItems(); ++n)
+    for (auto n = 0; n < atoms_.nItems(); ++n)
         updateCellLocation(atoms[n]);
 }
 
@@ -37,7 +37,7 @@ void Configuration::updateCellLocation(Atom *i)
 // Update Cell location of specified Molecule
 void Configuration::updateCellLocation(std::shared_ptr<Molecule> mol)
 {
-    for (int n = 0; n < mol->nAtoms(); ++n)
+    for (auto n = 0; n < mol->nAtoms(); ++n)
         updateCellLocation(mol->atom(n));
 }
 

--- a/src/classes/distributor.cpp
+++ b/src/classes/distributor.cpp
@@ -105,7 +105,7 @@ bool Distributor::addHardLocks(Array<Cell *> cells)
                             softCells.nItems());
 
     // Loop over Cells to hard-lock
-    for (int n = 0; n < cells.nItems(); ++n)
+    for (auto n = 0; n < cells.nItems(); ++n)
     {
         cellId = cells.constAt(n)->index();
 
@@ -127,7 +127,7 @@ bool Distributor::addHardLocks(Array<Cell *> cells)
     }
 
     // Must now soft-lock all the surrounding Cells
-    for (int n = 0; n < softCells.nItems(); ++n)
+    for (auto n = 0; n < softCells.nItems(); ++n)
     {
         cellId = softCells.constAt(n)->index();
         if (!addSoftLock(cellId))
@@ -148,7 +148,7 @@ bool Distributor::removeHardLocks(Array<Cell *> cells)
                             softCells.nItems());
 
     // Loop over Cells to hard-unlock
-    for (int n = 0; n < cells.nItems(); ++n)
+    for (auto n = 0; n < cells.nItems(); ++n)
     {
         cellId = cells.constAt(n)->index();
 
@@ -170,7 +170,7 @@ bool Distributor::removeHardLocks(Array<Cell *> cells)
     }
 
     // Must now soft-unlock all the surrounding Cells
-    for (int n = 0; n < softCells.nItems(); ++n)
+    for (auto n = 0; n < softCells.nItems(); ++n)
     {
         cellId = softCells.constAt(n)->index();
         if (!removeSoftLock(cellId))
@@ -195,7 +195,7 @@ bool Distributor::canHardLock(int cellIndex) const
     // For the specified Cell to be hard lockable its neighbours must not be HardLocked
 
     // Check lock status of local Cell neighbours
-    for (int n = 0; n < cell->nCellNeighbours(); ++n)
+    for (auto n = 0; n < cell->nCellNeighbours(); ++n)
     {
         id = cell->cellNeighbour(n)->index();
         if (cellLocks_.constAt(id) == HardLocked)
@@ -203,7 +203,7 @@ bool Distributor::canHardLock(int cellIndex) const
     }
 
     // Check lock status of minimum image Cell neighbours
-    for (int n = 0; n < cell->nMimCellNeighbours(); ++n)
+    for (auto n = 0; n < cell->nMimCellNeighbours(); ++n)
     {
         id = cell->mimCellNeighbour(n)->index();
         if (cellLocks_.constAt(id) == HardLocked)
@@ -216,7 +216,7 @@ bool Distributor::canHardLock(int cellIndex) const
 // Check hard lock possibility for list of Cells
 bool Distributor::canHardLock(Array<Cell *> cells) const
 {
-    for (int n = 0; n < cells.nItems(); ++n)
+    for (auto n = 0; n < cells.nItems(); ++n)
         if (!canHardLock(cells[n]->index()))
             return false;
     return true;
@@ -227,10 +227,10 @@ Array<Cell *> Distributor::surroundingCells(Array<Cell *> centralCells)
 {
     Array<Cell *> surroundingCells;
     int i;
-    for (int n = 0; n < centralCells.nItems(); ++n)
+    for (auto n = 0; n < centralCells.nItems(); ++n)
     {
         // Local Cell neighbours
-        for (int nbr = 0; nbr < centralCells[n]->nCellNeighbours(); ++nbr)
+        for (auto nbr = 0; nbr < centralCells[n]->nCellNeighbours(); ++nbr)
         {
             Cell *nbrCell = centralCells[n]->cellNeighbour(nbr);
 
@@ -252,7 +252,7 @@ Array<Cell *> Distributor::surroundingCells(Array<Cell *> centralCells)
         }
 
         // MIM Cell neighbours
-        for (int nbr = 0; nbr < centralCells[n]->nMimCellNeighbours(); ++nbr)
+        for (auto nbr = 0; nbr < centralCells[n]->nMimCellNeighbours(); ++nbr)
         {
             Cell *nbrCell = centralCells[n]->mimCellNeighbour(nbr);
 
@@ -305,7 +305,7 @@ int Distributor::nextAvailableObject(bool &changesBroadcastRequired)
     // Loop over target groups / processes
     // Every process will determine the next object for every group / process, and return therelevant one at the end of the
     // routine
-    for (int processOrGroup = 0; processOrGroup < nProcessesOrGroups_; ++processOrGroup)
+    for (auto processOrGroup = 0; processOrGroup < nProcessesOrGroups_; ++processOrGroup)
     {
         // Find the next object for this process / group, starting from the last one we found.
         // If there is no last object, work out a sensible starting point
@@ -328,7 +328,7 @@ int Distributor::nextAvailableObject(bool &changesBroadcastRequired)
             nextObject = startIndex;
         }
         else
-            for (int n = 0; n < nObjects_; ++n)
+            for (auto n = 0; n < nObjects_; ++n)
             {
                 // Get wrapped object index
                 auto index = (startIndex + n) % nObjects_;
@@ -352,7 +352,7 @@ int Distributor::nextAvailableObject(bool &changesBroadcastRequired)
                     // the search
                     // TODO Should we just broadcast changes instead of continuing the search?
                     hardCellModified = false;
-                    for (int i = 0; i < hardLocksRequired.nItems(); ++i)
+                    for (auto i = 0; i < hardLocksRequired.nItems(); ++i)
                     {
                         if (cellContentsModifiedBy_[hardLocksRequired[i]->index()] == -1)
                             continue;
@@ -378,7 +378,7 @@ int Distributor::nextAvailableObject(bool &changesBroadcastRequired)
                     if (!changesBroadcastRequired)
                     {
                         softLocksRequired = surroundingCells(hardLocksRequired);
-                        for (int i = 0; i < softLocksRequired.nItems(); ++i)
+                        for (auto i = 0; i < softLocksRequired.nItems(); ++i)
                         {
                             // Get index of surrounding Cell
                             auto cellIndex = softLocksRequired[i]->index();
@@ -455,7 +455,7 @@ bool Distributor::finishedWithObject()
     // We assume that changes were made to all hard-locked cells by all processes / groups. This may not be the case, but to
     // find out the true picture we would need to perform further MPI broadcast of information each time, and that is what
     // we are trying to avoid!
-    for (int processOrGroup = 0; processOrGroup < nProcessesOrGroups_; ++processOrGroup)
+    for (auto processOrGroup = 0; processOrGroup < nProcessesOrGroups_; ++processOrGroup)
     {
         auto objectIndex = lastObjectDistributed_[processOrGroup];
 
@@ -464,7 +464,7 @@ bool Distributor::finishedWithObject()
             objectStatus_[objectIndex] = Distributor::CompletedFlag;
 
         // Mark hard-locked Cells as being modified
-        for (int n = 0; n < lastHardLockedCells_[processOrGroup].nItems(); ++n)
+        for (auto n = 0; n < lastHardLockedCells_[processOrGroup].nItems(); ++n)
         {
             auto cellIndex = lastHardLockedCells_[processOrGroup].constAt(n)->index();
 

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -96,11 +96,10 @@ double EnergyKernel::energy(Cell *centralCell, Cell *otherCell, bool applyMim, b
     double totalEnergy = 0.0;
     auto &centralAtoms = centralCell->atoms();
     auto &otherAtoms = otherCell->atoms();
-    Atom *ii, *jj;
+    Atom *ii;
     Vec3<double> rI;
     std::shared_ptr<Molecule> molI;
     double rSq, scale;
-    auto central = centralAtoms.begin();
 
     // Get start/stride for specified loop context
     auto start = processPool_.interleavedLoopStart(strategy);
@@ -185,7 +184,7 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
 {
     double totalEnergy = 0.0;
     auto &centralAtoms = centralCell->atoms();
-    Atom *ii, *jj;
+    Atom *ii;
     Vec3<double> rJ;
     std::shared_ptr<Molecule> molJ;
     double rSq, scale;
@@ -204,7 +203,6 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
             molJ = jj->molecule();
             rJ = jj->r();
 
-            auto central = centralAtoms.begin();
             // Loop over central cell atoms
             for (auto indexI = centralAtoms.begin() + start; indexI < centralAtoms.end(); indexI += stride)
             {
@@ -242,7 +240,6 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
             molJ = jj->molecule();
             rJ = jj->r();
 
-            auto central = centralAtoms.begin();
             // Loop over central cell atoms
             for (auto indexI = centralAtoms.begin() + start; indexI < centralAtoms.end(); indexI += stride)
             {
@@ -294,11 +291,8 @@ double EnergyKernel::energy(const Atom *i, const Cell *cell, int flags, ProcessP
 #endif
     double totalEnergy = 0.0;
     Atom *jj;
-    int j;
     double rSq, scale;
     auto &otherAtoms = cell->atoms();
-    auto other = otherAtoms.begin();
-    auto nOtherAtoms = cell->nAtoms();
 
     // Grab some information on the supplied Atom
     std::shared_ptr<Molecule> moleculeI = i->molecule();
@@ -585,8 +579,6 @@ double EnergyKernel::energy(std::shared_ptr<const Molecule> mol, ProcessPool::Di
 double EnergyKernel::correct(const Atom *i)
 {
     // Loop over atoms in molecule
-    auto nMolAtoms = i->molecule()->nAtoms();
-    Atom *j;
     std::vector<Atom *> atoms = i->molecule()->atoms();
     double scale, r, correctionEnergy = 0.0;
     const auto rI = i->r();

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -609,7 +609,7 @@ double EnergyKernel::energy(const CellArray &cellArray, bool interMolecular, Pro
 
     double totalEnergy = 0.0;
     Cell *cell;
-    for (int cellId = start; cellId < cellArray.nCells(); cellId += stride)
+    for (auto cellId = start; cellId < cellArray.nCells(); cellId += stride)
     {
         cell = cellArray.cell(cellId);
 

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -119,7 +119,7 @@ void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool
 #endif
     OrderedVector<Atom *> &centralAtoms = centralCell->atoms();
     OrderedVector<Atom *> &otherAtoms = otherCell->atoms();
-    Atom *ii, *jj;
+    Atom *ii;
     Vec3<double> rI;
     std::shared_ptr<Molecule> molI;
     double scale;
@@ -214,7 +214,6 @@ void ForceKernel::forces(const Atom *i, Cell *cell, int flags, ProcessPool::Divi
     }
 #endif
     Atom *jj;
-    int j, index;
     double scale;
 
     // Grab some information on the supplied atom
@@ -289,7 +288,6 @@ void ForceKernel::forces(const Atom *i, Cell *cell, int flags, ProcessPool::Divi
         }
         else
         {
-            index = 0;
             for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
             {
                 // Grab other Atom pointer

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -188,7 +188,7 @@ bool Isotopologues::read(LineParser &parser, CoreData &coreData)
     speciesPopulation_ = parser.argi(1);
     auto nIso = parser.argi(2);
     mix_.clear();
-    for (int n = 0; n < nIso; ++n)
+    for (auto n = 0; n < nIso; ++n)
     {
         if (parser.getArgsDelim() != LineParser::Success)
             return false;
@@ -248,7 +248,7 @@ bool Isotopologues::broadcast(ProcessPool &procPool, const int root, const CoreD
     double weight;
     if (procPool.poolRank() == root)
     {
-        for (int n = 0; n < nIso; ++n)
+        for (auto n = 0; n < nIso; ++n)
         {
             // Broadcast Isotopologue
             topeName = mix_[n].isotopologue()->name();
@@ -264,7 +264,7 @@ bool Isotopologues::broadcast(ProcessPool &procPool, const int root, const CoreD
     else
     {
         mix_.clear();
-        for (int n = 0; n < nIso; ++n)
+        for (auto n = 0; n < nIso; ++n)
         {
             // Broadcast Isotopologue index data
             if (!procPool.broadcast(topeName, root))

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -74,7 +74,7 @@ void Molecule::setCentreOfGeometry(const Box *box, const Vec3<double> newCentre)
     const auto cog = centreOfGeometry(box);
 
     // Apply transform
-    for (int n = 0; n < nAtoms(); ++n)
+    for (auto n = 0; n < nAtoms(); ++n)
     {
         newR = box->minimumVector(atom(n), cog) + newCentre;
         atom(n)->setCoordinates(newR);
@@ -89,7 +89,7 @@ Vec3<double> Molecule::centreOfGeometry(const Box *box) const
 
     // Calculate center relative to first atom in molecule
     auto cog = atom(0)->r();
-    for (int n = 1; n < nAtoms(); ++n)
+    for (auto n = 1; n < nAtoms(); ++n)
         cog += box->minimumImage(atom(n), atom(0)->r());
 
     return (cog / nAtoms());
@@ -103,7 +103,7 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix)
     const auto cog = centreOfGeometry(box);
 
     // Apply transform
-    for (int n = 0; n < nAtoms(); ++n)
+    for (auto n = 0; n < nAtoms(); ++n)
     {
         newR = transformationMatrix * box->minimumVector(cog, atom(n)->r()) + cog;
         atom(n)->setCoordinates(newR);
@@ -128,7 +128,7 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, co
 // Translate whole molecule by the delta specified
 void Molecule::translate(const Vec3<double> delta)
 {
-    for (int n = 0; n < nAtoms(); ++n)
+    for (auto n = 0; n < nAtoms(); ++n)
         atom(n)->translateCoordinates(delta);
 }
 

--- a/src/classes/moleculedistributor.cpp
+++ b/src/classes/moleculedistributor.cpp
@@ -25,7 +25,7 @@ Array<Cell *> MoleculeDistributor::cellsToBeModifiedForObject(int objectId)
     // Loop over Atoms in the Molecule, and add the (unique) cellID each Atom is in
     Array<Cell *> cells;
     int n;
-    for (int i = 0; i < molecule->nAtoms(); ++i)
+    for (auto i = 0; i < molecule->nAtoms(); ++i)
     {
         Cell *cell = molecule->atom(i)->cell();
 

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -346,7 +346,7 @@ bool NeutronWeights::read(LineParser &parser, CoreData &coreData)
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     auto nItems = parser.argi(0);
-    for (int n = 0; n < nItems; ++n)
+    for (auto n = 0; n < nItems; ++n)
     {
         isotopologueMixtures_.emplace_back();
         if (!isotopologueMixtures_.back().read(parser, coreData))

--- a/src/classes/pairpotential.cpp
+++ b/src/classes/pairpotential.cpp
@@ -22,7 +22,7 @@ double PairPotential::shortRangeTruncationWidth_ = 2.0;
 
 PairPotential::PairPotential() : ListItem<PairPotential>(), uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
 {
-    for (int n = 0; n < MAXSRPARAMETERS; ++n)
+    for (auto n = 0; n < MAXSRPARAMETERS; ++n)
         parameters_[n] = 0.0;
     chargeI_ = 0.0;
     chargeJ_ = 0.0;
@@ -415,7 +415,7 @@ void PairPotential::calculateDUFull()
         return;
 
     double fprime;
-    for (int n = 1; n < nPoints_ - 1; ++n)
+    for (auto n = 1; n < nPoints_ - 1; ++n)
     {
         /* Calculate numerical derivative with five-point stencil if possible. Otherwise use three-point stencil.
          * Assumes data are regularly-spaced (they should be, with gap of delta_)
@@ -499,7 +499,7 @@ void PairPotential::calculateUOriginal(bool recalculateUFull)
 {
     double r;
 
-    for (int n = 1; n < nPoints_; ++n)
+    for (auto n = 1; n < nPoints_; ++n)
     {
         r = n * delta_;
         uOriginal_.xAxis(n) = r;

--- a/src/classes/partialset.cpp
+++ b/src/classes/partialset.cpp
@@ -273,7 +273,7 @@ bool PartialSet::save() const
         auto &bound = boundPartials_.constAt(typeI, typeJ);
         auto &unbound = unboundPartials_.constAt(typeI, typeJ);
         parser.writeLineF("# {:<14}  {:<16}  {:<16}  {:<16}\n", abscissaUnits_, "Full", "Bound", "Unbound");
-        for (int n = 0; n < full.nValues(); ++n)
+        for (auto n = 0; n < full.nValues(); ++n)
             parser.writeLineF("{:16.9e}  {:16.9e}  {:16.9e}  {:16.9e}\n", full.constXAxis(n), full.constValue(n),
                               bound.constValue(n), unbound.constValue(n));
         parser.closeFiles();
@@ -420,7 +420,7 @@ void PartialSet::calculateRDF(Data1D &destination, Histogram1D &histogram, doubl
     destination.clear();
 
     double shellVolume, factor, r = 0.5 * delta, lowerShellLimit = 0.0, numberDensity = nSurrounding / boxVolume;
-    for (int n = 0; n < nBins; ++n)
+    for (auto n = 0; n < nBins; ++n)
     {
         shellVolume = (4.0 / 3.0) * PI * (pow(lowerShellLimit + delta, 3.0) - pow(lowerShellLimit, 3.0));
         factor = nCentres * (shellVolume * numberDensity);
@@ -487,9 +487,9 @@ void PartialSet::operator*=(const double factor)
 {
     auto nTypes = atomTypes_.nItems();
 
-    for (int n = 0; n < nTypes; ++n)
+    for (auto n = 0; n < nTypes; ++n)
     {
-        for (int m = n; m < nTypes; ++m)
+        for (auto m = n; m < nTypes; ++m)
         {
             partials_.at(n, m).values() *= factor;
             boundPartials_.at(n, m).values() *= factor;
@@ -530,9 +530,9 @@ bool PartialSet::read(LineParser &parser, CoreData &coreData)
     emptyBoundPartials_.initialise(nTypes, nTypes, true);
     emptyBoundPartials_ = false;
 
-    for (int typeI = 0; typeI < nTypes; ++typeI)
+    for (auto typeI = 0; typeI < nTypes; ++typeI)
     {
-        for (int typeJ = typeI; typeJ < nTypes; ++typeJ)
+        for (auto typeJ = typeI; typeJ < nTypes; ++typeJ)
         {
             if (!partials_.at(typeI, typeJ).read(parser, coreData))
                 return false;

--- a/src/classes/regionaldistributor.cpp
+++ b/src/classes/regionaldistributor.cpp
@@ -122,7 +122,7 @@ bool RegionalDistributor::cycle()
     // molecules sequentially to each
     if (nProcessesOrGroups_ == 1)
     {
-        for (int n = 0; n < nMoleculesToDistribute_; ++n)
+        for (auto n = 0; n < nMoleculesToDistribute_; ++n)
         {
             if (moleculeStatus_[n] == RegionalDistributor::WaitingFlag)
             {
@@ -184,7 +184,7 @@ bool RegionalDistributor::cycle()
                 // Assign all remaining Molecules to group 0, and copy this group for distribution to all
                 // others.
                 assignedMolecules_[0].clear();
-                for (int n = 0; n < nMoleculesToDistribute_; ++n)
+                for (auto n = 0; n < nMoleculesToDistribute_; ++n)
                 {
                     if (moleculeStatus_[n] == RegionalDistributor::WaitingFlag)
                     {
@@ -283,7 +283,7 @@ bool RegionalDistributor::assignMolecule(std::shared_ptr<const Molecule> mol, in
 
     // Go through the Atoms of the Molecule, assembling a list of primary Cells in which its Atoms are found.
     Array<Cell *> primaryCells;
-    for (int i = 0; i < mol->nAtoms(); ++i)
+    for (auto i = 0; i < mol->nAtoms(); ++i)
     {
         // Get Cell pointer and index
         primaryCell = mol->atom(i)->cell();
@@ -316,7 +316,7 @@ bool RegionalDistributor::assignMolecule(std::shared_ptr<const Molecule> mol, in
     // We are able to lock all Cells that we need to edit, so now construct a list of those within the cutoff range of any
     // primaryCell that we must be able to read (but not modify)
     OrderedPointerList<const Cell> readOnlyCells;
-    for (int c = 0; c < primaryCells.nItems(); ++c)
+    for (auto c = 0; c < primaryCells.nItems(); ++c)
     {
         // Loop over all cell neighbours for this primary Cell
         for (const auto &neighbour : primaryCells[c]->allCellNeighbours())
@@ -347,7 +347,7 @@ bool RegionalDistributor::assignMolecule(std::shared_ptr<const Molecule> mol, in
     // If we reach this point, we can lock all the necessary Cells for editing, and mark all those necessary for reading.
 
     // Add primary and secondary lock Cells to our list, sanity checking along the way
-    for (int c = 0; c < primaryCells.nItems(); ++c)
+    for (auto c = 0; c < primaryCells.nItems(); ++c)
     {
         cellIndex = primaryCells[c]->index();
 
@@ -499,7 +499,7 @@ std::shared_ptr<Molecule> RegionalDistributor::assignMolecule(int processOrGroup
     }
 
     // No suitable Molecule yet, so start searching over all Cells from a suitable point along the array.
-    for (int n = 0; n < cellArray_.nCells(); ++n)
+    for (auto n = 0; n < cellArray_.nCells(); ++n)
     {
         // Determine Cell index
         cellIndex = n;

--- a/src/classes/regionaldistributor.cpp
+++ b/src/classes/regionaldistributor.cpp
@@ -267,7 +267,7 @@ bool RegionalDistributor::canLockCellForEditing(int processOrGroup, int cellInde
 // Assign Molecule to process/group if possible
 bool RegionalDistributor::assignMolecule(std::shared_ptr<const Molecule> mol, int processOrGroup)
 {
-    Cell *primaryCell;
+    Cell *primaryCell = nullptr;
     const Cell *readOnlyCell;
     int cellIndex;
 

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -70,10 +70,10 @@ void ScatteringMatrix::print() const
     Messenger::print("{}", line);
 
     // Loop over reference data
-    for (int row = 0; row < data_.nItems(); ++row)
+    for (auto row = 0; row < data_.nItems(); ++row)
     {
         line.clear();
-        for (int n = 0; n < A_.nColumns(); ++n)
+        for (auto n = 0; n < A_.nColumns(); ++n)
         {
             line += fmt::format("{:10f} ", A_.constAt(row, n));
 
@@ -90,7 +90,7 @@ void ScatteringMatrix::print() const
         if (row >= std::max(nColsWritten, 10))
         {
             line.clear();
-            for (int n = 0; n < nColsWritten; ++n)
+            for (auto n = 0; n < nColsWritten; ++n)
                 line += "    ...    ";
             Messenger::print("{}\n", line);
             break;
@@ -140,7 +140,7 @@ void ScatteringMatrix::printInverse() const
         if (col >= std::max(nColsWritten, 10))
         {
             line.clear();
-            for (int n = 0; n < nColsWritten; ++n)
+            for (auto n = 0; n < nColsWritten; ++n)
                 line += "    ...    ";
             Messenger::print(line);
             break;
@@ -169,14 +169,14 @@ void ScatteringMatrix::generatePartials(Array2D<Data1D> &estimatedSQ)
     Data1D *partials = estimatedSQ.linearArray();
 
     // Clear current partials
-    for (int n = 0; n < estimatedSQ.linearArraySize(); ++n)
+    for (auto n = 0; n < estimatedSQ.linearArraySize(); ++n)
         partials[n].clear();
 
     // Generate new partials (nPartials = nColumns)
-    for (int n = 0; n < A_.nColumns(); ++n)
+    for (auto n = 0; n < A_.nColumns(); ++n)
     {
         // Add in contribution from each datset (row).
-        for (int m = 0; m < data_.nItems(); ++m)
+        for (auto m = 0; m < data_.nItems(); ++m)
         {
             Interpolator::addInterpolated(partials[n], data_[m], inverseA_.constAt(n, m));
         }
@@ -252,9 +252,9 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, NeutronWeigh
     // Set coefficients in A_
     const auto nUsedTypes = dataWeights.nUsedTypes();
     AtomTypeList &usedTypes = dataWeights.atomTypes();
-    for (int n = 0; n < nUsedTypes; ++n)
+    for (auto n = 0; n < nUsedTypes; ++n)
     {
-        for (int m = n; m < nUsedTypes; ++m)
+        for (auto m = n; m < nUsedTypes; ++m)
         {
             auto colIndex = pairIndex(usedTypes.atomType(n), usedTypes.atomType(m));
             if (colIndex == -1)

--- a/src/classes/sitestack.cpp
+++ b/src/classes/sitestack.cpp
@@ -68,7 +68,7 @@ bool SiteStack::create(Configuration *cfg, SpeciesSite *speciesSite)
 
             // Calculate origin
 #ifdef CHECKS
-        for (int i = 0; i < originAtomIndices.nItems(); ++i)
+        for (auto i = 0; i < originAtomIndices.nItems(); ++i)
             if ((originAtomIndices[i] < 0) || (originAtomIndices[i] >= molecule->nAtoms()))
                 return Messenger::error("Origin atom index {} is out of range for molecule (contains {} atoms).\n",
                                         originAtomIndices[i], molecule->nAtoms());
@@ -78,7 +78,7 @@ bool SiteStack::create(Configuration *cfg, SpeciesSite *speciesSite)
             double mass = AtomicMass::mass(molecule->atom(originAtomIndices.firstValue())->speciesAtom()->element());
             origin = molecule->atom(originAtomIndices.firstValue())->r() * mass;
             double massNorm = mass;
-            for (int m = 1; m < originAtomIndices.nItems(); ++m)
+            for (auto m = 1; m < originAtomIndices.nItems(); ++m)
             {
                 mass = AtomicMass::mass(molecule->atom(originAtomIndices[m])->speciesAtom()->element());
                 origin += box->minimumImage(molecule->atom(originAtomIndices[m])->r(),
@@ -91,7 +91,7 @@ bool SiteStack::create(Configuration *cfg, SpeciesSite *speciesSite)
         else
         {
             origin = molecule->atom(originAtomIndices.firstValue())->r();
-            for (int m = 1; m < originAtomIndices.nItems(); ++m)
+            for (auto m = 1; m < originAtomIndices.nItems(); ++m)
                 origin += box->minimumImage(molecule->atom(originAtomIndices[m])->r(),
                                             molecule->atom(originAtomIndices.firstValue())->r());
             origin /= originAtomIndices.nItems();
@@ -101,18 +101,18 @@ bool SiteStack::create(Configuration *cfg, SpeciesSite *speciesSite)
         if (sitesHaveOrientation_)
         {
 #ifdef CHECKS
-            for (int i = 0; i < xAxisAtomIndices.nItems(); ++i)
+            for (auto i = 0; i < xAxisAtomIndices.nItems(); ++i)
                 if ((xAxisAtomIndices[i] < 0) || (xAxisAtomIndices[i] >= molecule->nAtoms()))
                     return Messenger::error("X-axis atom index {} is out of range for molecule (contains {} atoms).\n",
                                             xAxisAtomIndices[i], molecule->nAtoms());
-            for (int i = 0; i < yAxisAtomIndices.nItems(); ++i)
+            for (auto i = 0; i < yAxisAtomIndices.nItems(); ++i)
                 if ((yAxisAtomIndices[i] < 0) || (yAxisAtomIndices[i] >= molecule->nAtoms()))
                     return Messenger::error("Y-axis atom index {} is out of range for molecule (contains {} atoms).\n",
                                             yAxisAtomIndices[i], molecule->nAtoms());
 #endif
             // Get average position of supplied x-axis atoms
             v = molecule->atom(xAxisAtomIndices.firstValue())->r();
-            for (int m = 1; m < xAxisAtomIndices.nItems(); ++m)
+            for (auto m = 1; m < xAxisAtomIndices.nItems(); ++m)
                 v += box->minimumImage(molecule->atom(xAxisAtomIndices[m])->r(),
                                        molecule->atom(xAxisAtomIndices.firstValue())->r());
             v /= xAxisAtomIndices.nItems();
@@ -123,7 +123,7 @@ bool SiteStack::create(Configuration *cfg, SpeciesSite *speciesSite)
 
             // Get average position of supplied y-axis atoms
             v = molecule->atom(yAxisAtomIndices.firstValue())->r();
-            for (int m = 1; m < yAxisAtomIndices.nItems(); ++m)
+            for (auto m = 1; m < yAxisAtomIndices.nItems(); ++m)
                 v += box->minimumImage(molecule->atom(yAxisAtomIndices[m])->r(),
                                        molecule->atom(yAxisAtomIndices.firstValue())->r());
             v /= yAxisAtomIndices.nItems();

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -133,7 +133,7 @@ void Species::print()
     Messenger::print("  Atoms:\n");
     Messenger::print("      ID   El  Type (ID)        X             Y             Z             Q\n");
     Messenger::print("    ----------------------------------------------------------------------------\n");
-    for (int n = 0; n < nAtoms(); ++n)
+    for (auto n = 0; n < nAtoms(); ++n)
     {
         SpeciesAtom *i = atoms_[n];
         Messenger::print("    {:4d}  {:3}  {:4} ({:2d})  {:12.4e}  {:12.4e}  {:12.4e}  {:12.4e}\n", n + 1,

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -181,12 +181,12 @@ void Species::addMissingBonds(double tolerance)
     Vec3<double> vij;
     double radiusI;
     SpeciesAtom **atoms = atoms_.array();
-    for (int indexI = 0; indexI < nAtoms() - 1; ++indexI)
+    for (auto indexI = 0; indexI < nAtoms() - 1; ++indexI)
     {
         // Get SpeciesAtom 'i' and its radius
         SpeciesAtom *i = atoms[indexI];
         radiusI = AtomicRadius::radius(i->element());
-        for (int indexJ = indexI + 1; indexJ < nAtoms(); ++indexJ)
+        for (auto indexJ = indexI + 1; indexJ < nAtoms(); ++indexJ)
         {
             // Get SpeciesAtom 'j'
             SpeciesAtom *j = atoms[indexJ];

--- a/src/classes/speciesatom.cpp
+++ b/src/classes/speciesatom.cpp
@@ -227,7 +227,7 @@ const std::vector<std::reference_wrapper<SpeciesImproper>> &SpeciesAtom::imprope
 double SpeciesAtom::scaling(const SpeciesAtom *j) const
 {
     // Look through our ordered list of excluded Atom interactions
-    for (int n = 0; n < exclusions_.nItems(); ++n)
+    for (auto n = 0; n < exclusions_.nItems(); ++n)
     {
         // If the current item matches our Atom 'j', we have found a match
         if (exclusions_.pointer(n) == j)

--- a/src/classes/speciesbond.cpp
+++ b/src/classes/speciesbond.cpp
@@ -181,7 +181,7 @@ double BondTypeOrders[] = {1.0, 2.0, 3.0, 4.0, 1.5};
 // Convert bond type string to functional form
 SpeciesBond::BondType SpeciesBond::bondType(std::string_view s)
 {
-    for (int n = 0; n < SpeciesBond::nBondTypes; ++n)
+    for (auto n = 0; n < SpeciesBond::nBondTypes; ++n)
         if (DissolveSys::sameString(s, BondTypeKeywords[n]))
             return (SpeciesBond::BondType)n;
     return SpeciesBond::nBondTypes;

--- a/src/classes/speciessite.cpp
+++ b/src/classes/speciessite.cpp
@@ -287,7 +287,7 @@ Site *SpeciesSite::createFromParent() const
     if (originMassWeighted_)
     {
         double massNorm = 0.0;
-        for (int m = 0; m < originIndices.nItems(); ++m)
+        for (auto m = 0; m < originIndices.nItems(); ++m)
         {
             mass = AtomicMass::mass(parent_->atom(originIndices[m])->element());
             origin += parent_->atom(originIndices[m])->r() * mass;
@@ -297,7 +297,7 @@ Site *SpeciesSite::createFromParent() const
     }
     else
     {
-        for (int m = 0; m < originIndices.nItems(); ++m)
+        for (auto m = 0; m < originIndices.nItems(); ++m)
             origin += parent_->atom(originIndices[m])->r();
         origin /= originIndices.nItems();
     }
@@ -316,7 +316,7 @@ Site *SpeciesSite::createFromParent() const
         Vec3<double> v;
 
         // Get average position of supplied x-axis atoms
-        for (int m = 0; m < xAxisIndices.nItems(); ++m)
+        for (auto m = 0; m < xAxisIndices.nItems(); ++m)
             v += parent_->atom(xAxisIndices[m])->r();
         v /= xAxisIndices.nItems();
 
@@ -326,7 +326,7 @@ Site *SpeciesSite::createFromParent() const
 
         // Get average position of supplied y-axis atoms
         v.zero();
-        for (int m = 0; m < yAxisIndices.nItems(); ++m)
+        for (auto m = 0; m < yAxisIndices.nItems(); ++m)
             v += parent_->atom(yAxisIndices[m])->r();
         v /= yAxisIndices.nItems();
 
@@ -394,7 +394,7 @@ bool SpeciesSite::read(LineParser &parser)
                 blockDone = true;
                 break;
             case (SpeciesSite::OriginKeyword):
-                for (int n = 1; n < parser.nArgs(); ++n)
+                for (auto n = 1; n < parser.nArgs(); ++n)
                 {
                     if (!addOriginAtom(parser.argi(n) - 1))
                     {
@@ -467,7 +467,7 @@ bool SpeciesSite::write(LineParser &parser, std::string_view prefix)
         Array<int> indices = originAtomIndices();
 
         std::string atomIndices;
-        for (int n = 0; n < indices.nItems(); ++n)
+        for (auto n = 0; n < indices.nItems(); ++n)
             atomIndices += fmt::format("  {}", indices[n] + 1);
 
         if (!parser.writeLineF("{}  {}{}\n", prefix, keywords().keyword(OriginKeyword), atomIndices))
@@ -484,7 +484,7 @@ bool SpeciesSite::write(LineParser &parser, std::string_view prefix)
         Array<int> indices = xAxisAtomIndices();
 
         std::string atomIndices;
-        for (int n = 0; n < indices.nItems(); ++n)
+        for (auto n = 0; n < indices.nItems(); ++n)
             atomIndices += fmt::format("  {}", indices[n] + 1);
 
         if (!parser.writeLineF("{}  {}{}\n", prefix, keywords().keyword(XAxisKeyword), atomIndices))
@@ -497,7 +497,7 @@ bool SpeciesSite::write(LineParser &parser, std::string_view prefix)
         Array<int> indices = yAxisAtomIndices();
 
         std::string atomIndices;
-        for (int n = 0; n < indices.nItems(); ++n)
+        for (auto n = 0; n < indices.nItems(); ++n)
             atomIndices += fmt::format("  {}", indices[n] + 1);
 
         if (!parser.writeLineF("{}  {}{}\n", prefix, keywords().keyword(YAxisKeyword), atomIndices))

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -178,7 +178,7 @@ Array<double> XRayWeights::formFactor(int typeIndexI, const Array<double> &Q) co
 
     auto &fi = formFactorData_[typeIndexI].get();
 
-    for (int n = 0; n < Q.nItems(); ++n)
+    for (auto n = 0; n < Q.nItems(); ++n)
         fiq[n] = fi.magnitude(Q.constAt(n));
 
     return fiq;
@@ -232,7 +232,7 @@ Array<double> XRayWeights::weight(int typeIndexI, int typeIndexJ, const Array<do
     auto &fj = formFactorData_[typeIndexJ].get();
     auto preFactor = preFactors_.constAt(typeIndexI, typeIndexJ);
 
-    for (int n = 0; n < Q.nItems(); ++n)
+    for (auto n = 0; n < Q.nItems(); ++n)
         fijq[n] = fi.magnitude(Q.constAt(n)) * fj.magnitude(Q.constAt(n)) * preFactor;
 
     return fijq;
@@ -244,12 +244,12 @@ Array<double> XRayWeights::boundCoherentSquareOfAverage(const Array<double> &Q) 
     // Initialise results array
     Array<double> bbar(Q.nItems());
 
-    for (int typeI = 0; typeI < atomTypes_.nItems(); ++typeI)
+    for (auto typeI = 0; typeI < atomTypes_.nItems(); ++typeI)
     {
         const double ci = concentrations_.constAt(typeI);
         auto &fi = formFactorData_[typeI].get();
 
-        for (int n = 0; n < Q.nItems(); ++n)
+        for (auto n = 0; n < Q.nItems(); ++n)
             bbar[n] += ci * fi.magnitude(Q.constAt(n));
     }
 
@@ -262,12 +262,12 @@ Array<double> XRayWeights::boundCoherentAverageOfSquares(const Array<double> &Q)
     // Initialise results array
     Array<double> bbar(Q.nItems());
 
-    for (int typeI = 0; typeI < atomTypes_.nItems(); ++typeI)
+    for (auto typeI = 0; typeI < atomTypes_.nItems(); ++typeI)
     {
         const double ci = concentrations_.constAt(typeI);
         auto &fi = formFactorData_[typeI].get();
 
-        for (int n = 0; n < Q.nItems(); ++n)
+        for (auto n = 0; n < Q.nItems(); ++n)
             bbar[n] += ci * fi.magnitude(Q.constAt(n)) * fi.magnitude(Q.constAt(n));
     }
 

--- a/src/data/elements.cpp
+++ b/src/data/elements.cpp
@@ -129,7 +129,7 @@ Element &Elements::element(std::string_view symbol)
             return elements()[Z];
     }
     else
-        for (int n = 0; n < nElements(); n++)
+        for (auto n = 0; n < nElements(); n++)
             if (cleaned == elements()[n].symbol())
                 return elements()[n];
 

--- a/src/data/elements.h
+++ b/src/data/elements.h
@@ -77,7 +77,7 @@ class Elements
          * again from the destruction of the static array.
          */
         listArray.initialise(Elements::nElements());
-        for (int n = 0; n < nElements(); ++n)
+        for (auto n = 0; n < nElements(); ++n)
             listArray[n].setDisownOnDestruction(true);
     }
     // Create array of RefLists, with array size equal to number of elements defined

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -540,7 +540,6 @@ Forcefield::AtomGeometry Forcefield::geometryOfAtom(SpeciesAtom *i) const
 {
     AtomGeometry result = nAtomGeometries;
     double angle, largest;
-    SpeciesBond *b1, *b2;
     SpeciesAtom *h, *j;
     // 	RefListItem<SpeciesBond,int>* bref1, *bref2;
 

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -541,7 +541,6 @@ Forcefield::AtomGeometry Forcefield::geometryOfAtom(SpeciesAtom *i) const
     AtomGeometry result = nAtomGeometries;
     double angle, largest;
     SpeciesAtom *h, *j;
-    // 	RefListItem<SpeciesBond,int>* bref1, *bref2;
 
     // Work based on the number of bound atoms
     switch (i->nBonds())
@@ -566,28 +565,10 @@ Forcefield::AtomGeometry Forcefield::geometryOfAtom(SpeciesAtom *i) const
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             if (angle > 150.0)
                 result = Forcefield::LinearGeometry;
-            // 			else if ((angle > 100.0) && (angle < 115.0)) result =
-            // Forcefield::TetrahedralGeometry;
             else
                 result = Forcefield::TetrahedralGeometry;
             break;
         case (3):
-            // 			bref1 = bonds();
-            // 			bref2 = bonds()->next;
-            // 			b1 = bref1->item;
-            // 			b2 = bref2->item;
-            // 			angle = parent_->angle(b1->partner(this),this,b2->partner(this));
-            // 			largest = angle;
-            // 			b2 = bref2->next->item;
-            // 			angle = parent_->angle(b1->partner(this),this,b2->partner(this));
-            // 			if (angle > largest) largest = angle;
-            // 			b1 = bref1->next->item;
-            // 			angle = parent_->angle(b1->partner(this),this,b2->partner(this));
-            // 			if (angle > largest) largest = angle;
-            // 			if (largest > 170.0) result = Forcefield::TShapeGeometry;
-            // 			else if ((largest > 115.0) && (largest < 125.0)) result =
-            // Forcefield::TrigPlanarGeometry; 			else if ((largest < 115.0) && (largest > 100.0))
-            // result = Forcefield::TetrahedralGeometry; Get largest of the three angles around the central atom
             h = i->bond(0).partner(i);
             j = i->bond(1).partner(i);
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
@@ -604,8 +585,6 @@ Forcefield::AtomGeometry Forcefield::geometryOfAtom(SpeciesAtom *i) const
                 result = Forcefield::TShapeGeometry;
             else if ((largest > 115.0) && (largest < 125.0))
                 result = Forcefield::TrigonalPlanarGeometry;
-            // 			else if ((largest < 115.0) && (largest > 100.0)) result =
-            // Forcefield::TetrahedralGeometry;
             else
                 result = Forcefield::TetrahedralGeometry;
             break;
@@ -625,8 +604,6 @@ Forcefield::AtomGeometry Forcefield::geometryOfAtom(SpeciesAtom *i) const
             angle /= 6.0;
             if ((angle > 100.0) && (angle < 115.0))
                 result = Forcefield::TetrahedralGeometry;
-            // 			else if ((angle >= 115.0) && (angle < 125.0)) result =
-            // Forcefield::SquarePlanarGeometry;
             else
                 result = Forcefield::SquarePlanarGeometry;
             break;

--- a/src/data/ff.cpp
+++ b/src/data/ff.cpp
@@ -161,7 +161,7 @@ OptionalReferenceWrapper<const ForcefieldAtomType> Forcefield::atomTypeByName(st
 {
     auto startZ = (element ? element->Z() : 0);
     auto endZ = (element ? element->Z() : nElements() - 1);
-    for (int Z = startZ; Z <= endZ; ++Z)
+    for (auto Z = startZ; Z <= endZ; ++Z)
     {
         // Go through types associated to the Element
         auto it = std::find_if(atomTypesByElementPrivate_[Z].cbegin(), atomTypesByElementPrivate_[Z].cend(),
@@ -178,7 +178,7 @@ OptionalReferenceWrapper<const ForcefieldAtomType> Forcefield::atomTypeById(int 
 {
     auto startZ = (element ? element->Z() : 0);
     auto endZ = (element ? element->Z() : nElements() - 1);
-    for (int Z = startZ; Z <= endZ; ++Z)
+    for (auto Z = startZ; Z <= endZ; ++Z)
     {
         // Go through types associated to the Element
         auto it = std::find_if(atomTypesByElementPrivate_[Z].cbegin(), atomTypesByElementPrivate_[Z].cend(),
@@ -470,7 +470,7 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
                 continue;
 
             // Loop over combinations of bonds to the central atom
-            for (int indexJ = 0; indexJ < i->nBonds() - 2; ++indexJ)
+            for (auto indexJ = 0; indexJ < i->nBonds() - 2; ++indexJ)
             {
                 // Get SpeciesAtom 'j'
                 auto *j = i->bond(indexJ).partner(i);
@@ -481,7 +481,7 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
                 if (selectionOnly && (!j->isSelected()))
                     continue;
 
-                for (int indexK = indexJ + 1; indexK < i->nBonds() - 1; ++indexK)
+                for (auto indexK = indexJ + 1; indexK < i->nBonds() - 1; ++indexK)
                 {
                     // Get SpeciesAtom 'k'
                     auto *k = i->bond(indexK).partner(i);
@@ -492,7 +492,7 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
                     if (selectionOnly && (!k->isSelected()))
                         continue;
 
-                    for (int indexL = indexK + 1; indexL < i->nBonds(); ++indexL)
+                    for (auto indexL = indexK + 1; indexL < i->nBonds(); ++indexL)
                     {
                         // Get SpeciesAtom 'l'
                         auto *l = i->bond(indexL).partner(i);
@@ -592,10 +592,10 @@ Forcefield::AtomGeometry Forcefield::geometryOfAtom(SpeciesAtom *i) const
             // Two possibilities - tetrahedral or square planar. Tetrahedral will have an
             // average of all angles of ~ 109.5, for square planar (1/6) * (4*90 + 2*180) = 120
             angle = 0.0;
-            for (int n = 0; n < i->nBonds(); ++n)
+            for (auto n = 0; n < i->nBonds(); ++n)
             {
                 h = i->bond(n).partner(i);
-                for (int m = n + 1; m < i->nBonds(); ++m)
+                for (auto m = n + 1; m < i->nBonds(); ++m)
                 {
                     j = i->bond(m).partner(i);
                     angle += NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());

--- a/src/data/sg/generator.cpp
+++ b/src/data/sg/generator.cpp
@@ -68,7 +68,7 @@ bool SymmetryGenerator::set(std::string_view s)
     matrix_.zero();
 
     // Loop over arguments (equivalent to rows in matrix) and set parameters
-    for (int n = 0; n < 3; ++n)
+    for (auto n = 0; n < 3; ++n)
     {
         // Step through characters in 'part', adding until we find a (second) 'delimiting' character
         std::string subString;

--- a/src/expression/function.cpp
+++ b/src/expression/function.cpp
@@ -28,7 +28,7 @@ void ExpressionFunction::nodePrint(int offset, std::string_view prefix)
 {
     // Construct tabbed offset
     std::string tab;
-    for (int n = 0; n < offset - 1; n++)
+    for (auto n = 0; n < offset - 1; n++)
         tab += '\t';
     if (offset > 1)
         tab += "   |--> ";

--- a/src/expression/functions.cpp
+++ b/src/expression/functions.cpp
@@ -93,7 +93,7 @@ ExpressionFunctionData ExpressionFunctions::data[ExpressionFunctions::nFunctions
 // Return enumerated command from string
 ExpressionFunctions::Function ExpressionFunctions::function(std::string_view s)
 {
-    for (int result = ExpressionFunctions::NoFunction; result < ExpressionFunctions::nFunctions; result++)
+    for (auto result = (int)ExpressionFunctions::NoFunction; result < ExpressionFunctions::nFunctions; ++result)
         if (DissolveSys::sameString(data[result].keyword, s))
             return (ExpressionFunctions::Function)result;
 

--- a/src/expression/node.cpp
+++ b/src/expression/node.cpp
@@ -103,7 +103,7 @@ void ExpressionNode::addArguments(int nargs, ...)
     va_start(vars, nargs);
 
     // Add arguments in the order they were provided
-    for (int n = 0; n < nargs; n++)
+    for (auto n = 0; n < nargs; n++)
         addArgument(va_arg(vars, ExpressionNode *));
     va_end(vars);
 }

--- a/src/expression/variable.cpp
+++ b/src/expression/variable.cpp
@@ -95,7 +95,7 @@ void ExpressionVariable::nodePrint(int offset, std::string_view prefix)
 {
     // Construct tabbed offset
     std::string tab;
-    for (int n = 0; n < offset - 1; n++)
+    for (auto n = 0; n < offset - 1; n++)
         tab += '\t';
     if (offset > 1)
         tab += "   |--> ";

--- a/src/genericitems/array.h
+++ b/src/genericitems/array.h
@@ -52,7 +52,7 @@ template <class T> class GenericItemContainer<Array<T>> : public GenericItem
     {
         parser.writeLineF("{}\n", data_.nItems());
         T *array = data_.array();
-        for (int n = 0; n < data_.nItems(); ++n)
+        for (auto n = 0; n < data_.nItems(); ++n)
         {
             if (!array[n].write(parser))
                 return false;
@@ -67,7 +67,7 @@ template <class T> class GenericItemContainer<Array<T>> : public GenericItem
         int nItems = parser.argi(0);
         data_.initialise(nItems);
 
-        for (int n = 0; n < nItems; ++n)
+        for (auto n = 0; n < nItems; ++n)
             if (!data_[n].read(parser, coreData))
                 return false;
         return true;

--- a/src/genericitems/array2d.h
+++ b/src/genericitems/array2d.h
@@ -50,7 +50,7 @@ template <class T> class GenericItemContainer<Array2D<T>> : public GenericItem
     bool write(LineParser &parser)
     {
         parser.writeLineF("{}  {}  {}\n", data_.nRows(), data_.nColumns(), DissolveSys::btoa(data_.halved()));
-        for (int n = 0; n < data_.linearArraySize(); ++n)
+        for (auto n = 0; n < data_.linearArraySize(); ++n)
             if (!data_.linearValue(n).write(parser))
                 return false;
         return true;
@@ -63,7 +63,7 @@ template <class T> class GenericItemContainer<Array2D<T>> : public GenericItem
         int nRows = parser.argi(0), nColumns = parser.argi(1);
         data_.initialise(nRows, nColumns, parser.argb(2));
 
-        for (int n = 0; n < data_.linearArraySize(); ++n)
+        for (auto n = 0; n < data_.linearArraySize(); ++n)
             if (!data_.linearArray()[n].read(parser, coreData))
                 return false;
         return true;
@@ -95,7 +95,7 @@ template <class T> class GenericItemContainer<Array2D<T>> : public GenericItem
             // Now broadcast Array data
             if ((nRows * nColumns) > 0)
             {
-                for (int n = 0; n < data_.linearArraySize(); ++n)
+                for (auto n = 0; n < data_.linearArraySize(); ++n)
                     if (!data_.linearArray()[n].broadcast(procPool, root, coreData))
                         return false;
             }
@@ -114,7 +114,7 @@ template <class T> class GenericItemContainer<Array2D<T>> : public GenericItem
             data_.initialise(nRows, nColumns, half);
             if ((nRows * nColumns) > 0)
             {
-                for (int n = 0; n < data_.linearArraySize(); ++n)
+                for (auto n = 0; n < data_.linearArraySize(); ++n)
                     if (!data_.linearArray()[n].broadcast(procPool, root, coreData))
                         return false;
             }
@@ -135,7 +135,7 @@ template <class T> class GenericItemContainer<Array2D<T>> : public GenericItem
         if (!procPool.equality(data_.halved()))
             return Messenger::error("Array2D<double> half-status are not equivalent.\n");
         // Keep it simple (and slow) and check/send one value at a time
-        for (int n = 0; n < data_.linearArraySize(); ++n)
+        for (auto n = 0; n < data_.linearArraySize(); ++n)
             if (!data_.linearArray()[n].equality(procPool))
                 return false;
         return true;

--- a/src/genericitems/array2darraydouble.h
+++ b/src/genericitems/array2darraydouble.h
@@ -50,12 +50,12 @@ template <> class GenericItemContainer<Array2D<Array<double>>> : public GenericI
     static bool write(const Array2D<Array<double>> &thisData, LineParser &parser)
     {
         parser.writeLineF("{}  {}  {}\n", thisData.nRows(), thisData.nColumns(), DissolveSys::btoa(thisData.halved()));
-        for (int n = 0; n < thisData.linearArraySize(); ++n)
+        for (auto n = 0; n < thisData.linearArraySize(); ++n)
         {
             const Array<double> &arrayData = thisData.constLinearValue(n);
 
             parser.writeLineF("{}\n", arrayData.nItems());
-            for (int m = 0; m < arrayData.nItems(); ++m)
+            for (auto m = 0; m < arrayData.nItems(); ++m)
             {
                 if (!parser.writeLineF("{:16.9e}\n", arrayData.constAt(m)))
                     return false;
@@ -71,13 +71,13 @@ template <> class GenericItemContainer<Array2D<Array<double>>> : public GenericI
         int nRows = parser.argi(0), nColumns = parser.argi(1);
         thisData.initialise(nRows, nColumns, parser.argb(2));
 
-        for (int n = 0; n < thisData.linearArraySize(); ++n)
+        for (auto n = 0; n < thisData.linearArraySize(); ++n)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
             int nItems = parser.argi(0);
             thisData.linearArray()[n].createEmpty(nItems);
-            for (int m = 0; m < nItems; ++m)
+            for (auto m = 0; m < nItems; ++m)
             {
                 if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                     return false;
@@ -123,7 +123,7 @@ template <> class GenericItemContainer<Array2D<Array<double>>> : public GenericI
             }
 
             // Now broadcast Array elements
-            for (int n = 0; n < data_.linearArraySize(); ++n)
+            for (auto n = 0; n < data_.linearArraySize(); ++n)
             {
                 if (!procPool.broadcast(data_.linearArray()[n], root))
                     return false;
@@ -156,7 +156,7 @@ template <> class GenericItemContainer<Array2D<Array<double>>> : public GenericI
 
             // Resize and receive array
             data_.initialise(nRows, nColumns, half);
-            for (int n = 0; n < data_.linearArraySize(); ++n)
+            for (auto n = 0; n < data_.linearArraySize(); ++n)
             {
                 if (!procPool.broadcast(data_.linearArray()[n], root))
                     return false;
@@ -181,7 +181,7 @@ template <> class GenericItemContainer<Array2D<Array<double>>> : public GenericI
                                     procPool.poolRank(), data_.halved());
 
         // Keep it simple (and slow) and check/send one object at a time
-        for (int n = 0; n < data_.linearArraySize(); ++n)
+        for (auto n = 0; n < data_.linearArraySize(); ++n)
             if (!procPool.equality(data_.linearArray()[n]))
                 return Messenger::error("Array<double> index {} is not equivalent (process {}.\n", procPool.poolRank());
 #endif

--- a/src/genericitems/array2dbool.h
+++ b/src/genericitems/array2dbool.h
@@ -50,7 +50,7 @@ template <> class GenericItemContainer<Array2D<bool>> : public GenericItem
     static bool write(const Array2D<bool> &thisData, LineParser &parser)
     {
         parser.writeLineF("{}  {}  {}\n", thisData.nRows(), thisData.nColumns(), DissolveSys::btoa(thisData.halved()));
-        for (int n = 0; n < thisData.linearArraySize(); ++n)
+        for (auto n = 0; n < thisData.linearArraySize(); ++n)
             if (!parser.writeLineF("{}\n", thisData.constLinearValue(n) ? 'T' : 'F'))
                 return false;
         return true;
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<Array2D<bool>> : public GenericItem
         int nRows = parser.argi(0), nColumns = parser.argi(1);
         thisData.initialise(nRows, nColumns, parser.argb(2));
 
-        for (int n = 0; n < thisData.linearArraySize(); ++n)
+        for (auto n = 0; n < thisData.linearArraySize(); ++n)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;

--- a/src/genericitems/array2ddouble.h
+++ b/src/genericitems/array2ddouble.h
@@ -50,7 +50,7 @@ template <> class GenericItemContainer<Array2D<double>> : public GenericItem
     static bool write(const Array2D<double> &thisData, LineParser &parser)
     {
         parser.writeLineF("{}  {}  {}\n", thisData.nRows(), thisData.nColumns(), DissolveSys::btoa(thisData.halved()));
-        for (int n = 0; n < thisData.linearArraySize(); ++n)
+        for (auto n = 0; n < thisData.linearArraySize(); ++n)
             if (!parser.writeLineF("{:16.9e}\n", thisData.constLinearValue(n)))
                 return false;
         return true;
@@ -63,7 +63,7 @@ template <> class GenericItemContainer<Array2D<double>> : public GenericItem
         int nRows = parser.argi(0), nColumns = parser.argi(1);
         thisData.initialise(nRows, nColumns, parser.argb(2));
 
-        for (int n = 0; n < thisData.linearArraySize(); ++n)
+        for (auto n = 0; n < thisData.linearArraySize(); ++n)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;

--- a/src/genericitems/arraydouble.h
+++ b/src/genericitems/arraydouble.h
@@ -50,7 +50,7 @@ template <> class GenericItemContainer<Array<double>> : public GenericItem
     static bool write(const Array<double> &thisData, LineParser &parser)
     {
         parser.writeLineF("{}\n", thisData.nItems());
-        for (int n = 0; n < thisData.nItems(); ++n)
+        for (auto n = 0; n < thisData.nItems(); ++n)
         {
             if (!parser.writeLineF("{:16.9e}\n", thisData.constAt(n)))
                 return false;
@@ -64,7 +64,7 @@ template <> class GenericItemContainer<Array<double>> : public GenericItem
             return false;
         int nItems = parser.argi(0);
         thisData.createEmpty(nItems);
-        for (int n = 0; n < nItems; ++n)
+        for (auto n = 0; n < nItems; ++n)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;

--- a/src/genericitems/arrayint.h
+++ b/src/genericitems/arrayint.h
@@ -46,7 +46,7 @@ template <> class GenericItemContainer<Array<int>> : public GenericItem
     bool write(LineParser &parser)
     {
         parser.writeLineF("{}\n", data_.nItems());
-        for (int n = 0; n < data_.nItems(); ++n)
+        for (auto n = 0; n < data_.nItems(); ++n)
         {
             if (!parser.writeLineF("{}\n", data_.constAt(n)))
                 return false;
@@ -60,7 +60,7 @@ template <> class GenericItemContainer<Array<int>> : public GenericItem
             return false;
         int nItems = parser.argi(0);
         data_.createEmpty(nItems);
-        for (int n = 0; n < nItems; ++n)
+        for (auto n = 0; n < nItems; ++n)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;

--- a/src/genericitems/arrayvec3double.h
+++ b/src/genericitems/arrayvec3double.h
@@ -47,7 +47,7 @@ template <> class GenericItemContainer<Array<Vec3<double>>> : public GenericItem
     {
         parser.writeLineF("{}\n", data_.nItems());
         Vec3<double> *array = data_.array();
-        for (int n = 0; n < data_.nItems(); ++n)
+        for (auto n = 0; n < data_.nItems(); ++n)
         {
             if (!parser.writeLineF("{:16.9e} {:16.9e} {:16.9e}\n", array[n].x, array[n].y, array[n].z))
                 return false;
@@ -61,7 +61,7 @@ template <> class GenericItemContainer<Array<Vec3<double>>> : public GenericItem
             return false;
         int nItems = parser.argi(0);
         data_.createEmpty(nItems);
-        for (int n = 0; n < nItems; ++n)
+        for (auto n = 0; n < nItems; ++n)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
@@ -83,7 +83,7 @@ template <> class GenericItemContainer<Array<Vec3<double>>> : public GenericItem
         if (!procPool.equality(data_.nItems()))
             return false;
         // Keep it simple (and slow) and check/send one value at a time
-        for (int n = 0; n < data_.nItems(); ++n)
+        for (auto n = 0; n < data_.nItems(); ++n)
             if (!procPool.equality(data_.constAt(n)))
                 return false;
         return true;

--- a/src/genericitems/arrayvec3int.h
+++ b/src/genericitems/arrayvec3int.h
@@ -47,7 +47,7 @@ template <> class GenericItemContainer<Array<Vec3<int>>> : public GenericItem
     {
         parser.writeLineF("{}\n", data_.nItems());
         Vec3<int> *array = data_.array();
-        for (int n = 0; n < data_.nItems(); ++n)
+        for (auto n = 0; n < data_.nItems(); ++n)
         {
             if (!parser.writeLineF("{} {} {}\n", array[n].x, array[n].y, array[n].z))
                 return false;
@@ -61,7 +61,7 @@ template <> class GenericItemContainer<Array<Vec3<int>>> : public GenericItem
             return false;
         int nItems = parser.argi(0);
         data_.createEmpty(nItems);
-        for (int n = 0; n < nItems; ++n)
+        for (auto n = 0; n < nItems; ++n)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
@@ -83,7 +83,7 @@ template <> class GenericItemContainer<Array<Vec3<int>>> : public GenericItem
         if (!procPool.equality(data_.nItems()))
             return false;
         // Keep it simple (and slow) and check/send one value at a time
-        for (int n = 0; n < data_.nItems(); ++n)
+        for (auto n = 0; n < data_.nItems(); ++n)
             if (!procPool.equality(data_.constAt(n)))
                 return false;
         return true;

--- a/src/genericitems/list.cpp
+++ b/src/genericitems/list.cpp
@@ -226,7 +226,7 @@ bool GenericList::equality(ProcessPool &procPool)
     RefList<GenericItem> checkedItems;
     std::string itemName, itemClassName;
     auto nFailed = 0;
-    for (int n = 0; n < procPool.nProcesses(); ++n)
+    for (auto n = 0; n < procPool.nProcesses(); ++n)
     {
         // The master process - rank 'n' - will control the loop
         if (procPool.poolRank() == n)

--- a/src/gui/addconfigurationwizard_funcs.cpp
+++ b/src/gui/addconfigurationwizard_funcs.cpp
@@ -110,8 +110,6 @@ bool AddConfigurationWizard::progressionAllowed(int index) const
 // Perform any necessary actions before moving to the next page
 bool AddConfigurationWizard::prepareForNextPage(int currentIndex)
 {
-    Species *sp;
-
     switch (currentIndex)
     {
         case (AddConfigurationWizard::SelectTemplatePage):

--- a/src/gui/addforcefieldtermswizard_funcs.cpp
+++ b/src/gui/addforcefieldtermswizard_funcs.cpp
@@ -514,7 +514,7 @@ void AddForcefieldTermsWizard::checkForAtomTypeConflicts()
 {
     // Determine whether we have any naming conflicts
     auto nConflicts = 0;
-    for (int i = 0; i < ui_.AtomTypesConflictsList->count(); ++i)
+    for (auto i = 0; i < ui_.AtomTypesConflictsList->count(); ++i)
     {
         QListWidgetItem *item = ui_.AtomTypesConflictsList->item(i);
 
@@ -679,7 +679,7 @@ void AddForcefieldTermsWizard::masterTermsTreeEdited(QWidget *lineEdit)
 {
     // Since the signal that leads us here does not tell us the item that was edited, update all MasterTerm names here
     // before updating the page
-    for (int n = 0; n < masterBondItemParent_->childCount(); ++n)
+    for (auto n = 0; n < masterBondItemParent_->childCount(); ++n)
     {
         QTreeWidgetItem *item = masterBondItemParent_->child(n);
         MasterIntra *intra = VariantPointer<MasterIntra>(item->data(0, Qt::UserRole));
@@ -688,7 +688,7 @@ void AddForcefieldTermsWizard::masterTermsTreeEdited(QWidget *lineEdit)
 
         intra->setName(qPrintable(item->text(0)));
     }
-    for (int n = 0; n < masterAngleItemParent_->childCount(); ++n)
+    for (auto n = 0; n < masterAngleItemParent_->childCount(); ++n)
     {
         QTreeWidgetItem *item = masterAngleItemParent_->child(n);
         MasterIntra *intra = VariantPointer<MasterIntra>(item->data(0, Qt::UserRole));
@@ -697,7 +697,7 @@ void AddForcefieldTermsWizard::masterTermsTreeEdited(QWidget *lineEdit)
 
         intra->setName(qPrintable(item->text(0)));
     }
-    for (int n = 0; n < masterTorsionItemParent_->childCount(); ++n)
+    for (auto n = 0; n < masterTorsionItemParent_->childCount(); ++n)
     {
         QTreeWidgetItem *item = masterTorsionItemParent_->child(n);
         MasterIntra *intra = VariantPointer<MasterIntra>(item->data(0, Qt::UserRole));

--- a/src/gui/charts/chart_funcs.cpp
+++ b/src/gui/charts/chart_funcs.cpp
@@ -121,9 +121,7 @@ void ChartBase::mouseMoveEvent(QMouseEvent *event)
     repaint();
 
     // Begin the drag event
-    Qt::DropAction dropAction = drag->exec(Qt::MoveAction);
-    // 	if (dropAction
-    // 	...
+    drag->exec(Qt::MoveAction);
 
     // Nullify the dragged block
     draggedBlock_ = nullptr;

--- a/src/gui/charts/modulelist.cpp
+++ b/src/gui/charts/modulelist.cpp
@@ -279,9 +279,7 @@ void ModuleListChart::handleDroppedObject(const MimeStrings *strings)
         // Create a new instance of the specified module type
         Module *newModule = dissolve_.createModuleInstance(strings->data(MimeString::ModuleType));
 
-        // Cast the blocks either side of the current hotspot up to ModuleBlocks, and get their Modules
-        //         auto *moduleBlockBefore = dynamic_cast<ModuleBlock *>(currentHotSpot_->blockBefore());
-        // Module *moduleBeforeHotSpot = (moduleBlockBefore ? moduleBlockBefore->module() : nullptr);
+        // Cast necessary blocks around the current hotspot up to ModuleBlocks, and get their Modules
         auto *moduleBlockAfter = dynamic_cast<ModuleBlock *>(currentHotSpot_->blockAfter());
         Module *moduleAfterHotSpot = (moduleBlockAfter ? moduleBlockAfter->module() : nullptr);
 

--- a/src/gui/charts/modulelist.cpp
+++ b/src/gui/charts/modulelist.cpp
@@ -280,8 +280,8 @@ void ModuleListChart::handleDroppedObject(const MimeStrings *strings)
         Module *newModule = dissolve_.createModuleInstance(strings->data(MimeString::ModuleType));
 
         // Cast the blocks either side of the current hotspot up to ModuleBlocks, and get their Modules
-        auto *moduleBlockBefore = dynamic_cast<ModuleBlock *>(currentHotSpot_->blockBefore());
-        Module *moduleBeforeHotSpot = (moduleBlockBefore ? moduleBlockBefore->module() : nullptr);
+        //         auto *moduleBlockBefore = dynamic_cast<ModuleBlock *>(currentHotSpot_->blockBefore());
+        // Module *moduleBeforeHotSpot = (moduleBlockBefore ? moduleBlockBefore->module() : nullptr);
         auto *moduleBlockAfter = dynamic_cast<ModuleBlock *>(currentHotSpot_->blockAfter());
         Module *moduleAfterHotSpot = (moduleBlockAfter ? moduleBlockAfter->module() : nullptr);
 

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -28,7 +28,7 @@ ConfigurationTab::ConfigurationTab(DissolveWindow *dissolveWindow, Dissolve &dis
     configuration_ = cfg;
 
     // Populate coordinates file format combo
-    for (int n = 0; n < cfg->inputCoordinates().nFormats(); ++n)
+    for (auto n = 0; n < cfg->inputCoordinates().nFormats(); ++n)
         ui_.CoordinatesFileFormatCombo->addItem(QString::fromStdString(std::string(cfg->inputCoordinates().formatKeyword(n))));
 
     // Populate density units combo

--- a/src/gui/configurationviewer_input.cpp
+++ b/src/gui/configurationviewer_input.cpp
@@ -14,7 +14,6 @@ void ConfigurationViewer::mouseMoved(int dx, int dy)
         return;
 
     auto refresh = false;
-    Atom *currentAtom = nullptr;
 
     // What we do here depends on the current mode
     switch (interactionMode())

--- a/src/gui/configurationviewer_interaction.cpp
+++ b/src/gui/configurationviewer_interaction.cpp
@@ -21,7 +21,7 @@ const Atom *ConfigurationViewer::atomAt(int x, int y)
     // Loop over atoms, converting the local coordinates into screen coordinates, and testing distance from the point
     // provided
     const DynamicArray<Atom> &atoms = configuration_->constAtoms();
-    for (int n = 0; n < atoms.nItems(); ++n)
+    for (auto n = 0; n < atoms.nItems(); ++n)
     {
         const Atom *i = atoms.constValue(n);
 

--- a/src/gui/datamanagerdialog_funcs.cpp
+++ b/src/gui/datamanagerdialog_funcs.cpp
@@ -68,7 +68,7 @@ void DataManagerDialog::addItemsToTable(QTableWidget *table, List<GenericItem> &
 void DataManagerDialog::filterTable(QTableWidget *table, GenericItem *current, QString filter)
 {
     // Loop over rows in the table
-    for (int n = 0; n < table->rowCount(); ++n)
+    for (auto n = 0; n < table->rowCount(); ++n)
     {
         QTableWidgetItem *item = table->item(n, 0);
         if (!item)

--- a/src/gui/dataviewer_contextmenu.cpp
+++ b/src/gui/dataviewer_contextmenu.cpp
@@ -19,7 +19,6 @@
 void DataViewer::showGeneralContextMenu(QPoint pos)
 {
     QMenu menu;
-    QAction *action;
     menu.setFont(font());
 
     // Reset View

--- a/src/gui/dataviewer_input.cpp
+++ b/src/gui/dataviewer_input.cpp
@@ -128,6 +128,8 @@ void DataViewer::mouseDoubleClicked()
             break;
         case (GridLineMinorObject):
             break;
+        case (CustomObject):
+            break;
     }
 
     // Reset clicked object info

--- a/src/gui/delegates/intraformcombo_funcs.cpp
+++ b/src/gui/delegates/intraformcombo_funcs.cpp
@@ -44,7 +44,7 @@ void IntraFormComboDelegate::setEditorData(QWidget *editor, const QModelIndex &i
     // Get the current text and search for it in the combo
     QString value = index.model()->data(index, Qt::EditRole).toString();
 
-    for (int n = 0; n < comboBox->count(); ++n)
+    for (auto n = 0; n < comboBox->count(); ++n)
     {
         if (comboBox->itemText(n) == value)
         {

--- a/src/gui/delegates/usedspeciescombo_funcs.cpp
+++ b/src/gui/delegates/usedspeciescombo_funcs.cpp
@@ -43,7 +43,7 @@ void UsedSpeciesComboDelegate::setEditorData(QWidget *editor, const QModelIndex 
     // Get the current text and search for it in the combo
     QString value = index.model()->data(index, Qt::EditRole).toString();
 
-    for (int n = 0; n < comboBox->count(); ++n)
+    for (auto n = 0; n < comboBox->count(); ++n)
     {
         if (comboBox->itemText(n) == value)
         {

--- a/src/gui/forcefieldtab_funcs.cpp
+++ b/src/gui/forcefieldtab_funcs.cpp
@@ -45,7 +45,7 @@ ForcefieldTab::ForcefieldTab(DissolveWindow *dissolveWindow, Dissolve &dissolve,
                this, new ComboEnumOptionsItems<SpeciesImproper::ImproperFunction>(SpeciesImproper::improperFunctions())));
 
     // -- Parameters
-    for (int n = 2; n < 6; ++n)
+    for (auto n = 2; n < 6; ++n)
     {
         ui_.MasterBondsTable->setItemDelegateForColumn(n, new ExponentialSpinDelegate(this));
         ui_.MasterAnglesTable->setItemDelegateForColumn(n, new ExponentialSpinDelegate(this));
@@ -72,7 +72,7 @@ ForcefieldTab::ForcefieldTab(DissolveWindow *dissolveWindow, Dissolve &dissolve,
     ui_.AtomTypesTable->setItemDelegateForColumn(
         3, new ComboListDelegate(this, new ComboEnumOptionsItems<Forcefield::ShortRangeType>(Forcefield::shortRangeTypes())));
     // -- Charge / Parameters
-    for (int n = 4; n < 9; ++n)
+    for (auto n = 4; n < 9; ++n)
         ui_.AtomTypesTable->setItemDelegateForColumn(n, new ExponentialSpinDelegate(this));
 
     // Ensure fonts for table headers are set correctly and the headers themselves are visible
@@ -98,7 +98,7 @@ ForcefieldTab::ForcefieldTab(DissolveWindow *dissolveWindow, Dissolve &dissolve,
     ui_.PairPotentialsTable->horizontalHeader()->setVisible(true);
 
     // -- Charges / Parameters delegates
-    // 	for (int n=3; n<9; ++n) ui_.PairPotentialsTable->setItemDelegateForColumn(n, new ExponentialSpinDelegate(this));
+    // 	for (auto n=3; n<9; ++n) ui_.PairPotentialsTable->setItemDelegateForColumn(n, new ExponentialSpinDelegate(this));
 
     DataViewer *viewer = ui_.PairPotentialsPlotWidget->dataViewer();
     viewer->view().axes().setTitle(0, "\\it{r}, \\sym{angstrom}");
@@ -344,7 +344,7 @@ void ForcefieldTab::updateAtomTypesTableRow(int row, std::shared_ptr<AtomType> a
     item->setText(QString::fromStdString(std::string(Forcefield::shortRangeTypes().keyword(atomType->shortRangeType()))));
 
     // Parameters
-    for (int n = 0; n < MAXSRPARAMETERS; ++n)
+    for (auto n = 0; n < MAXSRPARAMETERS; ++n)
     {
         if (createItems)
         {
@@ -424,7 +424,7 @@ void ForcefieldTab::updatePairPotentialsTableRow(int row, PairPotential *pairPot
     item->setText(QString::number(pairPotential->chargeJ()));
 
     // Parameters
-    for (int n = 0; n < MAXSRPARAMETERS; ++n)
+    for (auto n = 0; n < MAXSRPARAMETERS; ++n)
     {
         if (createItems)
         {

--- a/src/gui/helpers/combopopulator.h
+++ b/src/gui/helpers/combopopulator.h
@@ -19,7 +19,7 @@ class ComboEnumOptionsPopulator
             combo->clear();
 
         // Add our text items to the list
-        for (int n = 0; n < options.nOptions(); ++n)
+        for (auto n = 0; n < options.nOptions(); ++n)
             combo->addItem(QString::fromStdString(std::string(options.keywordByIndex(n))));
     }
 };

--- a/src/gui/importspecieswizard_funcs.cpp
+++ b/src/gui/importspecieswizard_funcs.cpp
@@ -128,8 +128,6 @@ bool ImportSpeciesWizard::progressionAllowed(int index) const
 // Perform any necessary actions before moving to the next page
 bool ImportSpeciesWizard::prepareForNextPage(int currentIndex)
 {
-    SpeciesAtom *atomicAtom;
-
     switch (currentIndex)
     {
         case (ImportSpeciesWizard::SelectFilePage):

--- a/src/gui/importspecieswizard_funcs.cpp
+++ b/src/gui/importspecieswizard_funcs.cpp
@@ -301,7 +301,7 @@ void ImportSpeciesWizard::atomTypesListEdited(QWidget *lineEdit)
 {
     // Since the signal that leads us here does not tell us the item that was edited, update all AtomType names here before
     // updating the page
-    for (int n = 0; n < ui_.AtomTypesList->count(); ++n)
+    for (auto n = 0; n < ui_.AtomTypesList->count(); ++n)
     {
         QListWidgetItem *item = ui_.AtomTypesList->item(n);
         std::shared_ptr<AtomType> at = item->data(Qt::UserRole).value<std::shared_ptr<AtomType>>();
@@ -431,7 +431,7 @@ void ImportSpeciesWizard::masterTermsTreeEdited(QWidget *lineEdit)
 {
     // Since the signal that leads us here does not tell us the item that was edited, update all MasterTerm names here
     // before updating the page
-    for (int n = 0; n < masterBondItemParent_->childCount(); ++n)
+    for (auto n = 0; n < masterBondItemParent_->childCount(); ++n)
     {
         QTreeWidgetItem *item = masterBondItemParent_->child(n);
         MasterIntra *intra = VariantPointer<MasterIntra>(item->data(0, Qt::UserRole));
@@ -440,7 +440,7 @@ void ImportSpeciesWizard::masterTermsTreeEdited(QWidget *lineEdit)
 
         intra->setName(qPrintable(item->text(0)));
     }
-    for (int n = 0; n < masterAngleItemParent_->childCount(); ++n)
+    for (auto n = 0; n < masterAngleItemParent_->childCount(); ++n)
     {
         QTreeWidgetItem *item = masterAngleItemParent_->child(n);
         MasterIntra *intra = VariantPointer<MasterIntra>(item->data(0, Qt::UserRole));
@@ -449,7 +449,7 @@ void ImportSpeciesWizard::masterTermsTreeEdited(QWidget *lineEdit)
 
         intra->setName(qPrintable(item->text(0)));
     }
-    for (int n = 0; n < masterTorsionItemParent_->childCount(); ++n)
+    for (auto n = 0; n < masterTorsionItemParent_->childCount(); ++n)
     {
         QTreeWidgetItem *item = masterTorsionItemParent_->child(n);
         MasterIntra *intra = VariantPointer<MasterIntra>(item->data(0, Qt::UserRole));

--- a/src/gui/integrator1dgizmo_funcs.cpp
+++ b/src/gui/integrator1dgizmo_funcs.cpp
@@ -93,8 +93,7 @@ void Integrator1DGizmo::setGraphDataTargets()
     if (!integrationTarget_)
         return;
 
-    Renderable *data = ui_.PlotWidget->createRenderable(Renderable::Data1DRenderable, integrationTarget_->objectTag(),
-                                                        integrationTarget_->name());
+    ui_.PlotWidget->createRenderable(Renderable::Data1DRenderable, integrationTarget_->objectTag(), integrationTarget_->name());
 }
 
 /*

--- a/src/gui/keywordwidgets/atomtypeselection_funcs.cpp
+++ b/src/gui/keywordwidgets/atomtypeselection_funcs.cpp
@@ -106,7 +106,7 @@ void AtomTypeSelectionKeywordWidget::updateKeywordData()
 {
     // Loop over items in the QListWidget, adding the associated AtomTypes for any that are checked
     AtomTypeList newSelection;
-    for (int n = 0; n < ui.SelectionList->count(); ++n)
+    for (auto n = 0; n < ui.SelectionList->count(); ++n)
     {
         QListWidgetItem *item = ui.SelectionList->item(n);
         if (item->checkState() == Qt::Checked)

--- a/src/gui/keywordwidgets/broadeningfunction_funcs.cpp
+++ b/src/gui/keywordwidgets/broadeningfunction_funcs.cpp
@@ -15,7 +15,7 @@ BroadeningFunctionKeywordWidget::BroadeningFunctionKeywordWidget(QWidget *parent
     ui_.setupUi(dropWidget());
 
     // Add BroadeningFunction types to Combo
-    for (int n = 0; n < BroadeningFunction::nFunctionTypes; ++n)
+    for (auto n = 0; n < BroadeningFunction::nFunctionTypes; ++n)
         ui_.FunctionCombo->addItem(
             QString::fromStdString(std::string(BroadeningFunction::functionType((BroadeningFunction::FunctionType)n))));
 

--- a/src/gui/keywordwidgets/configurationreflist_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationreflist_funcs.cpp
@@ -68,7 +68,7 @@ void ConfigurationRefListKeywordWidget::itemChanged(QListWidgetItem *item)
     for (auto n = 0; n < ui_.SelectionList->count(); ++n)
         if (ui_.SelectionList->item(n)->checkState() == Qt::Checked)
             ++nChecked;
-    switch (keyword_->maxListSize().value_or(Module::OneOrMoreTargets))
+    switch (keyword_->maxListSize())
     {
         case (Module::ZeroTargets):
             if (nChecked != 0)

--- a/src/gui/keywordwidgets/configurationreflist_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationreflist_funcs.cpp
@@ -65,20 +65,20 @@ void ConfigurationRefListKeywordWidget::itemChanged(QListWidgetItem *item)
 
     // Ensure that we obey any limit on maximum number of selected items
     auto nChecked = 0;
-    for (int n = 0; n < ui_.SelectionList->count(); ++n)
+    for (auto n = 0; n < ui_.SelectionList->count(); ++n)
         if (ui_.SelectionList->item(n)->checkState() == Qt::Checked)
             ++nChecked;
     switch (keyword_->maxListSize())
     {
         case (Module::ZeroTargets):
             if (nChecked != 0)
-                for (int n = 0; n < ui_.SelectionList->count(); ++n)
+                for (auto n = 0; n < ui_.SelectionList->count(); ++n)
                     ui_.SelectionList->item(n)->setCheckState(Qt::Unchecked);
             break;
         case (Module::ExactlyOneTarget):
             if (nChecked > 1)
             {
-                for (int n = 0; n < ui_.SelectionList->count(); ++n)
+                for (auto n = 0; n < ui_.SelectionList->count(); ++n)
                     if ((ui_.SelectionList->item(n)->checkState() == Qt::Checked) && (ui_.SelectionList->item(n) != item))
                         ui_.SelectionList->item(n)->setCheckState(Qt::Unchecked);
             }
@@ -89,7 +89,7 @@ void ConfigurationRefListKeywordWidget::itemChanged(QListWidgetItem *item)
         default:
             if (nChecked > keyword_->maxListSize())
             {
-                for (int n = 0; n < ui_.SelectionList->count(); ++n)
+                for (auto n = 0; n < ui_.SelectionList->count(); ++n)
                 {
                     if ((ui_.SelectionList->item(n)->checkState() == Qt::Checked) && (ui_.SelectionList->item(n) != item))
                     {
@@ -138,7 +138,7 @@ void ConfigurationRefListKeywordWidget::updateKeywordData()
 {
     // Loop over items in the QListWidget, adding the associated Configurations for any that are checked
     RefList<Configuration> newSelection;
-    for (int n = 0; n < ui_.SelectionList->count(); ++n)
+    for (auto n = 0; n < ui_.SelectionList->count(); ++n)
     {
         QListWidgetItem *item = ui_.SelectionList->item(n);
         if (item->checkState() == Qt::Checked)

--- a/src/gui/keywordwidgets/configurationreflist_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationreflist_funcs.cpp
@@ -68,7 +68,7 @@ void ConfigurationRefListKeywordWidget::itemChanged(QListWidgetItem *item)
     for (auto n = 0; n < ui_.SelectionList->count(); ++n)
         if (ui_.SelectionList->item(n)->checkState() == Qt::Checked)
             ++nChecked;
-    switch (keyword_->maxListSize())
+    switch (keyword_->maxListSize().value_or(Module::OneOrMoreTargets))
     {
         case (Module::ZeroTargets):
             if (nChecked != 0)

--- a/src/gui/keywordwidgets/fileandformat_funcs.cpp
+++ b/src/gui/keywordwidgets/fileandformat_funcs.cpp
@@ -31,7 +31,7 @@ FileAndFormatKeywordWidget::FileAndFormatKeywordWidget(QWidget *parent, KeywordB
 
     // Populate combo with the file formats available
     ui_.FormatCombo->clear();
-    for (int n = 0; n < keyword_->data().nFormats(); ++n)
+    for (auto n = 0; n < keyword_->data().nFormats(); ++n)
         ui_.FormatCombo->addItem(QString::fromStdString(std::string(keyword_->data().formatKeyword(n))));
 
     // If the FileAndFormat has keyword options, enable the options button.

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -337,7 +337,7 @@ void IsotopologueSetKeywordWidget::updateWidgetValues(const CoreData &coreData)
     isotopologuesItemManager_.update(ui_.IsotopologueTree, keyword_->data().isotopologues(),
                                      &IsotopologueSetKeywordWidget::updateIsotopologueTreeRootItem);
 
-    for (int n = 0; n < 3; ++n)
+    for (auto n = 0; n < 3; ++n)
         ui_.IsotopologueTree->resizeColumnToContents(n);
     ui_.IsotopologueTree->expandAll();
 

--- a/src/gui/keywordwidgets/modulereflist_funcs.cpp
+++ b/src/gui/keywordwidgets/modulereflist_funcs.cpp
@@ -96,7 +96,7 @@ void ModuleRefListKeywordWidget::updateKeywordData()
 {
     // Loop over items in the QListWidget, adding the associated Modules for any that are checked
     RefList<Module> newSelection;
-    for (int n = 0; n < ui_.SelectionList->count(); ++n)
+    for (auto n = 0; n < ui_.SelectionList->count(); ++n)
     {
         QListWidgetItem *item = ui_.SelectionList->item(n);
         if (item->checkState() == Qt::Checked)

--- a/src/gui/keywordwidgets/speciesreflist_funcs.cpp
+++ b/src/gui/keywordwidgets/speciesreflist_funcs.cpp
@@ -92,7 +92,7 @@ void SpeciesRefListKeywordWidget::updateKeywordData()
 {
     // Loop over items in the QListWidget, adding the associated Speciess for any that are checked
     RefList<Species> newSelection;
-    for (int n = 0; n < ui_.SelectionList->count(); ++n)
+    for (auto n = 0; n < ui_.SelectionList->count(); ++n)
     {
         QListWidgetItem *item = ui_.SelectionList->item(n);
         if (item->checkState() == Qt::Checked)

--- a/src/gui/keywordwidgets/windowfunction_funcs.cpp
+++ b/src/gui/keywordwidgets/windowfunction_funcs.cpp
@@ -14,7 +14,7 @@ WindowFunctionKeywordWidget::WindowFunctionKeywordWidget(QWidget *parent, Keywor
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(4);
     functionCombo_ = new QComboBox;
-    for (int n = 0; n < WindowFunction::nFunctionTypes; ++n)
+    for (auto n = 0; n < WindowFunction::nFunctionTypes; ++n)
         functionCombo_->addItem(
             QString::fromStdString(std::string(WindowFunction::functionType((WindowFunction::FunctionType)n))));
     layout->addWidget(functionCombo_);

--- a/src/gui/modulelisteditor_funcs.cpp
+++ b/src/gui/modulelisteditor_funcs.cpp
@@ -124,7 +124,7 @@ void ModuleListEditor::disableSensitiveControls()
 {
     ui_.AvailableModulesTree->setEnabled(false);
     chartWidget_->disableSensitiveControls();
-    for (int n = 0; n < ui_.ModuleControlsStack->count(); ++n)
+    for (auto n = 0; n < ui_.ModuleControlsStack->count(); ++n)
     {
         ModuleControlWidget *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->widget(n));
         if (mcw)
@@ -137,7 +137,7 @@ void ModuleListEditor::enableSensitiveControls()
 {
     ui_.AvailableModulesTree->setEnabled(true);
     chartWidget_->enableSensitiveControls();
-    for (int n = 0; n < ui_.ModuleControlsStack->count(); ++n)
+    for (auto n = 0; n < ui_.ModuleControlsStack->count(); ++n)
     {
         ModuleControlWidget *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->widget(n));
         if (mcw)
@@ -155,7 +155,7 @@ void ModuleListEditor::setModulePaletteVisible(bool visible) { ui_.ModulePalette
 // Find the ModuleControlWidget for this Module in the stack, if it exists
 ModuleControlWidget *ModuleListEditor::controlWidgetForModule(Module *module) const
 {
-    for (int n = 0; n < ui_.ModuleControlsStack->count(); ++n)
+    for (auto n = 0; n < ui_.ModuleControlsStack->count(); ++n)
     {
         ModuleControlWidget *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->widget(n));
         if (mcw && (mcw->module() == module))
@@ -168,7 +168,7 @@ ModuleControlWidget *ModuleListEditor::controlWidgetForModule(Module *module) co
 // Return the index of the ModuleControlWidget for this Module in the stack, if it exists
 int ModuleListEditor::widgetIndexForModule(Module *module) const
 {
-    for (int n = 0; n < ui_.ModuleControlsStack->count(); ++n)
+    for (auto n = 0; n < ui_.ModuleControlsStack->count(); ++n)
     {
         ModuleControlWidget *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->widget(n));
         if (mcw && (mcw->module() == module))

--- a/src/gui/render/axes.cpp
+++ b/src/gui/render/axes.cpp
@@ -75,7 +75,7 @@ Axes::Axes(View &parent, FontInstance &fontInstance) : parentView_(parent), font
     autoPositionTitles_ = true;
 
     // GL
-    for (int n = 0; n < 3; ++n)
+    for (auto n = 0; n < 3; ++n)
     {
         axisPrimitives_[n].initialise(GL_LINES, false);
         axisPrimitives_[n].setNoInstances();
@@ -117,7 +117,7 @@ EnumOptions<Axes::AutoScaleMethod> &Axes::autoScaleMethods()
 void Axes::updateCoordinates()
 {
     // Loop over axes
-    for (int axis = 0; axis < 3; ++axis)
+    for (auto axis = 0; axis < 3; ++axis)
     {
         // Determine central coordinate component
         if (logarithmic_[axis])
@@ -127,7 +127,7 @@ void Axes::updateCoordinates()
             coordCentre_[axis] = (max_[axis] + min_[axis]) * 0.5 * stretch_[axis];
 
         // Set axis position along other directions
-        for (int n = 0; n < 3; ++n)
+        for (auto n = 0; n < 3; ++n)
         {
             // Get axis position
             double position = (positionIsFractional_[axis] ? positionFractional_[axis][n] * (max_[n] - min_[n]) + min_[n]
@@ -167,7 +167,7 @@ void Axes::clamp(int axis)
     }
 
     // 	// Clamp axis position point values if necessary
-    // 	for (int axis=0; axis < 3; ++axis)
+    // 	for (auto axis=0; axis < 3; ++axis)
     // 	{
     // 		if (positionReal_[axis][(axis+1)%3] < limitMin_[(axis+1)%3])
     // 		{
@@ -322,7 +322,7 @@ double Axes::limitMax(int axis) const { return limitMax_.get(axis); }
 // Set all axis limits at once
 void Axes::expandLimits(bool noShrink)
 {
-    for (int axis = 0; axis < 3; ++axis)
+    for (auto axis = 0; axis < 3; ++axis)
     {
         if ((min_[axis] > limitMin_[axis]) || (!noShrink))
             setToLimit(axis, true);
@@ -475,13 +475,13 @@ double Axes::transformX(double x) const
 void Axes::transformX(Array<double> &xArray) const
 {
     if (inverted_.x && logarithmic_.x)
-        for (int n = 0; n < xArray.nItems(); ++n)
+        for (auto n = 0; n < xArray.nItems(); ++n)
             xArray[n] = log10(max_.x / xArray[n]) * stretch_.x;
     else if (inverted_.x)
-        for (int n = 0; n < xArray.nItems(); ++n)
+        for (auto n = 0; n < xArray.nItems(); ++n)
             xArray[n] = ((max_.x - xArray[n]) + min_.x) * stretch_.x;
     else if (logarithmic_.x)
-        for (int n = 0; n < xArray.nItems(); ++n)
+        for (auto n = 0; n < xArray.nItems(); ++n)
             xArray[n] = log10(xArray[n]) * stretch_.x;
     else
         xArray *= stretch_.x;
@@ -504,17 +504,17 @@ double Axes::transformY(double y) const
 void Axes::transformY(Array<double> &yArray) const
 {
     if (inverted_.y && logarithmic_.y)
-        for (int n = 0; n < yArray.nItems(); ++n)
+        for (auto n = 0; n < yArray.nItems(); ++n)
         {
             // 		if (max_.y / yArray[n] <= 0.0) typeArray[n] = DisplayDataSet::NoPoint;
             // 		else
             yArray[n] = log10(max_.y / yArray[n]) * stretch_.y;
         }
     else if (inverted_.y)
-        for (int n = 0; n < yArray.nItems(); ++n)
+        for (auto n = 0; n < yArray.nItems(); ++n)
             yArray[n] = ((max_.y - yArray[n]) + min_.y) * stretch_.y;
     else if (logarithmic_.y)
-        for (int n = 0; n < yArray.nItems(); ++n)
+        for (auto n = 0; n < yArray.nItems(); ++n)
         {
             // 		if (yArray[n] <= 0.0) typeArray[n] = DisplayDataSet::NoPoint;
             // 		else
@@ -541,17 +541,17 @@ double Axes::transformZ(double z) const
 void Axes::transformZ(Array<double> &zArray) const
 {
     if (inverted_.z && logarithmic_.z)
-        for (int n = 0; n < zArray.nItems(); ++n)
+        for (auto n = 0; n < zArray.nItems(); ++n)
         {
             // 		if (max_.z / zArray[n] <= 0.0) typeArray[n] = DisplayDataSet::NoPoint;
             // 		else
             zArray[n] = log10(max_.z / zArray[n]) * stretch_.z;
         }
     else if (inverted_.z)
-        for (int n = 0; n < zArray.nItems(); ++n)
+        for (auto n = 0; n < zArray.nItems(); ++n)
             zArray[n] = ((max_.z - zArray[n]) + min_.z) * stretch_.z;
     else if (logarithmic_.z)
-        for (int n = 0; n < zArray.nItems(); ++n)
+        for (auto n = 0; n < zArray.nItems(); ++n)
         {
             // 		if (zArray[n] <= 0.0) typeArray[n] = DisplayDataSet::NoPoint;
             // 		else
@@ -773,7 +773,7 @@ void Axes::determineLabelFormat(int axis)
             QString tickLabel, oldLabel;
             auto nTicks = (max_[axis] - min_[axis]) / tickDelta_[axis];
             double axisValue = tickFirst_[axis];
-            for (int n = 0; n < nTicks; ++n)
+            for (auto n = 0; n < nTicks; ++n)
             {
                 // Print the current label value
                 tickLabel = numberFormat_[axis].format(axisValue);
@@ -1071,7 +1071,7 @@ void Axes::updateAxisPrimitives()
         inPlaneAxis = 0;
 
     // Set clip coordinates
-    for (int axis = 0; axis < 3; ++axis)
+    for (auto axis = 0; axis < 3; ++axis)
     {
         if (logarithmic_[axis])
         {
@@ -1087,7 +1087,7 @@ void Axes::updateAxisPrimitives()
     }
 
     // Construct axes
-    for (int axis = 0; axis < 3; ++axis)
+    for (auto axis = 0; axis < 3; ++axis)
     {
         // Clear old axis primitives
         axisPrimitives_[axis].forgetAll();
@@ -1301,7 +1301,7 @@ void Axes::updateAxisPrimitives()
     gridLineMajorPrimitives_[2].initialise(GL_LINES, false);
 
     // The 'axis' variable indicates the vector we are drawing lines along, and the relevant primitive store them in
-    for (int axis = 0; axis < 3; ++axis)
+    for (auto axis = 0; axis < 3; ++axis)
     {
         // Check to see if there is anything to draw for this direction
         if ((!gridLinesMajor_[axis]) && (!gridLinesMinor_[axis]))
@@ -1312,9 +1312,9 @@ void Axes::updateAxisPrimitives()
         int ortho2 = (axis + 2) % 3;
 
         // Double loop now, over the two sets of tickmarks that are orthogonal to 'axis'
-        for (int i1 = 0; i1 < tickPositions[ortho1].nItems(); ++i1)
+        for (auto i1 = 0; i1 < tickPositions[ortho1].nItems(); ++i1)
         {
-            for (int i2 = 0; i2 < tickPositions[ortho2].nItems(); ++i2)
+            for (auto i2 = 0; i2 < tickPositions[ortho2].nItems(); ++i2)
             {
                 // Set basic vector info
                 // The 'axis' will define its own component, with the other two coming from the tickmark

--- a/src/gui/render/colourscale.cpp
+++ b/src/gui/render/colourscale.cpp
@@ -238,7 +238,6 @@ void ColourScale::setAllAlpha(double alpha)
 // Recalculate colour deltas between points
 void ColourScale::calculateDeltas()
 {
-    // Reinitialise deltas array
     deltas_.clear();
     for (auto n = 0; n < points_.nItems() - 1; ++n)
         deltas_.add(ColourScaleDelta(points_[n], points_[n + 1], useHSV_));

--- a/src/gui/render/colourscale.cpp
+++ b/src/gui/render/colourscale.cpp
@@ -47,7 +47,7 @@ void ColourScale::addPoint(double value, QColor colour)
     else
     {
         // Find a suitable insertion point now, so we don't have to reorder
-        for (int n = 0; n < points_.nItems(); ++n)
+        for (auto n = 0; n < points_.nItems(); ++n)
         {
             if (points_[n].value() > value)
             {
@@ -156,7 +156,7 @@ QColor ColourScale::colour(double value) const
         return points_.constAt(nPoints() - 1).colour();
 
     // Find the correct delta to use
-    for (int n = 0; n < deltas_.nItems(); ++n)
+    for (auto n = 0; n < deltas_.nItems(); ++n)
     {
         if (deltas_.constAt(n).containsValue(value))
         {
@@ -197,7 +197,7 @@ void ColourScale::colour(double value, GLfloat *rgba) const
     }
 
     // Find the correct delta to use
-    for (int n = 0; n < deltas_.nItems(); ++n)
+    for (auto n = 0; n < deltas_.nItems(); ++n)
     {
         if (deltas_.constAt(n).containsValue(value))
         {
@@ -225,7 +225,7 @@ void ColourScale::setAllAlpha(double alpha)
     else if (alphai > 255)
         alphai = 255;
 
-    for (int n = 0; n < points_.nItems(); ++n)
+    for (auto n = 0; n < points_.nItems(); ++n)
         points_[n].setAlpha(alphai);
 
     calculateDeltas();
@@ -240,7 +240,7 @@ void ColourScale::calculateDeltas()
 {
     // Reinitialise deltas array
     deltas_.clear();
-    for (int n = 0; n < points_.nItems() - 1; ++n)
+    for (auto n = 0; n < points_.nItems() - 1; ++n)
         deltas_.add(ColourScaleDelta(points_[n], points_[n + 1], useHSV_));
 }
 

--- a/src/gui/render/linestipple.cpp
+++ b/src/gui/render/linestipple.cpp
@@ -17,7 +17,7 @@ LineStipple LineStipple::stipple[] = {{1, 0xffff, "Solid"},       {1, 0xaaaa, "D
 // Convert text string to StippleType
 LineStipple::StippleType LineStipple::stippleType(std::string_view s)
 {
-    for (int n = 0; n < LineStipple::nStippleTypes; ++n)
+    for (auto n = 0; n < LineStipple::nStippleTypes; ++n)
         if (DissolveSys::sameString(s, LineStipple::stipple[n].name))
             return (LineStipple::StippleType)n;
     return LineStipple::nStippleTypes;
@@ -66,7 +66,7 @@ QVector<qreal> &LineStipple::dashPattern()
     // 	test[16] = '\0';
     auto consecutive = 0, last = -1, nEntries = 0;
     int bit;
-    for (int n = 15; n >= 0; --n)
+    for (auto n = 15; n >= 0; --n)
     {
         bit = (stipplePattern & (1 << n) ? 1 : 0);
         // 		test[15-n] = (bit ? '1' : '0');

--- a/src/gui/render/primitive.cpp
+++ b/src/gui/render/primitive.cpp
@@ -588,7 +588,7 @@ void Primitive::cross(double width)
 {
     Vec3<double> v;
     const auto halfWidth = 0.5 * width;
-    for (int i = 0; i < 3; ++i)
+    for (auto i = 0; i < 3; ++i)
     {
         v.zero();
         v.set(i, halfWidth);

--- a/src/gui/render/primitiveassembly.cpp
+++ b/src/gui/render/primitiveassembly.cpp
@@ -61,6 +61,6 @@ void PrimitiveAssembly::add(LineStyle lineStyle)
 // Send to OpenGL (i.e. render)
 void PrimitiveAssembly::sendToGL(double pixelScaling)
 {
-    for (int n = 0; n < assembly_.nItems(); ++n)
+    for (auto n = 0; n < assembly_.nItems(); ++n)
         assembly_[n]->sendToGL(pixelScaling);
 }

--- a/src/gui/render/renderableconfiguration.cpp
+++ b/src/gui/render/renderableconfiguration.cpp
@@ -164,7 +164,7 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
 
         // Draw Atoms
         const DynamicArray<Atom> &atoms = source_->constAtoms();
-        for (int n = 0; n < atoms.nItems(); ++n)
+        for (auto n = 0; n < atoms.nItems(); ++n)
         {
             // Get the Atom pointer
             i = atoms.constValue(n);
@@ -212,7 +212,7 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
 
         // Draw Atoms
         const DynamicArray<Atom> &atoms = source_->constAtoms();
-        for (int n = 0; n < atoms.nItems(); ++n)
+        for (auto n = 0; n < atoms.nItems(); ++n)
         {
             const Atom *i = atoms.constValue(n);
 
@@ -313,7 +313,7 @@ bool RenderableConfiguration::writeStyleBlock(LineParser &parser, int indentLeve
 {
     // Construct indent string
     char *indent = new char[indentLevel * 2 + 1];
-    for (int n = 0; n < indentLevel * 2; ++n)
+    for (auto n = 0; n < indentLevel * 2; ++n)
         indent[n] = ' ';
     indent[indentLevel * 2] = '\0';
 

--- a/src/gui/render/renderableconfiguration.cpp
+++ b/src/gui/render/renderableconfiguration.cpp
@@ -154,7 +154,6 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
 
     // Grab the Configuration's Box and CellArray
     const Box *box = source_->box();
-    const CellArray &cellArray = source_->constCells();
 
     // Render according to the current displayStyle
     if (displayStyle_ == LinesStyle)

--- a/src/gui/render/renderabledata1d.cpp
+++ b/src/gui/render/renderabledata1d.cpp
@@ -80,7 +80,7 @@ void RenderableData1D::transformValues()
     }
 
     // Now determine minimum positive limits - loop over points in data, searching for first positive, non-zero value
-    for (int n = 0; n < transformedData_.nValues(); ++n)
+    for (auto n = 0; n < transformedData_.nValues(); ++n)
     {
         // X
         if (transformedData_.constXAxis(n) > 0.0)
@@ -151,7 +151,7 @@ bool RenderableData1D::yRangeOverX(double xMin, double xMax, double &yMin, doubl
     const auto &data = transformedData();
 
     auto first = true;
-    for (int n = 0; n < data.nValues(); ++n)
+    for (auto n = 0; n < data.nValues(); ++n)
     {
         if (data.constXAxis(n) < xMin)
             continue;
@@ -241,7 +241,7 @@ void RenderableData1D::constructLineXY(const Array<double> &displayAbscissa, con
         colourDefinition.colour(0.0, colour);
 
         // Loop over x values
-        for (int n = 0; n < nX; ++n)
+        for (auto n = 0; n < nX; ++n)
         {
             vertexB = primitive->defineVertex(x.constAt(n), y.constAt(n), z, nrm, colour);
 
@@ -255,7 +255,7 @@ void RenderableData1D::constructLineXY(const Array<double> &displayAbscissa, con
     else
     {
         // Loop over x values
-        for (int n = 0; n < nX; ++n)
+        for (auto n = 0; n < nX; ++n)
         {
             colourDefinition.colour(yLogarithmic ? pow(10.0, y.constAt(n) / yStretch) : y.constAt(n) / yStretch, colour);
             vertexB = primitive->defineVertex(x.constAt(n), y.constAt(n), z, nrm, colour);
@@ -314,7 +314,7 @@ bool RenderableData1D::writeStyleBlock(LineParser &parser, int indentLevel) cons
 {
     // Construct indent string
     char *indent = new char[indentLevel * 2 + 1];
-    for (int n = 0; n < indentLevel * 2; ++n)
+    for (auto n = 0; n < indentLevel * 2; ++n)
         indent[n] = ' ';
     indent[indentLevel * 2] = '\0';
 

--- a/src/gui/render/renderabledata2d.cpp
+++ b/src/gui/render/renderabledata2d.cpp
@@ -82,7 +82,7 @@ void RenderableData2D::transformValues()
 
     // Now determine minimum positive limits - loop over points in data, searching for first positive, non-zero value
     // X
-    for (int n = 0; n < transformedData_.constXAxis().nItems(); ++n)
+    for (auto n = 0; n < transformedData_.constXAxis().nItems(); ++n)
     {
         if (transformedData_.constXAxis(n) > 0.0)
         {
@@ -97,7 +97,7 @@ void RenderableData2D::transformValues()
     }
 
     // Y
-    for (int n = 0; n < transformedData_.constYAxis().nItems(); ++n)
+    for (auto n = 0; n < transformedData_.constYAxis().nItems(); ++n)
     {
         if (transformedData_.constYAxis(n) > 0.0)
         {
@@ -112,7 +112,7 @@ void RenderableData2D::transformValues()
     }
 
     // Values
-    for (int n = 0; n < transformedData_.nValues(); ++n)
+    for (auto n = 0; n < transformedData_.nValues(); ++n)
     {
         if (transformedData_.value(n) > 0.0)
         {
@@ -179,7 +179,7 @@ const void RenderableData2D::sendToGL(const double pixelScaling)
     // Disable lighting
     glDisable(GL_LIGHTING);
 
-    for (int n = 0; n < nPrimitives(); ++n)
+    for (auto n = 0; n < nPrimitives(); ++n)
         primitive(n)->sendToGL();
 
     // Reset LineStyle back to defaults
@@ -227,13 +227,13 @@ void RenderableData2D::constructLine(const Array<double> &displayXAbscissa, cons
         colourDefinition.colour(0.0, colour);
 
         // Loop over y
-        for (int n = 0; n < nY; ++n)
+        for (auto n = 0; n < nY; ++n)
         {
             // Set vertexA to -1 so we don't draw a line at n=0
             vertexA = -1;
             p = primitive(n);
             // Loop over x
-            for (int m = 0; m < nX; ++m)
+            for (auto m = 0; m < nX; ++m)
             {
                 vertexB = p->defineVertex(x.constAt(m), y.constAt(n), v.constAt(m, n), nrm, colour);
 
@@ -252,14 +252,14 @@ void RenderableData2D::constructLine(const Array<double> &displayXAbscissa, cons
         colourDef.setHSVGradientEndValue(positiveValuesMax_);
 
         // Loop over y
-        for (int n = 0; n < nY; ++n)
+        for (auto n = 0; n < nY; ++n)
         {
             // Set vertexA to -1 so we don't draw a line at n=0
             vertexA = -1;
             p = primitive(n);
 
             // Loop over x
-            for (int m = 0; m < nX; ++m)
+            for (auto m = 0; m < nX; ++m)
             {
                 // Assigning colour based on value
                 double c = (vLogarithmic ? pow(displayValues.constAt(m, n), 10.0) : displayValues.constAt(m, n));
@@ -320,7 +320,7 @@ bool RenderableData2D::writeStyleBlock(LineParser &parser, int indentLevel) cons
 {
     // Construct indent string
     char *indent = new char[indentLevel * 2 + 1];
-    for (int n = 0; n < indentLevel * 2; ++n)
+    for (auto n = 0; n < indentLevel * 2; ++n)
         indent[n] = ' ';
     indent[indentLevel * 2] = '\0';
 

--- a/src/gui/render/renderabledata3d.cpp
+++ b/src/gui/render/renderabledata3d.cpp
@@ -90,7 +90,7 @@ void RenderableData3D::transformValues()
 
     // Now determine minimum positive limits - loop over points in data, searching for first positive, non-zero value
     // X
-    for (int n = 0; n < transformedData_.constXAxis().nItems(); ++n)
+    for (auto n = 0; n < transformedData_.constXAxis().nItems(); ++n)
     {
         if (transformedData_.constXAxis(n) > 0.0)
         {
@@ -105,7 +105,7 @@ void RenderableData3D::transformValues()
     }
 
     // Y
-    for (int n = 0; n < transformedData_.constYAxis().nItems(); ++n)
+    for (auto n = 0; n < transformedData_.constYAxis().nItems(); ++n)
     {
         if (transformedData_.constYAxis(n) > 0.0)
         {
@@ -120,7 +120,7 @@ void RenderableData3D::transformValues()
     }
 
     // Z
-    for (int n = 0; n < transformedData_.constZAxis().nItems(); ++n)
+    for (auto n = 0; n < transformedData_.constZAxis().nItems(); ++n)
     {
         if (transformedData_.constZAxis(n) > 0.0)
         {
@@ -135,7 +135,7 @@ void RenderableData3D::transformValues()
     }
 
     // Values
-    for (int n = 0; n < transformedData_.nValues(); ++n)
+    for (auto n = 0; n < transformedData_.nValues(); ++n)
     {
         double val = transformedData_.values().linearValue(n);
         if (val > 0.0)
@@ -695,7 +695,7 @@ bool RenderableData3D::writeStyleBlock(LineParser &parser, int indentLevel) cons
 {
     // Construct indent string
     char *indent = new char[indentLevel * 2 + 1];
-    for (int n = 0; n < indentLevel * 2; ++n)
+    for (auto n = 0; n < indentLevel * 2; ++n)
         indent[n] = ' ';
     indent[indentLevel * 2] = '\0';
 

--- a/src/gui/render/renderablegroup.cpp
+++ b/src/gui/render/renderablegroup.cpp
@@ -128,7 +128,7 @@ void RenderableGroup::setRenderableColour(Renderable *rend)
     {
         // Find the StockColour with the lowest usage count
         auto lowestId = 0;
-        for (int colourId = 0; colourId < StockColours::nStockColours; ++colourId)
+        for (auto colourId = 0; colourId < StockColours::nStockColours; ++colourId)
         {
             if (automaticStockColourUsageCount_[colourId] < automaticStockColourUsageCount_[lowestId])
                 lowestId = colourId;

--- a/src/gui/render/renderablegroupmanager.cpp
+++ b/src/gui/render/renderablegroupmanager.cpp
@@ -37,7 +37,7 @@ RenderableGroup *RenderableGroupManager::createGroup(std::string_view name)
         // No existing group, so must add a new one
         // First, find the StockColour with the lowest usage count
         auto lowestId = 0;
-        for (int colourId = 0; colourId < StockColours::nStockColours; ++colourId)
+        for (auto colourId = 0; colourId < StockColours::nStockColours; ++colourId)
         {
             if (stockColourUsageCount_[colourId] < stockColourUsageCount_[lowestId])
                 lowestId = colourId;

--- a/src/gui/render/renderablespecies.cpp
+++ b/src/gui/render/renderablespecies.cpp
@@ -520,7 +520,7 @@ bool RenderableSpecies::writeStyleBlock(LineParser &parser, int indentLevel) con
 {
     // Construct indent string
     char *indent = new char[indentLevel * 2 + 1];
-    for (int n = 0; n < indentLevel * 2; ++n)
+    for (auto n = 0; n < indentLevel * 2; ++n)
         indent[n] = ' ';
     indent[indentLevel * 2] = '\0';
 

--- a/src/gui/render/renderablespecies.cpp
+++ b/src/gui/render/renderablespecies.cpp
@@ -264,8 +264,6 @@ void RenderableSpecies::recreateSelectionPrimitive()
 
     const GLfloat *colour;
     Matrix4 A;
-    const Atom *i;
-    const SpeciesBond *b;
 
     if (displayStyle_ == LinesStyle)
     {

--- a/src/gui/render/renderablespeciessite.cpp
+++ b/src/gui/render/renderablespeciessite.cpp
@@ -166,7 +166,7 @@ bool RenderableSpeciesSite::writeStyleBlock(LineParser &parser, int indentLevel)
 {
     // Construct indent string
     char *indent = new char[indentLevel * 2 + 1];
-    for (int n = 0; n < indentLevel * 2; ++n)
+    for (auto n = 0; n < indentLevel * 2; ++n)
         indent[n] = ' ';
     indent[indentLevel * 2] = '\0';
 

--- a/src/gui/render/renderablespeciessite.cpp
+++ b/src/gui/render/renderablespeciessite.cpp
@@ -70,8 +70,6 @@ void RenderableSpeciesSite::transformValues() { return; }
 void RenderableSpeciesSite::recreatePrimitives(const View &view, const ColourDefinition &colourDefinition)
 {
     Matrix4 A;
-    const GLfloat *colour;
-    const GLfloat colourBlack[4] = {0.0, 0.0, 0.0, 1.0};
 
     // Clear existing data
     siteAssembly_.clear();

--- a/src/gui/render/symbol.cpp
+++ b/src/gui/render/symbol.cpp
@@ -60,7 +60,7 @@ SymbolData SymbolData::symbols[] = {{0x00D7, "mult", "Multiplication Sign"},
 // Return named symbol
 SymbolData *SymbolData::symbol(QString name)
 {
-    for (int n = 0; n < nSymbols; ++n)
+    for (auto n = 0; n < nSymbols; ++n)
         if (name == symbols[n].name)
             return &symbols[n];
 

--- a/src/gui/render/textprimitivelist.cpp
+++ b/src/gui/render/textprimitivelist.cpp
@@ -36,7 +36,7 @@ Cuboid TextPrimitiveList::boundingCuboid(FontInstance &fontInstance, const Matri
 
         // Transform the four corners of the bounding box with the text primitive's transformation matrix
         // and determine the extreme x, y, and z coordinates of the primitives in the local frame
-        for (int m = 0; m < 4; ++m)
+        for (auto m = 0; m < 4; ++m)
         {
             local = textMatrix * corners[m];
             result.updateExtremes(local);

--- a/src/gui/render/vertexchunk.cpp
+++ b/src/gui/render/vertexchunk.cpp
@@ -66,7 +66,7 @@ void VertexChunk::initialise(GLenum type, bool colourData)
     nDefinedTypes_ = 0;
     vertexData_ = new GLfloat[maxVertices_ * dataPerVertex_];
     centroids_ = new GLfloat[VERTEXCHUNKSIZE * 3];
-    for (int n = 0; n < VERTEXCHUNKSIZE * 3; ++n)
+    for (auto n = 0; n < VERTEXCHUNKSIZE * 3; ++n)
         centroids_[n] = 0.0f;
 }
 
@@ -177,7 +177,7 @@ void VertexChunk::forgetAll()
 {
     nDefinedTypes_ = 0;
     nDefinedVertices_ = 0;
-    for (int n = 0; n < VERTEXCHUNKSIZE * 3; ++n)
+    for (auto n = 0; n < VERTEXCHUNKSIZE * 3; ++n)
         centroids_[n] = 0.0f;
 }
 

--- a/src/gui/render/view.cpp
+++ b/src/gui/render/view.cpp
@@ -504,7 +504,7 @@ Vec3<double> View::screenToData(int x, int y, double z) const
     newx = viewportMatrix_[0] + viewportMatrix_[2] * (temp.x / temp.w + 1.0) * 0.5;
     newy = viewportMatrix_[1] + viewportMatrix_[3] * (temp.y / temp.w + 1.0) * 0.5;
 
-    for (int n = 0; n < 10; ++n)
+    for (auto n = 0; n < 10; ++n)
     {
         // Determine new (better) coordinate from a yardstick centred at current world coordinates
         temp = projectionMatrix_ * Vec4<double>(worldr.x + 1.0, worldr.y + 1.0, worldr.z, worldr.w);
@@ -644,7 +644,7 @@ void View::recalculateView(bool force)
     Vec3<double> coordMin[3], coordMax[3], labelMin, labelMax, a, b, globalMin, globalMax;
 
     // Iterate for a few cycles
-    for (int cycle = 0; cycle < 5; ++cycle)
+    for (auto cycle = 0; cycle < 5; ++cycle)
     {
         // We will now calculate more accurate stretch factors to apply to the X and Y axes.
         // Project the axis limits on to the screen using the relevant viewmatrix + coordinate centre translation
@@ -677,7 +677,7 @@ void View::recalculateView(bool force)
             coordMax[axis].set(std::max(a.x, b.x), std::max(a.y, b.y), std::max(a.z, b.z));
 
             // Update global min/max
-            for (int n = 0; n < 3; ++n)
+            for (auto n = 0; n < 3; ++n)
             {
                 if (coordMin[axis][n] < globalMin[n])
                     globalMin[n] = coordMin[axis][n];
@@ -695,7 +695,7 @@ void View::recalculateView(bool force)
             b = dataToScreen(cuboid.maxima(), tempProjection, viewMat);
 
             // Update global and label min/max
-            for (int n = 0; n < 3; ++n)
+            for (auto n = 0; n < 3; ++n)
             {
                 tempMin = std::min(a[n], b[n]);
                 tempMax = std::max(a[n], b[n]);
@@ -802,7 +802,7 @@ void View::showAllData(double xFrac, double yFrac, double zFrac)
     updateAxisLimits(xFrac, yFrac, zFrac);
 
     // Set axes limits to the extreme data values, making sure we have a sensible (i.e. non-zero range)
-    for (int axis = 0; axis < 3; ++axis)
+    for (auto axis = 0; axis < 3; ++axis)
     {
         // Grab axis limits and make sure the limits are sensible, expanding only if the range is zero
         double limitMin = axes_.limitMin(axis);
@@ -836,7 +836,7 @@ void View::zoomTo(Vec3<double> limit1, Vec3<double> limit2)
     else
     {
         // 3D view, so set all three axes
-        for (int axis = 0; axis < 3; ++axis)
+        for (auto axis = 0; axis < 3; ++axis)
         {
             axes_.setMin(axis, newMin.get(axis));
             axes_.setMax(axis, newMax.get(axis));
@@ -857,7 +857,7 @@ void View::scaleRange(double factor)
         skipAxis = 0;
 
     // Loop over axes
-    for (int axis = 0; axis < 3; ++axis)
+    for (auto axis = 0; axis < 3; ++axis)
     {
         if (axis == skipAxis)
             continue;
@@ -1151,7 +1151,7 @@ void View::updateAxisLimits(double xFrac, double yFrac, double zFrac)
     Vec3<double> fractions(xFrac, yFrac, zFrac);
 
     // Loop over axes
-    for (int axis = 0; axis < 3; ++axis)
+    for (auto axis = 0; axis < 3; ++axis)
     {
         // Adjust limits
         if (fractions[axis] > 0.0)
@@ -1204,7 +1204,7 @@ void View::shiftFlatAxisLimits(double deltaH, double deltaV)
     double deltas[2];
     deltas[0] = deltaH;
     deltas[1] = deltaV;
-    for (int n = 0; n < 2; ++n)
+    for (auto n = 0; n < 2; ++n)
     {
         double range = axes_.realRange(axes[n]);
         auto logarithmic = axes_.logarithmic(axes[n]);

--- a/src/gui/selectconfigurationwidget_funcs.cpp
+++ b/src/gui/selectconfigurationwidget_funcs.cpp
@@ -99,7 +99,7 @@ bool SelectConfigurationWidget::isSelectionValid() const
 int SelectConfigurationWidget::nSelected() const
 {
     auto count = 0;
-    for (int n = 0; n < ui_.ConfigurationList->count(); ++n)
+    for (auto n = 0; n < ui_.ConfigurationList->count(); ++n)
     {
         QListWidgetItem *item = ui_.ConfigurationList->item(n);
 
@@ -116,7 +116,7 @@ RefList<Configuration> SelectConfigurationWidget::currentConfiguration() const
     RefList<Configuration> selection;
 
     // Loop over items in the list and construct the selection RefList
-    for (int n = 0; n < ui_.ConfigurationList->count(); ++n)
+    for (auto n = 0; n < ui_.ConfigurationList->count(); ++n)
     {
         QListWidgetItem *item = ui_.ConfigurationList->item(n);
 

--- a/src/gui/selectforcefieldwidget_funcs.cpp
+++ b/src/gui/selectforcefieldwidget_funcs.cpp
@@ -29,7 +29,7 @@ SelectForcefieldWidget::~SelectForcefieldWidget() {}
 void SelectForcefieldWidget::updateForcefieldsList(std::shared_ptr<Forcefield> current, QString filter)
 {
     // Loop over items in the list
-    for (int n = 0; n < ui_.ForcefieldsList->count(); ++n)
+    for (auto n = 0; n < ui_.ForcefieldsList->count(); ++n)
     {
         QListWidgetItem *item = ui_.ForcefieldsList->item(n);
         if (!item)

--- a/src/gui/selectgenericitemdialog_funcs.cpp
+++ b/src/gui/selectgenericitemdialog_funcs.cpp
@@ -18,7 +18,7 @@ SelectGenericItemDialog::~SelectGenericItemDialog() {}
 void SelectGenericItemDialog::updateGenericItemTable(GenericItem *current, QString filter)
 {
     // Loop over rows in the table
-    for (int n = 0; n < ui_.ItemsTable->rowCount(); ++n)
+    for (auto n = 0; n < ui_.ItemsTable->rowCount(); ++n)
     {
         QTableWidgetItem *item = ui_.ItemsTable->item(n, 0);
         if (!item)

--- a/src/gui/selectspecieswidget_funcs.cpp
+++ b/src/gui/selectspecieswidget_funcs.cpp
@@ -95,7 +95,7 @@ bool SelectSpeciesWidget::isSelectionValid() const
 int SelectSpeciesWidget::nSelected() const
 {
     auto count = 0;
-    for (int n = 0; n < ui_.SpeciesList->count(); ++n)
+    for (auto n = 0; n < ui_.SpeciesList->count(); ++n)
     {
         QListWidgetItem *item = ui_.SpeciesList->item(n);
 
@@ -112,7 +112,7 @@ RefList<Species> SelectSpeciesWidget::currentSpecies() const
     RefList<Species> selection;
 
     // Loop over items in the list and construct the selection RefList
-    for (int n = 0; n < ui_.SpeciesList->count(); ++n)
+    for (auto n = 0; n < ui_.SpeciesList->count(); ++n)
     {
         QListWidgetItem *item = ui_.SpeciesList->item(n);
 

--- a/src/gui/selectsymbol_funcs.cpp
+++ b/src/gui/selectsymbol_funcs.cpp
@@ -126,7 +126,7 @@ void SelectSymbolDialog::updateTable(bool force)
         // Populate the symbols list
         QTableWidgetItem *item;
         QSize itemSize(itemSize_, itemSize_);
-        for (int n = 0; n < SymbolData::nSymbols; ++n)
+        for (auto n = 0; n < SymbolData::nSymbols; ++n)
         {
             item = new QTableWidgetItem();
             item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
@@ -144,7 +144,7 @@ void SelectSymbolDialog::updateTable(bool force)
         header->setStretchLastSection(true);
 
     // Set sizes of all columns except the last
-    for (int n = 0; n < nDisplayColumns; ++n)
+    for (auto n = 0; n < nDisplayColumns; ++n)
         ui.SymbolTable->setColumnWidth(n, itemSize_ + widthRemainder / nDisplayColumns);
 
     oldNColumns = nDisplayColumns;

--- a/src/gui/selectsystemtemplatedialog_funcs.cpp
+++ b/src/gui/selectsystemtemplatedialog_funcs.cpp
@@ -26,7 +26,7 @@ SelectSystemTemplateDialog::~SelectSystemTemplateDialog() {}
 void SelectSystemTemplateDialog::updateTemplatesList(QString filter)
 {
     // Loop over items in the list
-    for (int n = 0; n < ui_.TemplatesList->count(); ++n)
+    for (auto n = 0; n < ui_.TemplatesList->count(); ++n)
     {
         QListWidgetItem *item = ui_.TemplatesList->item(n);
         if (!item)

--- a/src/gui/siteviewer_input.cpp
+++ b/src/gui/siteviewer_input.cpp
@@ -14,7 +14,6 @@ void SiteViewer::mouseMoved(int dx, int dy)
         return;
 
     auto refresh = false;
-    SpeciesAtom *currentAtom = nullptr;
 
     // What we do here depends on the current mode
     switch (interactionMode())

--- a/src/gui/siteviewer_interaction.cpp
+++ b/src/gui/siteviewer_interaction.cpp
@@ -66,8 +66,6 @@ void SiteViewer::startInteraction()
 // End interaction at the specified screen coordinates
 void SiteViewer::endInteraction()
 {
-    SpeciesAtom *i, *j;
-
     // Finalise interaction type
     switch (interactionMode())
     {

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -28,7 +28,7 @@ SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainT
     // Set item delegates
     // -- SpeciesAtomTable
     ui_.AtomTable->setItemDelegateForColumn(1, new CustomComboDelegate<SpeciesTab>(this, &SpeciesTab::validAtomTypeNames));
-    for (int n = 2; n < 6; ++n)
+    for (auto n = 2; n < 6; ++n)
         ui_.AtomTable->setItemDelegateForColumn(n, new ExponentialSpinDelegate(this));
     // -- Geometry tables
     ui_.BondTable->setItemDelegateForColumn(

--- a/src/gui/speciestab_geometry.cpp
+++ b/src/gui/speciestab_geometry.cpp
@@ -322,10 +322,10 @@ void SpeciesTab::updateAtomTableSelection()
         i = VariantPointer<SpeciesAtom>(item->data(Qt::UserRole));
 
         if (i->isSelected())
-            for (int m = 0; m < 6; ++m)
+            for (auto m = 0; m < 6; ++m)
                 ui_.AtomTable->item(n, m)->setSelected(true);
         else
-            for (int m = 0; m < 6; ++m)
+            for (auto m = 0; m < 6; ++m)
                 ui_.AtomTable->item(n, m)->setSelected(false);
     }
 }

--- a/src/gui/speciestab_sites.cpp
+++ b/src/gui/speciestab_sites.cpp
@@ -158,7 +158,7 @@ void SpeciesTab::updateSitesTab()
     // Set origin atom indices
     Array<int> originAtoms = site->originAtomIndices();
     QString originText = originAtoms.nItems() == 0 ? QString() : QString::number(originAtoms.constAt(0) + 1);
-    for (int n = 1; n < originAtoms.nItems(); ++n)
+    for (auto n = 1; n < originAtoms.nItems(); ++n)
         originText += QString(" %1").arg(originAtoms.constAt(n) + 1);
     ui_.SiteOriginAtomsEdit->setText(originText);
     ui_.SiteOriginMassWeightedCheck->setCheckState(site->originMassWeighted() ? Qt::Checked : Qt::Unchecked);
@@ -166,14 +166,14 @@ void SpeciesTab::updateSitesTab()
     // Set x axis atom indices
     Array<int> xAxisAtoms = site->xAxisAtomIndices();
     QString xAxisText = xAxisAtoms.nItems() == 0 ? QString() : QString::number(xAxisAtoms.constAt(0) + 1);
-    for (int n = 1; n < xAxisAtoms.nItems(); ++n)
+    for (auto n = 1; n < xAxisAtoms.nItems(); ++n)
         xAxisText += QString(" %1").arg(xAxisAtoms.constAt(n) + 1);
     ui_.SiteXAxisAtomsEdit->setText(xAxisText);
 
     // Set y axis atom indices
     Array<int> yAxisAtoms = site->yAxisAtomIndices();
     QString yAxisText = yAxisAtoms.nItems() == 0 ? QString() : QString::number(yAxisAtoms.constAt(0) + 1);
-    for (int n = 1; n < yAxisAtoms.nItems(); ++n)
+    for (auto n = 1; n < yAxisAtoms.nItems(); ++n)
         yAxisText += QString(" %1").arg(yAxisAtoms.constAt(n) + 1);
     ui_.SiteYAxisAtomsEdit->setText(yAxisText);
 

--- a/src/gui/viewer_io.cpp
+++ b/src/gui/viewer_io.cpp
@@ -588,7 +588,7 @@ bool BaseViewer::writeRenderableBlock(LineParser &parser, Renderable *renderable
 {
     // Construct indent string
     char *indent = new char[indentLevel * 2 + 1];
-    for (int n = 0; n < indentLevel * 2; ++n)
+    for (auto n = 0; n < indentLevel * 2; ++n)
         indent[n] = ' ';
     indent[indentLevel * 2] = '\0';
 
@@ -644,7 +644,7 @@ bool BaseViewer::writeRenderableBlock(LineParser &parser, Renderable *renderable
         return false;
     // -- Custom Gradient
     const Array<ColourScalePoint> customGradient = colourDef.customGradientPoints();
-    for (int n = 0; n < customGradient.nItems(); ++n)
+    for (auto n = 0; n < customGradient.nItems(); ++n)
     {
         const ColourScalePoint &point = customGradient.constAt(n);
         if (!parser.writeLineF("{}  {}  {} {} {} {} {}\n", indent,
@@ -786,7 +786,7 @@ bool BaseViewer::writeRenderableGroupBlock(LineParser &parser, RenderableGroup *
 {
     // Construct indent string
     char *indent = new char[indentLevel * 2 + 1];
-    for (int n = 0; n < indentLevel * 2; ++n)
+    for (auto n = 0; n < indentLevel * 2; ++n)
         indent[n] = ' ';
     indent[indentLevel * 2] = '\0';
 
@@ -971,7 +971,7 @@ bool BaseViewer::writeViewBlock(LineParser &parser) const
     if (!parser.writeLineF("  {}  {}\n", BaseViewer::viewKeywords().keyword(BaseViewer::AutoPositionTitlesKeyword),
                            DissolveSys::btoa(view_.constAxes().autoPositionTitles())))
         return false;
-    for (int axis = 0; axis < 3; ++axis)
+    for (auto axis = 0; axis < 3; ++axis)
         writeAxisBlock(parser, view_.constAxes(), axis);
     if (!parser.writeLineF("  {}  {}\n", BaseViewer::viewKeywords().keyword(BaseViewer::FlatLabelsKeyword),
                            DissolveSys::btoa(view_.flatLabelsIn3D())))

--- a/src/gui/viewer_query.cpp
+++ b/src/gui/viewer_query.cpp
@@ -89,9 +89,9 @@ void BaseViewer::updateQuery(BaseViewer::ViewerObject objectType, std::string_vi
     // Compare the stored colours in the region with those in the current buffer
     auto index = 0;
     double delta = 0.0;
-    for (int dx = 0; dx < queryRegionWidth_; ++dx)
+    for (auto dx = 0; dx < queryRegionWidth_; ++dx)
     {
-        for (int dy = 0; dy < queryRegionHeight_; ++dy)
+        for (auto dy = 0; dy < queryRegionHeight_; ++dy)
         {
             // Accumulate difference between stored and current colour
             QColor pixelColour = tile.pixelColor(queryRegionLeft_ + dx, queryImageHeight_ - queryRegionBottom_ - dy);

--- a/src/gui/viewer_render.cpp
+++ b/src/gui/viewer_render.cpp
@@ -138,7 +138,7 @@ void BaseViewer::renderGL(int xOffset, int yOffset)
         if (fontInstance_.fontOK())
         {
             fontInstance_.setFaceSize(1);
-            for (int axis = 0; axis < 3; ++axis)
+            for (auto axis = 0; axis < 3; ++axis)
                 if (view_.axes().visible(axis) && (axis != skipAxis))
                 {
                     view_.axes().labelPrimitive(axis).renderAll(fontInstance_, viewMatrix, viewRotationInverse,
@@ -154,14 +154,14 @@ void BaseViewer::renderGL(int xOffset, int yOffset)
         glLoadMatrixd(viewMatrix.matrix());
         glDisable(GL_LIGHTING);
         glEnable(GL_LINE_SMOOTH);
-        for (int axis = 0; axis < 3; ++axis)
+        for (auto axis = 0; axis < 3; ++axis)
             if (view_.axes().visible(axis) && (axis != skipAxis))
             {
                 view_.axes().gridLineMinorStyle(axis).sendToGL(pixelScaling_);
                 view_.axes().gridLineMinorPrimitive(axis).sendToGL();
                 updateQuery(BaseViewer::GridLineMinorObject, fmt::format("{}", axis), fmt::format("{}", char(88 + axis)));
             }
-        for (int axis = 0; axis < 3; ++axis)
+        for (auto axis = 0; axis < 3; ++axis)
             if (view_.axes().visible(axis) && (axis != skipAxis))
             {
                 view_.axes().gridLineMajorStyle(axis).sendToGL(pixelScaling_);
@@ -171,7 +171,7 @@ void BaseViewer::renderGL(int xOffset, int yOffset)
 
         // -- Reset line style, ensure polygons are now filled, and render the axis lines
         LineStyle().sendToGL(pixelScaling_);
-        for (int axis = 0; axis < 3; ++axis)
+        for (auto axis = 0; axis < 3; ++axis)
             if (view_.axes().visible(axis) && (axis != skipAxis))
             {
                 view_.axes().axisPrimitive(axis).sendToGL();
@@ -393,7 +393,7 @@ void BaseViewer::enableClipping()
 
     // Loop over axes
     Vec3<double> translation;
-    for (int axis = 0; axis < 3; ++axis)
+    for (auto axis = 0; axis < 3; ++axis)
     {
         translation.zero();
 
@@ -480,9 +480,9 @@ QPixmap BaseViewer::generateImage(int imageWidth, int imageHeight)
     // Loop over tiles in x and y
     QProgressDialog progress("Generating tiled image", "Cancel", 0, nX * nY);
     progress.setWindowTitle("Dissolve");
-    for (int x = 0; x < nX; ++x)
+    for (auto x = 0; x < nX; ++x)
     {
-        for (int y = 0; y < nY; ++y)
+        for (auto y = 0; y < nY; ++y)
         {
             // Set progress value and check for cancellation
             if (progress.wasCanceled())

--- a/src/gui/widgets/elementselector_funcs.cpp
+++ b/src/gui/widgets/elementselector_funcs.cpp
@@ -23,7 +23,6 @@ ElementSelector::ElementSelector(QWidget *parent) : QWidget(parent)
     // Create periodic table buttons
     QLabel *label;
     int n, m, z;
-    double *colour;
 
     // Create element button array (and buttons)
     QToolButton *button;

--- a/src/gui/widgets/gradientbar_funcs.cpp
+++ b/src/gui/widgets/gradientbar_funcs.cpp
@@ -27,7 +27,7 @@ void GradientBar::setColourScale(const ColourScale &colourScale)
             const auto nPoints = 101;
             double value = colourScale.firstPoint().value();
             double delta = (colourScale.lastPoint().value() - value) / nPoints;
-            for (int n = 0; n < nPoints; ++n)
+            for (auto n = 0; n < nPoints; ++n)
             {
                 colourScale_.addPoint(value, colourScale.colour(value));
                 value += delta;
@@ -56,7 +56,7 @@ void GradientBar::setColourScale(const ColourScale &colourScale)
     {
         double zero = colourScale_.firstPoint().value();
         double span = colourScale_.lastPoint().value() - zero;
-        for (int n = 0; n < colourScale_.nPoints(); ++n)
+        for (auto n = 0; n < colourScale_.nPoints(); ++n)
             gradient_.setColorAt((colourScale_.point(n).value() - zero) / span, colourScale_.point(n).colour());
     }
 

--- a/src/gui/workspacetab_funcs.cpp
+++ b/src/gui/workspacetab_funcs.cpp
@@ -203,7 +203,7 @@ bool WorkspaceTab::readState(LineParser &parser, const CoreData &coreData)
     const auto nGizmos = parser.argi(0);
 
     // Read in widgets
-    for (int n = 0; n < nGizmos; ++n)
+    for (auto n = 0; n < nGizmos; ++n)
     {
         // Read line from the file, which should contain the gizmo type
         if (parser.getArgsDelim() != LineParser::Success)

--- a/src/io/export/coordinates.cpp
+++ b/src/io/export/coordinates.cpp
@@ -67,7 +67,7 @@ bool CoordinateExportFileFormat::exportXYZ(LineParser &parser, Configuration *cf
         return false;
 
     // Export Atoms
-    for (int n = 0; n < cfg->nAtoms(); ++n)
+    for (auto n = 0; n < cfg->nAtoms(); ++n)
     {
         Atom *i = cfg->atom(n);
         if (!parser.writeLineF("{:<3}   {:15.9f}  {:15.9f}  {:15.9f}\n", i->speciesAtom()->element()->symbol(), i->r().x,
@@ -117,7 +117,7 @@ bool CoordinateExportFileFormat::exportDLPOLY(LineParser &parser, Configuration 
     }
 
     // Export Atoms
-    for (int n = 0; n < cfg->nAtoms(); ++n)
+    for (auto n = 0; n < cfg->nAtoms(); ++n)
     {
         Atom *i = cfg->atom(n);
         if (!parser.writeLineF("{:<6}{:10d}{:20.10f}\n{:20.12f}{:20.12f}{:20.12f}\n",

--- a/src/io/export/data1d.cpp
+++ b/src/io/export/data1d.cpp
@@ -56,12 +56,12 @@ bool Data1DExportFileFormat::exportXY(LineParser &parser, const Data1D &data)
     if (data.valuesHaveErrors())
     {
         const auto &errors = data.constErrors();
-        for (int n = 0; n < x.nItems(); ++n)
+        for (auto n = 0; n < x.nItems(); ++n)
             if (!parser.writeLineF("{:16.10e}  {:16.10e}  {:16.10e}\n", x.constAt(n), values.constAt(n), errors.constAt(n)))
                 return false;
     }
     else
-        for (int n = 0; n < x.nItems(); ++n)
+        for (auto n = 0; n < x.nItems(); ++n)
             if (!parser.writeLineF("{:16.10e}  {:16.10e}\n", x.constAt(n), values.constAt(n)))
                 return false;
 

--- a/src/io/export/data2d.cpp
+++ b/src/io/export/data2d.cpp
@@ -58,9 +58,9 @@ bool Data2DExportFileFormat::exportBlock(LineParser &parser, const Data2D &data)
 
     // Export datapoints, separating each block of a specific x value with a single blank line
     const Array2D<double> &values = data.constValues2D();
-    for (int x = 0; x < values.nRows(); ++x)
+    for (auto x = 0; x < values.nRows(); ++x)
     {
-        for (int y = 0; y < values.nColumns(); ++y)
+        for (auto y = 0; y < values.nColumns(); ++y)
             if (!parser.writeLineF("{:15.9f}\n", values.constAt(x, y)))
                 return false;
         if (!parser.writeLineF("\n"))
@@ -77,9 +77,9 @@ bool Data2DExportFileFormat::exportCartesian(LineParser &parser, const Data2D &d
     const Array2D<double> &values = data.constValues2D();
     const auto &xAxis = data.constXAxis();
     const auto &yAxis = data.constYAxis();
-    for (int x = 0; x < values.nRows(); ++x)
+    for (auto x = 0; x < values.nRows(); ++x)
     {
-        for (int y = 0; y < values.nColumns(); ++y)
+        for (auto y = 0; y < values.nColumns(); ++y)
             if (!parser.writeLineF("{:15.9f} {:15.9f} {:15.9f}\n", xAxis.constAt(x), yAxis.constAt(y), values.constAt(x, y)))
                 return false;
         if (!parser.writeLineF("\n"))

--- a/src/io/export/data3d.cpp
+++ b/src/io/export/data3d.cpp
@@ -60,11 +60,11 @@ bool Data3DExportFileFormat::exportBlock(LineParser &parser, const Data3D &data)
 
     // Export datapoints, separating each block of a specific x value with a single blank line
     const Array3D<double> &values = data.constValues3D();
-    for (int x = 0; x < values.nX(); ++x)
+    for (auto x = 0; x < values.nX(); ++x)
     {
-        for (int y = 0; y < values.nY(); ++y)
+        for (auto y = 0; y < values.nY(); ++y)
         {
-            for (int z = 0; z < values.nZ(); ++z)
+            for (auto z = 0; z < values.nZ(); ++z)
             {
                 if (!parser.writeLineF("{:15.9e}\n", values.constAt(x, y, z)))
                     return false;
@@ -85,13 +85,13 @@ bool Data3DExportFileFormat::exportCartesian(LineParser &parser, const Data3D &d
     const auto &xAxis = data.constXAxis();
     const auto &yAxis = data.constYAxis();
     const auto &zAxis = data.constZAxis();
-    for (int x = 0; x < values.nX(); ++x)
+    for (auto x = 0; x < values.nX(); ++x)
     {
         double xVal = xAxis.constAt(x);
-        for (int y = 0; y < values.nY(); ++y)
+        for (auto y = 0; y < values.nY(); ++y)
         {
             double yVal = yAxis.constAt(y);
-            for (int z = 0; z < values.nZ(); ++z)
+            for (auto z = 0; z < values.nZ(); ++z)
             {
                 if (!parser.writeLineF("{:15.9e} {:15.9e} {:15.9e} {:15.9e}\n", xVal, yVal, zAxis.constAt(z),
                                        values.constAt(x, y, z)))
@@ -131,11 +131,11 @@ bool Data3DExportFileFormat::exportPDens(LineParser &parser, const Data3D &data)
         return false;
 
     // Lines 5+ (Data)
-    for (int x = 0; x < values.nX(); ++x)
+    for (auto x = 0; x < values.nX(); ++x)
     {
-        for (int y = 0; y < values.nY(); ++y)
+        for (auto y = 0; y < values.nY(); ++y)
         {
-            for (int z = 0; z < values.nZ(); ++z)
+            for (auto z = 0; z < values.nZ(); ++z)
             {
                 if (!parser.writeLineF("{:15.9e}\n", values.constAt(x, y, z)))
                     return false;

--- a/src/io/export/pairpotential.cpp
+++ b/src/io/export/pairpotential.cpp
@@ -73,7 +73,7 @@ bool PairPotentialExportFileFormat::exportBlock(LineParser &parser, PairPotentia
                            "U(kJ/mol)", "U(kJ/mol)", "U(kJ/mol)", "dU(kJ/mol/Ang)"))
         return false;
 
-    for (int n = 0; n < nPoints; ++n)
+    for (auto n = 0; n < nPoints; ++n)
         if (!parser.writeLineF("{:10.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}\n",
                                uOriginal.constXAxis(n), uFull.constValue(n), dUFull.constValue(n), uOriginal.constValue(n),
                                uAdditional.constValue(n), pp->analyticEnergy(uOriginal.constXAxis(n)),
@@ -104,7 +104,7 @@ bool PairPotentialExportFileFormat::exportDLPOLY(LineParser &parser, PairPotenti
         return false;
 
     // Write energy data
-    for (int n = 0; n < nPoints; ++n)
+    for (auto n = 0; n < nPoints; ++n)
     {
         if (!parser.writeLineF("{:17.12e} ", uFull.constValue(n)))
             return false;
@@ -116,7 +116,7 @@ bool PairPotentialExportFileFormat::exportDLPOLY(LineParser &parser, PairPotenti
     }
 
     // Write force data
-    for (int n = 0; n < nPoints; ++n)
+    for (auto n = 0; n < nPoints; ++n)
     {
         if (!parser.writeLineF("{:17.12e} ", dUFull.constValue(n)))
             return false;

--- a/src/io/export/trajectory.cpp
+++ b/src/io/export/trajectory.cpp
@@ -64,7 +64,7 @@ bool TrajectoryExportFileFormat::exportXYZ(LineParser &parser, Configuration *cf
         return false;
 
     // Write Atoms
-    for (int n = 0; n < cfg->nAtoms(); ++n)
+    for (auto n = 0; n < cfg->nAtoms(); ++n)
     {
         Atom *i = cfg->atom(n);
         if (!parser.writeLineF("{:<3}   {:15.9f}  {:15.9f}  {:15.9f}\n", i->speciesAtom()->element()->symbol(), i->r().x,

--- a/src/io/fileandformat.cpp
+++ b/src/io/fileandformat.cpp
@@ -18,7 +18,7 @@ FileAndFormat::operator std::string_view() const { return filename_; }
 // Convert text string to format index
 int FileAndFormat::format(std::string_view fmtString) const
 {
-    for (int n = 0; n < nFormats(); ++n)
+    for (auto n = 0; n < nFormats(); ++n)
         if (DissolveSys::sameString(fmtString, formatKeyword(n)))
             return n;
 
@@ -52,7 +52,7 @@ std::string_view FileAndFormat::description() const
 // Print available formats
 void FileAndFormat::printAvailableFormats() const
 {
-    for (int n = 0; n < nFormats(); ++n)
+    for (auto n = 0; n < nFormats(); ++n)
         Messenger::print("  {:12}  {}\n", formatKeyword(n), formatDescription(n));
 }
 

--- a/src/io/import/coordinates_epsr.cpp
+++ b/src/io/import/coordinates_epsr.cpp
@@ -55,7 +55,7 @@ bool CoordinateImportFileFormat::importEPSR(LineParser &parser, Array<Vec3<doubl
     auto atomOffset = 0;
     int nAtoms, nRestraints, currentArg;
     Vec3<double> com, delta;
-    for (int m = 0; m < nMols; m++)
+    for (auto m = 0; m < nMols; m++)
     {
         Messenger::printVerbose("Importing molecule {} from EPSR ato file...\n", m + 1);
 
@@ -64,7 +64,7 @@ bool CoordinateImportFileFormat::importEPSR(LineParser &parser, Array<Vec3<doubl
         nAtoms = parser.argi(0);
         com = parser.arg3d(1);
 
-        for (int n = 0; n < nAtoms; n++)
+        for (auto n = 0; n < nAtoms; n++)
         {
             // Atom name
             if (parser.getArgsDelim() != LineParser::Success)

--- a/src/io/import/coordinates_xyz.cpp
+++ b/src/io/import/coordinates_xyz.cpp
@@ -20,7 +20,7 @@ bool CoordinateImportFileFormat::importXYZ(LineParser &parser, Array<Vec3<double
 
     Messenger::print(" --> Expecting coordinates for {} atoms.\n", nAtoms);
     r.clear();
-    for (int n = 0; n < nAtoms; ++n)
+    for (auto n = 0; n < nAtoms; ++n)
     {
         if (parser.getArgsDelim() != LineParser::Success)
             return false;

--- a/src/io/import/forces_dlpoly.cpp
+++ b/src/io/import/forces_dlpoly.cpp
@@ -48,7 +48,7 @@ bool ForceImportFileFormat::importDLPOLY(LineParser &parser, Array<double> &fx, 
         parser.skipLines(3);
 
     // Loop over atoms
-    for (int n = 0; n < nAtoms; ++n)
+    for (auto n = 0; n < nAtoms; ++n)
     {
         // Skip atomname, position and velocity lines
         if (parser.skipLines(3) != LineParser::Success)

--- a/src/keywords/atomtypereflist.cpp
+++ b/src/keywords/atomtypereflist.cpp
@@ -27,7 +27,7 @@ int AtomTypeRefListKeyword::maxArguments() const { return 999; }
 bool AtomTypeRefListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Loop over arguments (which are AtomType names) and add them to our list
-    for (int n = startArg; n < parser.nArgs(); ++n)
+    for (auto n = startArg; n < parser.nArgs(); ++n)
     {
         // Do we recognise the AtomType?
         auto atomType = coreData.findAtomType(parser.argsv(n));

--- a/src/keywords/atomtypeselection.cpp
+++ b/src/keywords/atomtypeselection.cpp
@@ -74,7 +74,7 @@ bool AtomTypeSelectionKeyword::read(LineParser &parser, int startArg, CoreData &
     checkSelection();
 
     // Loop over arguments (which are AtomType names) and add them to our list
-    for (int n = startArg; n < parser.nArgs(); ++n)
+    for (auto n = startArg; n < parser.nArgs(); ++n)
     {
         // Do we recognise the AtomType?
         auto it = std::find_if(coreData.atomTypes().begin(), coreData.atomTypes().end(), [&parser, n](const auto atomType) {

--- a/src/keywords/broadeningfunction.cpp
+++ b/src/keywords/broadeningfunction.cpp
@@ -35,7 +35,7 @@ bool BroadeningFunctionKeyword::read(LineParser &parser, int startArg, CoreData 
 bool BroadeningFunctionKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
 {
     std::string params;
-    for (int n = 0; n < BroadeningFunction::nFunctionParameters(data_.function()); ++n)
+    for (auto n = 0; n < BroadeningFunction::nFunctionParameters(data_.function()); ++n)
         params += fmt::format("  {}", data_.parameter(n));
     return parser.writeLineF("{}{}  '{}'{}\n", prefix, keywordName, BroadeningFunction::functionType(data_.function()), params);
 }

--- a/src/keywords/configurationreflist.cpp
+++ b/src/keywords/configurationreflist.cpp
@@ -6,7 +6,7 @@
 #include "classes/configuration.h"
 #include "classes/coredata.h"
 
-ConfigurationRefListKeyword::ConfigurationRefListKeyword(RefList<Configuration> &references, int maxListSize)
+ConfigurationRefListKeyword::ConfigurationRefListKeyword(RefList<Configuration> &references, std::optional<int> maxListSize)
     : KeywordData<RefList<Configuration> &>(KeywordBase::ConfigurationRefListData, references)
 {
     maxListSize_ = maxListSize;
@@ -23,7 +23,7 @@ ConfigurationRefListKeyword::~ConfigurationRefListKeyword() {}
 bool ConfigurationRefListKeyword::isDataEmpty() const { return data_.nItems() == 0; }
 
 // Return maximum number of Configurations to allow in the list
-int ConfigurationRefListKeyword::maxListSize() const { return maxListSize_; }
+std::optional<int> ConfigurationRefListKeyword::maxListSize() const { return maxListSize_; }
 
 /*
  * Arguments
@@ -47,8 +47,8 @@ bool ConfigurationRefListKeyword::read(LineParser &parser, int startArg, CoreDat
                                     parser.argsv(n));
 
         // Check maximum size of list
-        if ((maxListSize_ != -1) && (data_.nItems() >= maxListSize_))
-            return Messenger::error("Too many configurations given to keyword. Maximum allowed is {}.\n", maxListSize_);
+        if (maxListSize_.has_value() && data_.nItems() >= maxListSize_.value())
+            return Messenger::error("Too many configurations given to keyword. Maximum allowed is {}.\n", maxListSize_.value());
 
         // Check that the configuration isn't already in the list
         if (data_.contains(cfg))

--- a/src/keywords/configurationreflist.cpp
+++ b/src/keywords/configurationreflist.cpp
@@ -39,7 +39,7 @@ int ConfigurationRefListKeyword::maxArguments() const { return 99; }
 bool ConfigurationRefListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Each argument is the name of a Configuration that we will add to our list
-    for (int n = startArg; n < parser.nArgs(); ++n)
+    for (auto n = startArg; n < parser.nArgs(); ++n)
     {
         Configuration *cfg = coreData.findConfiguration(parser.argsv(n));
         if (!cfg)

--- a/src/keywords/configurationreflist.cpp
+++ b/src/keywords/configurationreflist.cpp
@@ -6,7 +6,7 @@
 #include "classes/configuration.h"
 #include "classes/coredata.h"
 
-ConfigurationRefListKeyword::ConfigurationRefListKeyword(RefList<Configuration> &references, std::optional<int> maxListSize)
+ConfigurationRefListKeyword::ConfigurationRefListKeyword(RefList<Configuration> &references, int maxListSize)
     : KeywordData<RefList<Configuration> &>(KeywordBase::ConfigurationRefListData, references)
 {
     maxListSize_ = maxListSize;
@@ -23,7 +23,7 @@ ConfigurationRefListKeyword::~ConfigurationRefListKeyword() {}
 bool ConfigurationRefListKeyword::isDataEmpty() const { return data_.nItems() == 0; }
 
 // Return maximum number of Configurations to allow in the list
-std::optional<int> ConfigurationRefListKeyword::maxListSize() const { return maxListSize_; }
+int ConfigurationRefListKeyword::maxListSize() const { return maxListSize_; }
 
 /*
  * Arguments
@@ -47,8 +47,8 @@ bool ConfigurationRefListKeyword::read(LineParser &parser, int startArg, CoreDat
                                     parser.argsv(n));
 
         // Check maximum size of list
-        if (maxListSize_.has_value() && data_.nItems() >= maxListSize_.value())
-            return Messenger::error("Too many configurations given to keyword. Maximum allowed is {}.\n", maxListSize_.value());
+        if ((maxListSize_ != -1) && (data_.nItems() >= maxListSize_))
+            return Messenger::error("Too many configurations given to keyword. Maximum allowed is {}.\n", maxListSize_);
 
         // Check that the configuration isn't already in the list
         if (data_.contains(cfg))

--- a/src/keywords/configurationreflist.h
+++ b/src/keywords/configurationreflist.h
@@ -5,6 +5,7 @@
 
 #include "keywords/data.h"
 #include "templates/reflist.h"
+#include <optional>
 
 // Forward Declarations
 class Configuration;
@@ -13,7 +14,7 @@ class Configuration;
 class ConfigurationRefListKeyword : public KeywordData<RefList<Configuration> &>
 {
     public:
-    ConfigurationRefListKeyword(RefList<Configuration> &references, int maxListSize = -1);
+    ConfigurationRefListKeyword(RefList<Configuration> &references, std::optional<int> maxListSize = std::nullopt);
     ~ConfigurationRefListKeyword();
 
     /*
@@ -21,7 +22,7 @@ class ConfigurationRefListKeyword : public KeywordData<RefList<Configuration> &>
      */
     private:
     // Maximum number of Configurations to allow in the list (or -1 for any number)
-    int maxListSize_;
+    std::optional<int> maxListSize_;
 
     protected:
     // Determine whether current data is 'empty', and should be considered as 'not set'
@@ -29,7 +30,7 @@ class ConfigurationRefListKeyword : public KeywordData<RefList<Configuration> &>
 
     public:
     // Return maximum number of Configurations to allow in the list
-    int maxListSize() const;
+    std::optional<int> maxListSize() const;
 
     /*
      * Arguments

--- a/src/keywords/configurationreflist.h
+++ b/src/keywords/configurationreflist.h
@@ -14,7 +14,7 @@ class Configuration;
 class ConfigurationRefListKeyword : public KeywordData<RefList<Configuration> &>
 {
     public:
-    ConfigurationRefListKeyword(RefList<Configuration> &references, std::optional<int> maxListSize = std::nullopt);
+    ConfigurationRefListKeyword(RefList<Configuration> &references, int maxListSize);
     ~ConfigurationRefListKeyword();
 
     /*
@@ -22,7 +22,7 @@ class ConfigurationRefListKeyword : public KeywordData<RefList<Configuration> &>
      */
     private:
     // Maximum number of Configurations to allow in the list (or -1 for any number)
-    std::optional<int> maxListSize_;
+    int maxListSize_;
 
     protected:
     // Determine whether current data is 'empty', and should be considered as 'not set'
@@ -30,7 +30,7 @@ class ConfigurationRefListKeyword : public KeywordData<RefList<Configuration> &>
 
     public:
     // Return maximum number of Configurations to allow in the list
-    std::optional<int> maxListSize() const;
+    int maxListSize() const;
 
     /*
      * Arguments

--- a/src/keywords/elementreflist.cpp
+++ b/src/keywords/elementreflist.cpp
@@ -26,7 +26,7 @@ int ElementRefListKeyword::maxArguments() const { return 999; }
 bool ElementRefListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Loop over arguments (which are Element names) and add them to our list
-    for (int n = startArg; n < parser.nArgs(); ++n)
+    for (auto n = startArg; n < parser.nArgs(); ++n)
     {
         // Do we recognise the Element?
         Element *el = Elements::elementPointer(parser.argsv(n));

--- a/src/keywords/enumoptions.h
+++ b/src/keywords/enumoptions.h
@@ -51,7 +51,7 @@ template <class E> class EnumOptionsKeyword : public EnumOptionsBaseKeyword, pub
                                                                                                   options)
     {
         // Set our array of valid values
-        for (int n = 0; n < KeywordData<EnumOptions<E>>::data_.nOptions(); ++n)
+        for (auto n = 0; n < KeywordData<EnumOptions<E>>::data_.nOptions(); ++n)
             validKeywords_.emplace_back(std::string(KeywordData<EnumOptions<E>>::data_.keywordByIndex(n)));
     }
     ~EnumOptionsKeyword() {}

--- a/src/keywords/enumoptions.h
+++ b/src/keywords/enumoptions.h
@@ -47,8 +47,8 @@ template <class E> class EnumOptionsKeyword : public EnumOptionsBaseKeyword, pub
 {
     public:
     EnumOptionsKeyword(EnumOptions<E> options)
-        : KeywordData<EnumOptions<E>>(KeywordBase::EnumOptionsData, options),
-          EnumOptionsBaseKeyword(KeywordData<EnumOptions<E>>::data_)
+        : EnumOptionsBaseKeyword(KeywordData<EnumOptions<E>>::data_), KeywordData<EnumOptions<E>>(KeywordBase::EnumOptionsData,
+                                                                                                  options)
     {
         // Set our array of valid values
         for (int n = 0; n < KeywordData<EnumOptions<E>>::data_.nOptions(); ++n)

--- a/src/keywords/geometrylist.cpp
+++ b/src/keywords/geometrylist.cpp
@@ -38,7 +38,7 @@ int GeometryListKeyword::maxArguments() const
 bool GeometryListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     Geometry *g = data_.add();
-    for (int i = startArg; i <= (startArg + maxArguments() - 1); i++)
+    for (auto i = startArg; i <= (startArg + maxArguments() - 1); i++)
     {
         if (parser.argi(i) < 1)
             return Messenger::error("Index value, {}, not appropriate", parser.argi(i));
@@ -67,7 +67,7 @@ bool GeometryListKeyword::write(LineParser &parser, std::string_view keywordName
     while (Geometry *ref = GeoIterator.iterate())
     {
         index.clear();
-        for (int n = 0; n < maxArguments() - 1; ++n)
+        for (auto n = 0; n < maxArguments() - 1; ++n)
             index += fmt::format("  {}", ref->indices(n) + 1);
         if (!parser.writeLineF("{}{}{}  {:12.4e}\n", prefix, keywordName, index, ref->value()))
             return false;

--- a/src/keywords/modulereflist.cpp
+++ b/src/keywords/modulereflist.cpp
@@ -50,7 +50,7 @@ int ModuleRefListKeyword::maxArguments() const { return (maxModules_ == -1 ? 99 
 bool ModuleRefListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Loop over arguments provided to the keyword
-    for (int n = startArg; n < parser.nArgs(); ++n)
+    for (auto n = startArg; n < parser.nArgs(); ++n)
     {
         // Find specified Module by its unique name
         Module *module = coreData.findModule(parser.argsv(n));

--- a/src/keywords/nodearray.h
+++ b/src/keywords/nodearray.h
@@ -88,7 +88,7 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
         if (nodeArray.nItems() != fixedArraySize)
         {
             nodeArray.initialise(fixedArraySize);
-            for (int n = 0; n < fixedArraySize; ++n)
+            for (auto n = 0; n < fixedArraySize; ++n)
                 nodeArray[n] = nullptr;
         }
     }
@@ -110,7 +110,7 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
                                     KeywordBase::name());
 
         // Loop over arguments
-        for (int n = startArg; n < parser.nArgs(); ++n)
+        for (auto n = startArg; n < parser.nArgs(); ++n)
         {
             // Locate the named node - don't prune by type yet (we'll check that in setNode())
             ProcedureNode *node = onlyInScope() ? parentNode()->nodeInScope(parser.argsv(startArg))
@@ -132,7 +132,7 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
             return true;
 
         std::string nodes;
-        for (int n = 0; n < KeywordData<Array<N *> &>::data_.nItems(); ++n)
+        for (auto n = 0; n < KeywordData<Array<N *> &>::data_.nItems(); ++n)
         {
             N *node = KeywordData<Array<N *> &>::data_[n];
             nodes += fmt::format("  '{}'", node ? node->name() : "???");
@@ -233,7 +233,7 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
     // Return index of the specified node, if it is in the array
     int indexOfNode(ProcedureNode *node) const
     {
-        for (int n = 0; n < KeywordData<Array<N *> &>::data_.nItems(); ++n)
+        for (auto n = 0; n < KeywordData<Array<N *> &>::data_.nItems(); ++n)
             if (KeywordData<Array<N *> &>::data_.constAt(n) == node)
                 return n;
 
@@ -244,7 +244,7 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
     {
         Array<ProcedureNode *> nodes(KeywordData<Array<N *> &>::data_.nItems());
 
-        for (int n = 0; n < KeywordData<Array<N *> &>::data_.nItems(); ++n)
+        for (auto n = 0; n < KeywordData<Array<N *> &>::data_.nItems(); ++n)
             nodes[n] = KeywordData<Array<N *> &>::data_.constAt(n);
 
         return nodes;
@@ -271,7 +271,7 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
             return;
 
         // Loop over array items
-        for (int n = 0; n < KeywordData<Array<N *> &>::data_.nItems(); ++n)
+        for (auto n = 0; n < KeywordData<Array<N *> &>::data_.nItems(); ++n)
             if (KeywordData<Array<N *> &>::data_[n] == castNode)
                 KeywordData<Array<N *> &>::data_[n] = nullptr;
     }

--- a/src/keywords/nodereflist.h
+++ b/src/keywords/nodereflist.h
@@ -80,7 +80,7 @@ template <class N> class NodeRefListKeyword : public NodeRefListKeywordBase, pub
                                     KeywordBase::name());
 
         // Loop over arguments
-        for (int n = startArg; n < parser.nArgs(); ++n)
+        for (auto n = startArg; n < parser.nArgs(); ++n)
         {
             // Locate the named node - don't prune by type yet (we'll check that in setNode())
             ProcedureNode *node =

--- a/src/keywords/nodevalueenumoptions.h
+++ b/src/keywords/nodevalueenumoptions.h
@@ -59,9 +59,9 @@ class NodeValueEnumOptionsKeyword : public NodeValueEnumOptionsBaseKeyword, publ
 {
     public:
     NodeValueEnumOptionsKeyword(ProcedureNode *parentNode, NodeValue value, EnumOptions<E> enumOptions)
-        : KeywordData<Venum<NodeValue, E>>(KeywordBase::NodeValueEnumOptionsData, Venum<NodeValue, E>(value, enumOptions)),
-          NodeValueEnumOptionsBaseKeyword(KeywordData<Venum<NodeValue, E>>::data_.value(),
-                                          KeywordData<Venum<NodeValue, E>>::data_.baseOptions())
+        : NodeValueEnumOptionsBaseKeyword(KeywordData<Venum<NodeValue, E>>::data_.value(),
+                                          KeywordData<Venum<NodeValue, E>>::data_.baseOptions()),
+          KeywordData<Venum<NodeValue, E>>(KeywordBase::NodeValueEnumOptionsData, Venum<NodeValue, E>(value, enumOptions))
     {
         parentNode_ = parentNode;
     }

--- a/src/keywords/speciesreflist.cpp
+++ b/src/keywords/speciesreflist.cpp
@@ -34,7 +34,7 @@ int SpeciesRefListKeyword::maxArguments() const { return 99; }
 bool SpeciesRefListKeyword::read(LineParser &parser, int startArg, CoreData &coreData)
 {
     // Each argument is the name of a Species that we will add to our list
-    for (int n = startArg; n < parser.nArgs(); ++n)
+    for (auto n = startArg; n < parser.nArgs(); ++n)
     {
         Species *sp = coreData.findSpecies(parser.argsv(n));
         if (!sp)

--- a/src/keywords/vec3double.cpp
+++ b/src/keywords/vec3double.cpp
@@ -106,7 +106,7 @@ bool Vec3DoubleKeyword::read(LineParser &parser, int startArg, CoreData &coreDat
     if (parser.hasArg(startArg + 2))
     {
         // Check individual components of the vector
-        for (int n = 0; n < 3; ++n)
+        for (auto n = 0; n < 3; ++n)
         {
             if (!isValid(n, parser.argd(startArg + n)))
             {

--- a/src/keywords/vec3integer.cpp
+++ b/src/keywords/vec3integer.cpp
@@ -105,7 +105,7 @@ bool Vec3IntegerKeyword::read(LineParser &parser, int startArg, CoreData &coreDa
     if (parser.hasArg(startArg + 2))
     {
         // Check individual components of the vector
-        for (int n = 0; n < 3; ++n)
+        for (auto n = 0; n < 3; ++n)
         {
             if (!isValid(n, parser.argi(startArg + n)))
             {

--- a/src/main/comms.cpp
+++ b/src/main/comms.cpp
@@ -13,7 +13,7 @@ std::string_view ParallelStrategyKeywords[] = {"Sequential", "Even"};
 // Convert string to ParallelStrategy
 Dissolve::ParallelStrategy Dissolve::parallelStrategy(std::string_view s)
 {
-    for (int n = 0; n < Dissolve::nParallelStrategies; ++n)
+    for (auto n = 0; n < Dissolve::nParallelStrategies; ++n)
         if (DissolveSys::sameString(ParallelStrategyKeywords[n], s))
             return (Dissolve::ParallelStrategy)n;
     return Dissolve::nParallelStrategies;
@@ -42,7 +42,7 @@ ProcessPool &Dissolve::worldPool()
     {
         // Assemble list of (world) process ranks for the pool
         Array<int> ranks;
-        for (int n = 0; n < ProcessPool::nWorldProcesses(); ++n)
+        for (auto n = 0; n < ProcessPool::nWorldProcesses(); ++n)
             ranks.add(n);
         world.setUp("World", ranks, ProcessPool::MinimumGroupPopulation);
         firstRun = false;
@@ -72,7 +72,7 @@ bool Dissolve::setUpMPIPools()
 
     // Default pool - all world ranks
     Array<int> allProcesses;
-    for (int n = 0; n < ProcessPool::nWorldProcesses(); ++n)
+    for (auto n = 0; n < ProcessPool::nWorldProcesses(); ++n)
         allProcesses.add(n);
 
     // Set up pool based on selected strategy
@@ -108,7 +108,7 @@ bool Dissolve::setUpMPIPools()
             // Create new pool
             auto procsPerConfig = ProcessPool::nWorldProcesses() / nConfigurations();
             Array<int> poolProcesses;
-            for (int n = 0; n < procsPerConfig; ++n)
+            for (auto n = 0; n < procsPerConfig; ++n)
                 poolProcesses.add(procsPerConfig * cfgIndex + n);
             if (!cfg->setUpProcessPool(poolProcesses, parallelGroupPopulation_))
                 return false;

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -255,7 +255,7 @@ bool Dissolve::saveInput(std::string_view filename)
                                        PairPotentialsBlock::keywords().keyword(PairPotentialsBlock::ParametersKeyword),
                                        atomType->name(), atomType->element()->symbol(), atomType->parameters().charge(),
                                        Forcefield::shortRangeTypes().keyword(atomType->shortRangeType()));
-        for (int n = 0; n < MAXSRPARAMETERS; ++n)
+        for (auto n = 0; n < MAXSRPARAMETERS; ++n)
             line += fmt::format("  {:12.6e}", atomType->parameters().parameter(n));
         if (!parser.writeLine(line))
             return false;

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -31,7 +31,6 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
     Messenger::print("\nParsing {} block '{}'...\n",
                      BlockKeywords::keywords().keyword(BlockKeywords::ConfigurationBlockKeyword), cfg->name());
 
-    Species *sp;
     Module *module;
     std::string niceName;
     auto blockDone = false, error = false;

--- a/src/main/keywords_module.cpp
+++ b/src/main/keywords_module.cpp
@@ -27,7 +27,6 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
     Messenger::print("\nParsing {} block '{}'...\n", BlockKeywords::keywords().keyword(BlockKeywords::ModuleBlockKeyword),
                      module->type());
 
-    Configuration *targetCfg;
     auto blockDone = false, error = false;
 
     while (!parser.eofOrBlank())

--- a/src/main/keywords_pairpotentials.cpp
+++ b/src/main/keywords_pairpotentials.cpp
@@ -35,7 +35,6 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
 
     std::shared_ptr<AtomType> at1;
     std::optional<decltype(at1)> opt_at;
-    PairPotential::ShortRangeTruncationScheme srTrunc;
     auto blockDone = false, error = false;
 
     while (!parser.eofOrBlank())

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -118,7 +118,7 @@ bool Dissolve::iterate(int nIterations)
     iterationTimer_.zero();
     iterationTimer_.start();
 
-    for (int iter = 0; iter < nIterations; ++iter)
+    for (auto iter = 0; iter < nIterations; ++iter)
     {
         // Increase iteration counters
         ++iteration_;

--- a/src/math/averaging.h
+++ b/src/math/averaging.h
@@ -41,7 +41,7 @@ class Averaging
             moduleData.remove(fmt::format("{}_{}", name, nStored), prefix);
             --nStored;
         }
-        for (int n = nStored; n > 0; --n)
+        for (auto n = nStored; n > 0; --n)
             moduleData.rename(fmt::format("{}_{}", name, n), prefix, fmt::format("{}_{}", name, n + 1), prefix);
 
         return nStored;
@@ -86,7 +86,7 @@ class Averaging
         // Perform averaging of the datsets that we have
         currentData.reset();
         double weight = 1.0;
-        for (int n = 0; n < nData; ++n)
+        for (auto n = 0; n < nData; ++n)
         {
             // Get a copy of the (n+1)'th dataset
             T data = GenericListHelper<T>::value(moduleData, fmt::format("{}_{}", name, n + 1), prefix);
@@ -132,12 +132,12 @@ class Averaging
         double normalisation = normalisationFactor(averagingScheme, nData);
 
         // Reset array elements
-        for (int i = 0; i < currentData.nItems(); ++i)
+        for (auto i = 0; i < currentData.nItems(); ++i)
             currentData.at(i).reset();
 
         // Perform averaging of the datsets that we have
         double weight = 1.0;
-        for (int n = 0; n < nData; ++n)
+        for (auto n = 0; n < nData; ++n)
         {
             // Get a copy of the (n+1)'th dataset
             T data = GenericListHelper<T>::value(moduleData, fmt::format("{}_{}", name, n + 1), prefix);
@@ -149,7 +149,7 @@ class Averaging
                 weight = pow(expDecay(), n) / normalisation;
 
             // Loop over individual elements of the array
-            for (int i = 0; i < currentData.nItems(); ++i)
+            for (auto i = 0; i < currentData.nItems(); ++i)
             {
                 // Weight the data
                 data.at(i) *= weight;

--- a/src/math/broadeningfunction.cpp
+++ b/src/math/broadeningfunction.cpp
@@ -524,7 +524,6 @@ double BroadeningFunction::discreteKernelNormalisation(double deltaX) const
 // Return the discrete kernel normalisation factor for the current function, given the underlying data binwidth and omega value
 double BroadeningFunction::discreteKernelNormalisation(double deltaX, double omega) const
 {
-    double test;
     // Return the multiplicative factor to normalise the current function against its discretised sum
     switch (function_)
     {

--- a/src/math/broadeningfunction.cpp
+++ b/src/math/broadeningfunction.cpp
@@ -22,7 +22,7 @@ BroadeningFunction::BroadeningFunction(const BroadeningFunction &source) { (*thi
 void BroadeningFunction::operator=(const BroadeningFunction &source)
 {
     function_ = source.function_;
-    for (int n = 0; n < MAXBROADENINGFUNCTIONPARAMS; ++n)
+    for (auto n = 0; n < MAXBROADENINGFUNCTIONPARAMS; ++n)
         parameters_[n] = source.parameters_[n];
     inverted_ = source.inverted_;
     staticOmega_ = source.staticOmega_;
@@ -75,7 +75,7 @@ std::string_view BroadeningFunctionParameters[][MAXBROADENINGFUNCTIONPARAMS] = {
 // Return FunctionType from supplied string
 BroadeningFunction::FunctionType BroadeningFunction::functionType(std::string_view s)
 {
-    for (int n = 0; n < nFunctionTypes; ++n)
+    for (auto n = 0; n < nFunctionTypes; ++n)
         if (DissolveSys::sameString(s, BroadeningFunctionKeywords[n]))
             return (FunctionType)n;
     return BroadeningFunction::nFunctionTypes;
@@ -140,7 +140,7 @@ void BroadeningFunction::set(BroadeningFunction::FunctionType function, double p
 bool BroadeningFunction::set(LineParser &parser, int startArg)
 {
     // Zero all parameters before we start
-    for (int n = 0; n < MAXBROADENINGFUNCTIONPARAMS; ++n)
+    for (auto n = 0; n < MAXBROADENINGFUNCTIONPARAMS; ++n)
         parameters_[n] = 0.0;
 
     // First argument is the form of the function
@@ -613,7 +613,7 @@ bool BroadeningFunction::read(LineParser &parser, CoreData &coreData)
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     function_ = functionType(parser.argsv(0));
-    for (int n = 0; n < nFunctionParameters(function_); ++n)
+    for (auto n = 0; n < nFunctionParameters(function_); ++n)
         parameters_[n] = parser.argd(n + 1);
     return true;
 }
@@ -622,7 +622,7 @@ bool BroadeningFunction::read(LineParser &parser, CoreData &coreData)
 bool BroadeningFunction::write(LineParser &parser)
 {
     std::string line{functionType(function_)};
-    for (int n = 0; n < nFunctionParameters(function_); ++n)
+    for (auto n = 0; n < nFunctionParameters(function_); ++n)
         line += fmt::format(" {:16.9e}", parameters_[n]);
     return parser.writeLine(line);
 }

--- a/src/math/data1d.cpp
+++ b/src/math/data1d.cpp
@@ -235,7 +235,7 @@ double Data1D::minValue() const
         return 0.0;
 
     double value = values_.constAt(0);
-    for (int n = 1; n < values_.nItems(); ++n)
+    for (auto n = 1; n < values_.nItems(); ++n)
         if (values_.constAt(n) < value)
             value = values_.constAt(n);
 
@@ -249,7 +249,7 @@ double Data1D::maxValue() const
         return 0.0;
 
     double value = values_.constAt(0);
-    for (int n = 1; n < values_.nItems(); ++n)
+    for (auto n = 1; n < values_.nItems(); ++n)
         if (values_.constAt(n) > value)
             value = values_.constAt(n);
 
@@ -356,7 +356,7 @@ void Data1D::operator+=(const Data1D &source)
     ++version_;
 
     // Loop over points, summing them into our array
-    for (int n = 0; n < x_.nItems(); ++n)
+    for (auto n = 0; n < x_.nItems(); ++n)
     {
 #ifdef CHECKS
         // Check x values for consistency
@@ -374,7 +374,7 @@ void Data1D::operator+=(const Data1D &source)
 
 void Data1D::operator+=(const double delta)
 {
-    for (int n = 0; n < values_.nItems(); ++n)
+    for (auto n = 0; n < values_.nItems(); ++n)
         values_[n] += delta;
 
     ++version_;
@@ -386,7 +386,7 @@ void Data1D::operator-=(const Data1D &source)
     if (x_.nItems() == 0)
     {
         copyArrays(source);
-        for (int n = 0; n < values_.nItems(); ++n)
+        for (auto n = 0; n < values_.nItems(); ++n)
             values_[n] = -values_[n];
         return;
     }
@@ -401,7 +401,7 @@ void Data1D::operator-=(const Data1D &source)
     ++version_;
 
     // Loop over points, summing them into our array
-    for (int n = 0; n < x_.nItems(); ++n)
+    for (auto n = 0; n < x_.nItems(); ++n)
     {
 #ifdef CHECKS
         // Check x values for consistency
@@ -419,7 +419,7 @@ void Data1D::operator-=(const Data1D &source)
 
 void Data1D::operator-=(const double delta)
 {
-    for (int n = 0; n < values_.nItems(); ++n)
+    for (auto n = 0; n < values_.nItems(); ++n)
         values_[n] -= delta;
 
     ++version_;
@@ -443,7 +443,7 @@ void Data1D::operator*=(const Array<double> &factors)
         return;
     }
 
-    for (int n = 0; n < values_.nItems(); ++n)
+    for (auto n = 0; n < values_.nItems(); ++n)
         values_[n] *= factors.constAt(n);
 }
 
@@ -486,7 +486,7 @@ bool Data1D::read(LineParser &parser, CoreData &coreData)
     initialise(nPoints, errors);
 
     // Read data points
-    for (int n = 0; n < nPoints; ++n)
+    for (auto n = 0; n < nPoints; ++n)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
@@ -515,12 +515,12 @@ bool Data1D::write(LineParser &parser)
     // Write values / errors
     if (hasError_)
     {
-        for (int n = 0; n < x_.nItems(); ++n)
+        for (auto n = 0; n < x_.nItems(); ++n)
             if (!parser.writeLineF("{}  {}  {}\n", x_[n], values_[n], errors_[n]))
                 return false;
     }
     else
-        for (int n = 0; n < x_.nItems(); ++n)
+        for (auto n = 0; n < x_.nItems(); ++n)
             if (!parser.writeLineF("{}  {}\n", x_[n], values_[n]))
                 return false;
 

--- a/src/math/data1d.h
+++ b/src/math/data1d.h
@@ -16,7 +16,7 @@ class Data1D : public PlottableData, public ListItem<Data1D>, public ObjectStore
 {
     public:
     Data1D();
-    ~Data1D();
+    virtual ~Data1D();
     Data1D(const Data1D &source);
     // Clear data
     void clear();

--- a/src/math/data2d.cpp
+++ b/src/math/data2d.cpp
@@ -89,13 +89,13 @@ void Data2D::initialise(double xMin, double xMax, double xBin, double yMin, doub
     // Create x_ axis array
     x_.initialise(nXBins);
     auto xCentre = xMin + xBin * 0.5;
-    for (int n = 0; n < nXBins; ++n, xCentre += xBin)
+    for (auto n = 0; n < nXBins; ++n, xCentre += xBin)
         x_[n] = xCentre;
 
     // Create y_ axis array
     y_.initialise(nYBins);
     auto yCentre = yMin + yBin * 0.5;
-    for (int n = 0; n < nYBins; ++n, yCentre += yBin)
+    for (auto n = 0; n < nYBins; ++n, yCentre += yBin)
         y_[n] = yCentre;
 
     // Initialise values array
@@ -287,7 +287,7 @@ double Data2D::minValue() const
         return 0.0;
 
     double value = values_.constLinearValue(0);
-    for (int n = 1; n < values_.linearArraySize(); ++n)
+    for (auto n = 1; n < values_.linearArraySize(); ++n)
         if (values_.constLinearValue(n) < value)
             value = values_.constLinearValue(n);
 
@@ -301,7 +301,7 @@ double Data2D::maxValue() const
         return 0.0;
 
     double value = values_.constLinearValue(0);
-    for (int n = 1; n < values_.linearArraySize(); ++n)
+    for (auto n = 1; n < values_.linearArraySize(); ++n)
         if (values_.constLinearValue(n) > value)
             value = values_.constLinearValue(n);
 
@@ -419,7 +419,7 @@ void Data2D::operator=(const Data2D &source)
 
 void Data2D::operator+=(const double delta)
 {
-    for (int n = 0; n < values_.linearArraySize(); ++n)
+    for (auto n = 0; n < values_.linearArraySize(); ++n)
         values_.linearValue(n) += delta;
 
     ++version_;
@@ -427,7 +427,7 @@ void Data2D::operator+=(const double delta)
 
 void Data2D::operator-=(const double delta)
 {
-    for (int n = 0; n < values_.linearArraySize(); ++n)
+    for (auto n = 0; n < values_.linearArraySize(); ++n)
         values_.linearValue(n) -= delta;
 
     ++version_;
@@ -482,7 +482,7 @@ bool Data2D::read(LineParser &parser, CoreData &coreData)
     initialise(xSize, ySize, errors);
 
     // Read x axis
-    for (int x = 0; x < x_.nItems(); ++x)
+    for (auto x = 0; x < x_.nItems(); ++x)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
@@ -490,7 +490,7 @@ bool Data2D::read(LineParser &parser, CoreData &coreData)
     }
 
     // Read y axis
-    for (int y = 0; y < y_.nItems(); ++y)
+    for (auto y = 0; y < y_.nItems(); ++y)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
@@ -500,9 +500,9 @@ bool Data2D::read(LineParser &parser, CoreData &coreData)
     // Read errors / valuse
     if (hasError_)
     {
-        for (int x = 0; x < x_.nItems(); ++x)
+        for (auto x = 0; x < x_.nItems(); ++x)
         {
-            for (int y = 0; y < y_.nItems(); ++y)
+            for (auto y = 0; y < y_.nItems(); ++y)
             {
                 if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                     return false;
@@ -513,9 +513,9 @@ bool Data2D::read(LineParser &parser, CoreData &coreData)
     }
     else
     {
-        for (int x = 0; x < x_.nItems(); ++x)
+        for (auto x = 0; x < x_.nItems(); ++x)
         {
-            for (int y = 0; y < y_.nItems(); ++y)
+            for (auto y = 0; y < y_.nItems(); ++y)
             {
                 if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                     return false;
@@ -541,30 +541,30 @@ bool Data2D::write(LineParser &parser)
         return false;
 
     // Write x axis array
-    for (int x = 0; x < x_.nItems(); ++x)
+    for (auto x = 0; x < x_.nItems(); ++x)
         if (!parser.writeLineF("{:e}\n", x_[x]))
             return false;
 
     // Write y axis array
-    for (int y = 0; y < y_.nItems(); ++y)
+    for (auto y = 0; y < y_.nItems(); ++y)
         if (!parser.writeLineF("{:e}\n", y_[y]))
             return false;
 
     // Write values / errors
     if (hasError_)
     {
-        for (int x = 0; x < x_.nItems(); ++x)
+        for (auto x = 0; x < x_.nItems(); ++x)
         {
-            for (int y = 0; y < y_.nItems(); ++y)
+            for (auto y = 0; y < y_.nItems(); ++y)
                 if (!parser.writeLineF("{:e}  {:e}\n", values_.constAt(x, y), errors_.constAt(x, y)))
                     return false;
         }
     }
     else
     {
-        for (int x = 0; x < x_.nItems(); ++x)
+        for (auto x = 0; x < x_.nItems(); ++x)
         {
-            for (int y = 0; y < y_.nItems(); ++y)
+            for (auto y = 0; y < y_.nItems(); ++y)
                 if (!parser.writeLineF("{:e}\n", values_.constAt(x, y)))
                     return false;
         }

--- a/src/math/data2d.h
+++ b/src/math/data2d.h
@@ -17,7 +17,7 @@ class Data2D : public PlottableData, public ListItem<Data2D>, public ObjectStore
 {
     public:
     Data2D();
-    ~Data2D();
+    virtual ~Data2D();
     Data2D(const Data2D &source);
     // Clear data
     void clear();

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -293,7 +293,7 @@ double Data3D::minValue() const
         return 0.0;
 
     double value = values_.constLinearValue(0);
-    for (int n = 1; n < values_.linearArraySize(); ++n)
+    for (auto n = 1; n < values_.linearArraySize(); ++n)
         if (values_.constLinearValue(n) < value)
             value = values_.constLinearValue(n);
 
@@ -307,7 +307,7 @@ double Data3D::maxValue() const
         return 0.0;
 
     double value = values_.constLinearValue(0);
-    for (int n = 1; n < values_.linearArraySize(); ++n)
+    for (auto n = 1; n < values_.linearArraySize(); ++n)
         if (values_.constLinearValue(n) > value)
             value = values_.constLinearValue(n);
 
@@ -436,7 +436,7 @@ void Data3D::operator=(const Data3D &source)
 
 void Data3D::operator+=(const double delta)
 {
-    for (int n = 0; n < values_.linearArraySize(); ++n)
+    for (auto n = 0; n < values_.linearArraySize(); ++n)
         values_.linearValue(n) += delta;
 
     ++version_;
@@ -444,7 +444,7 @@ void Data3D::operator+=(const double delta)
 
 void Data3D::operator-=(const double delta)
 {
-    for (int n = 0; n < values_.linearArraySize(); ++n)
+    for (auto n = 0; n < values_.linearArraySize(); ++n)
         values_.linearValue(n) -= delta;
 
     ++version_;
@@ -500,7 +500,7 @@ bool Data3D::read(LineParser &parser, CoreData &coreData)
     initialise(xSize, ySize, zSize, errors);
 
     // Read x axis
-    for (int x = 0; x < x_.nItems(); ++x)
+    for (auto x = 0; x < x_.nItems(); ++x)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
@@ -508,7 +508,7 @@ bool Data3D::read(LineParser &parser, CoreData &coreData)
     }
 
     // Read y axis
-    for (int y = 0; y < y_.nItems(); ++y)
+    for (auto y = 0; y < y_.nItems(); ++y)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
@@ -516,7 +516,7 @@ bool Data3D::read(LineParser &parser, CoreData &coreData)
     }
 
     // Read z axis
-    for (int z = 0; z < z_.nItems(); ++z)
+    for (auto z = 0; z < z_.nItems(); ++z)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
@@ -526,11 +526,11 @@ bool Data3D::read(LineParser &parser, CoreData &coreData)
     // Read errors / valuse
     if (hasError_)
     {
-        for (int x = 0; x < x_.nItems(); ++x)
+        for (auto x = 0; x < x_.nItems(); ++x)
         {
-            for (int y = 0; y < y_.nItems(); ++y)
+            for (auto y = 0; y < y_.nItems(); ++y)
             {
-                for (int z = 0; z < z_.nItems(); ++z)
+                for (auto z = 0; z < z_.nItems(); ++z)
                 {
                     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                         return false;
@@ -542,11 +542,11 @@ bool Data3D::read(LineParser &parser, CoreData &coreData)
     }
     else
     {
-        for (int x = 0; x < x_.nItems(); ++x)
+        for (auto x = 0; x < x_.nItems(); ++x)
         {
-            for (int y = 0; y < y_.nItems(); ++y)
+            for (auto y = 0; y < y_.nItems(); ++y)
             {
-                for (int z = 0; z < z_.nItems(); ++z)
+                for (auto z = 0; z < z_.nItems(); ++z)
                 {
                     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                         return false;
@@ -573,28 +573,28 @@ bool Data3D::write(LineParser &parser)
         return false;
 
     // Write x axis array
-    for (int x = 0; x < x_.nItems(); ++x)
+    for (auto x = 0; x < x_.nItems(); ++x)
         if (!parser.writeLineF("{:e}\n", x_[x]))
             return false;
 
     // Write y axis array
-    for (int y = 0; y < y_.nItems(); ++y)
+    for (auto y = 0; y < y_.nItems(); ++y)
         if (!parser.writeLineF("{:e}\n", y_[y]))
             return false;
 
     // Write z axis array
-    for (int z = 0; z < z_.nItems(); ++z)
+    for (auto z = 0; z < z_.nItems(); ++z)
         if (!parser.writeLineF("{:e}\n", z_[z]))
             return false;
 
     // Write values / errors
     if (hasError_)
     {
-        for (int x = 0; x < x_.nItems(); ++x)
+        for (auto x = 0; x < x_.nItems(); ++x)
         {
-            for (int y = 0; y < y_.nItems(); ++y)
+            for (auto y = 0; y < y_.nItems(); ++y)
             {
-                for (int z = 0; z < z_.nItems(); ++z)
+                for (auto z = 0; z < z_.nItems(); ++z)
                     if (!parser.writeLineF("{:e}  {:e}\n", values_.constAt(x, y, z), errors_.constAt(x, y, z)))
                         return false;
             }
@@ -602,11 +602,11 @@ bool Data3D::write(LineParser &parser)
     }
     else
     {
-        for (int x = 0; x < x_.nItems(); ++x)
+        for (auto x = 0; x < x_.nItems(); ++x)
         {
-            for (int y = 0; y < y_.nItems(); ++y)
+            for (auto y = 0; y < y_.nItems(); ++y)
             {
-                for (int z = 0; z < z_.nItems(); ++z)
+                for (auto z = 0; z < z_.nItems(); ++z)
                     if (!parser.writeLineF("{:e}\n", values_.constAt(x, y, z)))
                         return false;
             }

--- a/src/math/data3d.h
+++ b/src/math/data3d.h
@@ -16,7 +16,7 @@ class Data3D : public PlottableData, public ListItem<Data3D>, public ObjectStore
 {
     public:
     Data3D();
-    ~Data3D();
+    virtual ~Data3D();
     Data3D(const Data3D &source);
     // Clear data
     void clear();

--- a/src/math/error.cpp
+++ b/src/math/error.cpp
@@ -58,7 +58,7 @@ double Error::rmse(const Data1D &A, const Data1D &B, bool quiet)
     double rmse = 0.0, delta;
     double firstX = 0.0, lastX = 0.0, x;
     auto nPointsConsidered = 0;
-    for (int n = 0; n < aX.nItems(); ++n)
+    for (auto n = 0; n < aX.nItems(); ++n)
     {
         // Grab x value
         x = aX.constAt(n);
@@ -104,7 +104,7 @@ double Error::mape(const Data1D &A, const Data1D &B, bool quiet)
     double sum = 0.0;
     double firstX = 0.0, lastX = 0.0, x, y;
     auto nPointsConsidered = 0;
-    for (int n = 0; n < aX.nItems(); ++n)
+    for (auto n = 0; n < aX.nItems(); ++n)
     {
         // Grab x value
         x = aX.constAt(n);
@@ -154,7 +154,7 @@ double Error::maape(const Data1D &A, const Data1D &B, bool quiet)
     double sum = 0.0;
     double firstX = 0.0, lastX = 0.0, x, y;
     auto nPointsConsidered = 0;
-    for (int n = 0; n < 1; ++n)
+    for (auto n = 0; n < 1; ++n)
     {
         // Grab x value
         x = aX.constAt(n);
@@ -203,7 +203,7 @@ double Error::percent(const Data1D &A, const Data1D &B, bool quiet)
     double sume = 0.0, sumy = 0.0;
     auto firstPoint = -1, lastPoint = -1;
     double x, y;
-    for (int n = 0; n < aX.nItems(); ++n)
+    for (auto n = 0; n < aX.nItems(); ++n)
     {
         // Grab x value
         x = aX.constAt(n);
@@ -259,7 +259,7 @@ double Error::rFactor(const Data1D &A, const Data1D &B, bool quiet)
     double rfac = 0.0, delta;
     double firstX = 0.0, lastX = 0.0, x;
     auto nPointsConsidered = 0;
-    for (int n = 0; n < aX.nItems(); ++n)
+    for (auto n = 0; n < aX.nItems(); ++n)
     {
         // Grab x value
         x = aX.constAt(n);

--- a/src/math/extrema.cpp
+++ b/src/math/extrema.cpp
@@ -11,7 +11,7 @@ double Extrema::min(const Array<double> &A)
     if (A.nItems() > 0)
     {
         double min = A.constAt(0);
-        for (int i = 0; i < A.nItems(); ++i)
+        for (auto i = 0; i < A.nItems(); ++i)
         {
             if (A.constAt(i) < min)
                 min = A.constAt(i);
@@ -28,7 +28,7 @@ double Extrema::max(const Array<double> &A)
     if (A.nItems() > 0)
     {
         double max = A.constAt(0);
-        for (int i = 0; i < A.nItems(); ++i)
+        for (auto i = 0; i < A.nItems(); ++i)
         {
             if (A.constAt(i) > max)
                 max = A.constAt(i);
@@ -45,7 +45,7 @@ double Extrema::min(const Array2D<double> &A)
     if (A.linearArraySize() > 0)
     {
         double min = A.constLinearValue(0);
-        for (int i = 0; i < A.linearArraySize(); ++i)
+        for (auto i = 0; i < A.linearArraySize(); ++i)
         {
             if (A.constLinearValue(i) < min)
                 min = A.constLinearValue(i);
@@ -62,7 +62,7 @@ double Extrema::max(const Array2D<double> &A)
     if (A.linearArraySize() > 0)
     {
         double max = A.constLinearValue(0);
-        for (int i = 0; i < A.linearArraySize(); ++i)
+        for (auto i = 0; i < A.linearArraySize(); ++i)
         {
             if (A.constLinearValue(i) > max)
                 max = A.constLinearValue(i);
@@ -79,7 +79,7 @@ double Extrema::absMin(const Array<double> &A)
     if (A.nItems() > 0)
     {
         double absMin = abs(A.constAt(0));
-        for (int i = 0; i < A.nItems(); ++i)
+        for (auto i = 0; i < A.nItems(); ++i)
         {
             if (abs(A.constAt(i)) < absMin)
                 absMin = abs(A.constAt(i));
@@ -96,7 +96,7 @@ double Extrema::absMax(const Array<double> &A)
     if (A.nItems() > 0)
     {
         double absMax = abs(A.constAt(0));
-        for (int i = 0; i < A.nItems(); ++i)
+        for (auto i = 0; i < A.nItems(); ++i)
         {
             if (abs(A.constAt(i)) > absMax)
                 absMax = abs(A.constAt(i));
@@ -113,7 +113,7 @@ double Extrema::absMin(const Array2D<double> &A)
     if (A.linearArraySize() > 0)
     {
         double absMin = abs(A.constLinearValue(0));
-        for (int i = 0; i < A.linearArraySize(); ++i)
+        for (auto i = 0; i < A.linearArraySize(); ++i)
         {
             if (abs(A.constLinearValue(i)) < absMin)
                 absMin = abs(A.constLinearValue(i));
@@ -130,7 +130,7 @@ double Extrema::absMax(const Array2D<double> &A)
     if (A.linearArraySize() > 0)
     {
         double absMax = abs(A.constLinearValue(0));
-        for (int i = 0; i < A.linearArraySize(); ++i)
+        for (auto i = 0; i < A.linearArraySize(); ++i)
         {
             if (abs(A.constLinearValue(i)) < absMax)
                 absMax = abs(A.constLinearValue(i));

--- a/src/math/filters.cpp
+++ b/src/math/filters.cpp
@@ -24,7 +24,7 @@ void Filters::convolve(Data1D &data, const BroadeningFunction &function, bool va
     // parameter
     double xCentre, xBroad, norm;
     if (variableOmega)
-        for (int n = 0; n < x.nItems(); ++n)
+        for (auto n = 0; n < x.nItems(); ++n)
         {
             // Grab x value as our current xCentre
             xCentre = x.constAt(n);
@@ -33,7 +33,7 @@ void Filters::convolve(Data1D &data, const BroadeningFunction &function, bool va
             norm = (normalise ? function.discreteKernelNormalisation(xDelta, xCentre) : 1.0);
 
             // Inner loop over whole array
-            for (int m = 0; m < x.nItems(); ++m)
+            for (auto m = 0; m < x.nItems(); ++m)
             {
                 xBroad = x.constAt(m) - xCentre;
                 newY[m] += y.constAt(n) * function.y(xBroad, xCentre) * norm;
@@ -44,13 +44,13 @@ void Filters::convolve(Data1D &data, const BroadeningFunction &function, bool va
         // Get normalisation for this convolution
         norm = (normalise ? function.discreteKernelNormalisation(xDelta) : 1.0);
 
-        for (int n = 0; n < x.nItems(); ++n)
+        for (auto n = 0; n < x.nItems(); ++n)
         {
             // Grab x value as our current xCentre
             xCentre = x.constAt(n);
 
             // Inner loop over whole array
-            for (int m = 0; m < x.nItems(); ++m)
+            for (auto m = 0; m < x.nItems(); ++m)
             {
                 xBroad = x.constAt(m) - xCentre;
                 newY[m] += y.constAt(n) * function.y(xBroad) * norm;
@@ -74,7 +74,7 @@ void Filters::convolve(double xCentre, double value, const BroadeningFunction &f
 
     // Loop over existing datapoints
     double xBroad;
-    for (int n = 0; n < x.nItems(); ++n)
+    for (auto n = 0; n < x.nItems(); ++n)
     {
         xBroad = x.constAt(n) - xCentre;
         y[n] += value * function.y(xBroad);
@@ -84,7 +84,7 @@ void Filters::convolve(double xCentre, double value, const BroadeningFunction &f
 // Apply Kolmogorov–Zurbenko filter
 void Filters::kolmogorovZurbenko(Data1D &data, int k, int m, bool normalised)
 {
-    for (int iteration = 0; iteration < k; ++iteration)
+    for (auto iteration = 0; iteration < k; ++iteration)
         normalised ? normalisedMovingAverage(data, m) : movingAverage(data, m);
 }
 
@@ -209,7 +209,7 @@ double Filters::subtractAverage(Data1D &data, double xStart)
 
     double sum = 0.0;
     auto nPoints = 0;
-    for (int n = 0; n < x.nItems(); ++n)
+    for (auto n = 0; n < x.nItems(); ++n)
     {
         if (x.constAt(n) >= xStart)
         {
@@ -228,7 +228,7 @@ void Filters::trim(Data1D &data, double xMin, double xMax, bool interpolateEnds,
 {
     Array<double> newX, newY;
     const auto &x = data.constXAxis();
-    for (int n = 0; n < x.nItems(); ++n)
+    for (auto n = 0; n < x.nItems(); ++n)
     {
         if (x.constAt(n) < xMin)
             continue;
@@ -281,7 +281,7 @@ void Filters::convertBinBoundaries(Data1D &data)
     // Assume that input x values are histogram bin left-boundaries, so x(n) = 0.5[x(n)+x(n_1)]
     Array<double> &x = data.xAxis();
     double a = x[0], b;
-    for (int n = 0; n < data.nValues() - 1; ++n)
+    for (auto n = 0; n < data.nValues() - 1; ++n)
     {
         b = x[n + 1];
         x[n] = 0.5 * (a + b);

--- a/src/math/gaussfit.cpp
+++ b/src/math/gaussfit.cpp
@@ -26,7 +26,7 @@ void GaussFit::generateApproximation(FunctionSpace::SpaceType space)
     approximateData_.initialise(referenceData_);
 
     // Sum defined Gaussians
-    for (int n = 0; n < nGaussians_; ++n)
+    for (auto n = 0; n < nGaussians_; ++n)
         addFunction(approximateData_, space, x_.constAt(n), A_.constAt(n), fwhm_.constAt(n));
 }
 
@@ -36,12 +36,12 @@ void GaussFit::addFunction(Data1D &data, FunctionSpace::SpaceType space, double 
     // Functional form of function to add depends on whether we're fitting Gaussians or FTs of Gaussians
     if (space == FunctionSpace::RealSpace)
     {
-        for (int m = 0; m < data.nValues(); ++m)
+        for (auto m = 0; m < data.nValues(); ++m)
             data.value(m) += gaussian(data.xAxis(m), xCentre, A, fwhm);
     }
     else
     {
-        for (int m = 0; m < data.nValues(); ++m)
+        for (auto m = 0; m < data.nValues(); ++m)
             data.value(m) += gaussianFT(data.xAxis(m), xCentre, A, fwhm);
     }
 }
@@ -108,7 +108,7 @@ bool GaussFit::saveCoefficients(std::string_view filename) const
         return false;
 
     parser.writeLineF("#  x  A  FWHM\n");
-    for (int n = 0; n < nGaussians_; ++n)
+    for (auto n = 0; n < nGaussians_; ++n)
         parser.writeLineF("{}  {}  {}\n", x_.constAt(n), A_.constAt(n), fwhm_.constAt(n));
 
     parser.closeFiles();
@@ -121,7 +121,7 @@ void GaussFit::printCoefficients() const
 {
     Messenger::print("Fitted nGaussians = {}:\n", nGaussians_);
     Messenger::print(" Gauss     A         x         FWHM\n");
-    for (int n = 0; n < nGaussians_; ++n)
+    for (auto n = 0; n < nGaussians_; ++n)
         Messenger::print("  {:4d}  =  {} {} {}\n", n, A_.constAt(n), x_.constAt(n), fwhm_.constAt(n));
 }
 
@@ -129,7 +129,7 @@ void GaussFit::printCoefficients() const
 bool GaussFit::saveFTGaussians(std::string_view filenamePrefix, double xStep) const
 {
     double xDelta = (xStep < 0.0 ? referenceData_.constXAxis(1) - referenceData_.constXAxis(0) : xStep);
-    for (int n = 0; n < nGaussians_; ++n)
+    for (auto n = 0; n < nGaussians_; ++n)
     {
         LineParser parser;
         if (!parser.openOutput(fmt::format("{}-{:03d}.gauss", filenamePrefix, n)))
@@ -170,7 +170,7 @@ Data1D GaussFit::approximation(FunctionSpace::SpaceType space, double factor, do
     }
 
     // Loop over defined Gaussians
-    for (int n = 0; n < nGaussians_; ++n)
+    for (auto n = 0; n < nGaussians_; ++n)
         addFunction(approx, space, x_.constAt(n), A_.constAt(n), fwhm_.constAt(n) * fwhmFactor);
 
     approx.values() *= factor;
@@ -211,7 +211,7 @@ void GaussFit::set(double rMax, const Array<double> &A, double sigma)
     A_ = A;
 
     double x, gDelta = rMax / nGaussians_;
-    for (int n = 0; n < nGaussians_; ++n)
+    for (auto n = 0; n < nGaussians_; ++n)
     {
         x = (n + 1) * gDelta;
         x_.add(x);
@@ -230,17 +230,17 @@ void GaussFit::updatePrecalculatedFunctions(FunctionSpace::SpaceType space, doub
 
     if (space == FunctionSpace::RealSpace)
     {
-        for (int n = 0; n < nGaussians_; ++n)
+        for (auto n = 0; n < nGaussians_; ++n)
         {
-            for (int m = 0; m < referenceData_.nValues(); ++m)
+            for (auto m = 0; m < referenceData_.nValues(); ++m)
                 functions_.at(n, m) = gaussian(referenceData_.xAxis(m), x_[n], A, fwhm_[n]);
         }
     }
     else
     {
-        for (int n = 0; n < nGaussians_; ++n)
+        for (auto n = 0; n < nGaussians_; ++n)
         {
-            for (int m = 0; m < referenceData_.nValues(); ++m)
+            for (auto m = 0; m < referenceData_.nValues(); ++m)
                 functions_.at(n, m) = gaussianFT(referenceData_.xAxis(m), x_[n], A, fwhm_[n]);
         }
     }
@@ -260,7 +260,7 @@ double GaussFit::sweepFitA(FunctionSpace::SpaceType space, double xMin, int samp
 
     currentError_ = 1.0e9;
 
-    for (int loop = 0; loop < nLoops; ++loop)
+    for (auto loop = 0; loop < nLoops; ++loop)
     {
         // Index of the Gaussian in the x_, A_, and fwhm_ arrays is given by 'g'
         auto g = loop * (sampleSize / nLoops);
@@ -279,7 +279,7 @@ double GaussFit::sweepFitA(FunctionSpace::SpaceType space, double xMin, int samp
             alphaSpace_ = space;
 
             // Add Gaussian parameters as fitting targets
-            for (int n = 0; n < sampleSize; ++n)
+            for (auto n = 0; n < sampleSize; ++n)
             {
                 // Add the Gaussian only if its xCentre is above xMin
                 if (x_[g] >= xMin)
@@ -337,7 +337,7 @@ double GaussFit::constructReal(double requiredError, int maxGaussians)
     {
         // Calculate the delta function between the reference and current approximate data
         referenceDelta.clear();
-        for (int n = 0; n < referenceData_.nValues(); ++n)
+        for (auto n = 0; n < referenceData_.nValues(); ++n)
             referenceDelta.addPoint(referenceData_.xAxis(n), referenceData_.value(n) - approximateData_.value(n));
 
         // Keep track of the number of Gaussians we add this cycle
@@ -346,11 +346,11 @@ double GaussFit::constructReal(double requiredError, int maxGaussians)
 
         // Go over points in the delta, calculating the gradient as we go, and seeking gradient minima (actually,
         // crossovers between -ve and +ve gradients)
-        for (int n = regionDelta; n < referenceData_.nValues() - regionDelta; ++n)
+        for (auto n = regionDelta; n < referenceData_.nValues() - regionDelta; ++n)
         {
             // Calculate gradient at this point
             gradient = 0.0;
-            for (int m = -regionDelta; m < regionDelta; ++m)
+            for (auto m = -regionDelta; m < regionDelta; ++m)
                 gradient += (referenceDelta.value(n + m + 1) - referenceDelta.value(n + m)) /
                             (referenceDelta.xAxis(n + m + 1) - referenceDelta.xAxis(n + m));
 
@@ -410,7 +410,7 @@ double GaussFit::constructReal(double requiredError, int maxGaussians)
                     // Add the accepted Gaussian in to the approximate data, and remove it from the
                     // reference delta
                     double x, y;
-                    for (int m = 0; m < referenceData_.nValues(); ++m)
+                    for (auto m = 0; m < referenceData_.nValues(); ++m)
                     {
                         x = referenceData_.xAxis(m);
                         y = gaussian(x, trialX, trialA, trialFWHM);
@@ -479,7 +479,7 @@ double GaussFit::constructReciprocal(double rMin, double rMax, int nGaussians, d
     approximateData_.initialise(referenceData_);
 
     double x, gDelta = rMax / nGaussians_;
-    for (int n = 0; n < nGaussians_; ++n)
+    for (auto n = 0; n < nGaussians_; ++n)
     {
         x = (n + 1) * gDelta;
         x_.add(x);
@@ -498,7 +498,7 @@ double GaussFit::constructReciprocal(double rMin, double rMax, int nGaussians, d
     alphaSpace_ = FunctionSpace::ReciprocalSpace;
 
     // Add the Gaussian amplitudes to the fitting pool - ignore any whose x centre is below rMin
-    for (int n = 0; n < nGaussians_; ++n)
+    for (auto n = 0; n < nGaussians_; ++n)
     {
         if (x_[n] < rMin)
             continue;
@@ -532,7 +532,7 @@ double GaussFit::constructReciprocal(double rMin, double rMax, const Array<doubl
     nGaussians_ = A_.nItems();
     approximateData_.initialise(referenceData_);
     double x, gDelta = rMax / nGaussians_;
-    for (int n = 0; n < nGaussians_; ++n)
+    for (auto n = 0; n < nGaussians_; ++n)
     {
         x = (n + 1) * gDelta;
         x_.add(x);
@@ -550,7 +550,7 @@ double GaussFit::constructReciprocal(double rMin, double rMax, const Array<doubl
     alphaSpace_ = FunctionSpace::ReciprocalSpace;
 
     // Add the Gaussian amplitudes to the fitting pool - ignore any whose x centre is below rMin
-    for (int n = 0; n < nGaussians_; ++n)
+    for (auto n = 0; n < nGaussians_; ++n)
     {
         if (x_[n] < rMin)
             continue;
@@ -587,14 +587,14 @@ double GaussFit::costAnalyticA(const Array<double> &alpha)
 
     // Loop over data points, add in our Gaussian contributions, and
     double x, y, dy;
-    for (int i = 0; i < approximateData_.nValues(); ++i)
+    for (auto i = 0; i < approximateData_.nValues(); ++i)
     {
         // Get approximate data x and y for this point
         x = approximateData_.xAxis(i);
         y = approximateData_.value(i);
 
         // Add in contributions from our Gaussians
-        for (int n = 0; n < alpha.nItems(); ++n)
+        for (auto n = 0; n < alpha.nItems(); ++n)
         {
             g = alphaIndex_[n];
             A = alpha.constAt(n);
@@ -622,14 +622,14 @@ double GaussFit::costAnalyticAF(const Array<double> &alpha)
 
     // Loop over data points, add in our Gaussian contributions, and
     double x, y, dy;
-    for (int i = 0; i < approximateData_.nValues(); ++i)
+    for (auto i = 0; i < approximateData_.nValues(); ++i)
     {
         // Get approximate data x and y for this point
         x = approximateData_.xAxis(i);
         y = approximateData_.value(i);
 
         // Add in contributions from our Gaussians
-        for (int n = 0; n < nGauss; ++n)
+        for (auto n = 0; n < nGauss; ++n)
         {
             xCentre = x_[alphaIndex_[n]];
             A = alpha.constAt(n * 2);
@@ -662,14 +662,14 @@ double GaussFit::costAnalyticAX(const Array<double> &alpha)
 
     // Loop over data points, add in our Gaussian contributions, and
     double x, y, dy;
-    for (int i = 0; i < approximateData_.nValues(); ++i)
+    for (auto i = 0; i < approximateData_.nValues(); ++i)
     {
         // Get approximate data x and y for this point
         x = approximateData_.xAxis(i);
         y = approximateData_.value(i);
 
         // Add in contributions from our Gaussians
-        for (int n = 0; n < nGauss; ++n)
+        for (auto n = 0; n < nGauss; ++n)
         {
             A = alpha.constAt(n * 2);
             xCentre = alpha.constAt(n * 2 + 1);
@@ -702,14 +702,14 @@ double GaussFit::costAnalyticAFX(const Array<double> &alpha)
 
     // Loop over data points, add in our Gaussian contributions, and
     double x, y, dy;
-    for (int i = 0; i < approximateData_.nValues(); ++i)
+    for (auto i = 0; i < approximateData_.nValues(); ++i)
     {
         // Get approximate data x and y for this point
         x = approximateData_.xAxis(i);
         y = approximateData_.value(i);
 
         // Add in contributions from our Gaussians
-        for (int n = 0; n < nGauss; ++n)
+        for (auto n = 0; n < nGauss; ++n)
         {
             A = alpha.constAt(n * 2);
             fwhm = alpha.constAt(n * 2 + 1);
@@ -737,13 +737,13 @@ double GaussFit::costTabulatedA(const Array<double> &alpha)
     // Loop over data points and sum contributions from tabulated functions on to the current approximate data
     double y, dy;
     auto nAlpha = alpha.nItems();
-    for (int i = 0; i < approximateData_.nValues(); ++i)
+    for (auto i = 0; i < approximateData_.nValues(); ++i)
     {
         // Get approximate data x and y for this point
         y = approximateData_.value(i);
 
         // Add in contributions from our Gaussians
-        for (int n = 0; n < nAlpha; ++n)
+        for (auto n = 0; n < nAlpha; ++n)
             y += functions_.at(alphaIndex_[n], i) * alpha.constAt(n);
 
         dy = referenceData_.value(i) - y;

--- a/src/math/histogram1d.cpp
+++ b/src/math/histogram1d.cpp
@@ -47,7 +47,7 @@ void Histogram1D::updateAccumulatedData()
     accumulatedData_.initialise(bins_.nItems(), true);
 
     // Store bin centres and accumulated averages in the object
-    for (int n = 0; n < bins_.nItems(); ++n)
+    for (auto n = 0; n < bins_.nItems(); ++n)
     {
         accumulatedData_.xAxis(n) = binCentres_[n];
         accumulatedData_.value(n) = averages_.constAt(n);
@@ -95,7 +95,7 @@ void Histogram1D::setUpAxis(double axisMin, double &axisMax, double binWidth, in
     // Create centre-bin array
     binCentres.initialise(nBins);
     double centre = axisMin + binWidth * 0.5;
-    for (int n = 0; n < nBins; ++n, centre += binWidth)
+    for (auto n = 0; n < nBins; ++n, centre += binWidth)
         binCentres[n] = centre;
 }
 
@@ -136,7 +136,7 @@ long int Histogram1D::nBinned() const { return nBinned_; }
 // Accumulate current histogram bins into averages
 void Histogram1D::accumulate()
 {
-    for (int n = 0; n < nBins_; ++n)
+    for (auto n = 0; n < nBins_; ++n)
         averages_[n] += double(bins_[n]);
 
     // Update accumulated data
@@ -158,7 +158,7 @@ void Histogram1D::add(Histogram1D &other, int factor)
                          other.nBins_);
         return;
     }
-    for (int n = 0; n < nBins_; ++n)
+    for (auto n = 0; n < nBins_; ++n)
         bins_[n] += other.bins_[n] * factor;
 }
 
@@ -207,7 +207,7 @@ bool Histogram1D::read(LineParser &parser, CoreData &coreData)
     nBinned_ = parser.argli(0);
     nMissed_ = parser.argli(1);
 
-    for (int n = 0; n < nBins_; ++n)
+    for (auto n = 0; n < nBins_; ++n)
         if (!averages_[n].read(parser, coreData))
             return false;
 
@@ -223,7 +223,7 @@ bool Histogram1D::write(LineParser &parser)
         return false;
     if (!parser.writeLineF("{}  {}\n", nBinned_, nMissed_))
         return false;
-    for (int n = 0; n < nBins_; ++n)
+    for (auto n = 0; n < nBins_; ++n)
         if (!averages_[n].write(parser))
             return false;
 
@@ -267,7 +267,7 @@ bool Histogram1D::broadcast(ProcessPool &procPool, const int root, const CoreDat
         return false;
     if (!procPool.broadcast(bins_, root))
         return false;
-    for (int n = 0; n < averages_.nItems(); ++n)
+    for (auto n = 0; n < averages_.nItems(); ++n)
         if (!averages_[n].broadcast(procPool, root, coreData))
             return false;
 #endif
@@ -301,7 +301,7 @@ bool Histogram1D::equality(ProcessPool &procPool)
     if (!procPool.equality(nMissed_))
         return Messenger::error("Histogram1D nunmber of binned values is not equivalent (process {} has {}).\n",
                                 procPool.poolRank(), nBinned_);
-    for (int n = 0; n < averages_.nItems(); ++n)
+    for (auto n = 0; n < averages_.nItems(); ++n)
         if (!averages_[n].equality(procPool))
             return Messenger::error("Histogram1D average values not equivalent.\n");
 #endif

--- a/src/math/histogram2d.cpp
+++ b/src/math/histogram2d.cpp
@@ -69,9 +69,9 @@ void Histogram2D::initialise(double xMin, double xMax, double xBinWidth, double 
 
     // Set up accumulated data array and set bin centres
     accumulatedData_.initialise(nXBins_, nYBins_, true);
-    for (int x = 0; x < nXBins_; ++x)
+    for (auto x = 0; x < nXBins_; ++x)
         accumulatedData_.xAxis(x) = xBinCentres_[x];
-    for (int y = 0; y < nYBins_; ++y)
+    for (auto y = 0; y < nYBins_; ++y)
         accumulatedData_.yAxis(y) = yBinCentres_[y];
 }
 
@@ -138,9 +138,9 @@ long int Histogram2D::nBinned() const { return nBinned_; }
 // Accumulate current histogram bins into averages
 void Histogram2D::accumulate()
 {
-    for (int x = 0; x < nXBins_; ++x)
+    for (auto x = 0; x < nXBins_; ++x)
     {
-        for (int y = 0; y < nYBins_; ++y)
+        for (auto y = 0; y < nYBins_; ++y)
         {
             // Update averages
             averages_.at(x, y) += double(bins_.at(x, y));
@@ -171,9 +171,9 @@ void Histogram2D::add(Histogram2D &other, int factor)
         return;
     }
 
-    for (int x = 0; x < nXBins_; ++x)
+    for (auto x = 0; x < nXBins_; ++x)
     {
-        for (int y = 0; y < nYBins_; ++y)
+        for (auto y = 0; y < nYBins_; ++y)
             bins_.at(x, y) += other.bins_.at(x, y) * factor;
     }
 }
@@ -228,9 +228,9 @@ bool Histogram2D::read(LineParser &parser, CoreData &coreData)
     nBinned_ = parser.argli(0);
     nMissed_ = parser.argli(1);
 
-    for (int x = 0; x < nXBins_; ++x)
+    for (auto x = 0; x < nXBins_; ++x)
     {
-        for (int y = 0; y < nYBins_; ++y)
+        for (auto y = 0; y < nYBins_; ++y)
             if (!averages_.at(x, y).read(parser, coreData))
                 return false;
     }
@@ -247,9 +247,9 @@ bool Histogram2D::write(LineParser &parser)
         return false;
     if (!parser.writeLineF("{}  {}\n", nBinned_, nMissed_))
         return false;
-    for (int x = 0; x < nXBins_; ++x)
+    for (auto x = 0; x < nXBins_; ++x)
     {
-        for (int y = 0; y < nYBins_; ++y)
+        for (auto y = 0; y < nYBins_; ++y)
             if (!averages_.at(x, y).write(parser))
                 return false;
     }
@@ -306,7 +306,7 @@ bool Histogram2D::broadcast(ProcessPool &procPool, const int root, const CoreDat
     if (!procPool.broadcast(bins_.linearArray(), bins_.linearArraySize(), root))
         return false;
     SampledDouble *avgs = averages_.linearArray();
-    for (int n = 0; n < averages_.linearArraySize(); ++n)
+    for (auto n = 0; n < averages_.linearArraySize(); ++n)
         if (!avgs[n].broadcast(procPool, root, coreData))
             return false;
 #endif
@@ -355,7 +355,7 @@ bool Histogram2D::equality(ProcessPool &procPool)
         return Messenger::error("Histogram2D nunmber of binned values is not equivalent (process {} has {}).\n",
                                 procPool.poolRank(), nBinned_);
     SampledDouble *avgs = averages_.linearArray();
-    for (int n = 0; n < averages_.linearArraySize(); ++n)
+    for (auto n = 0; n < averages_.linearArraySize(); ++n)
         if (!avgs[n].equality(procPool))
             return Messenger::error("Histogram2D average values not equivalent.\n");
 #endif

--- a/src/math/histogram3d.cpp
+++ b/src/math/histogram3d.cpp
@@ -56,15 +56,15 @@ void Histogram3D::clear()
 void Histogram3D::updateAccumulatedData()
 {
     // Store bin centres and accumulated averages in the object
-    for (int x = 0; x < nXBins_; ++x)
+    for (auto x = 0; x < nXBins_; ++x)
     {
         accumulatedData_.xAxis(x) = xBinCentres_[x];
-        for (int y = 0; y < nYBins_; ++y)
+        for (auto y = 0; y < nYBins_; ++y)
         {
             if (x == 0)
                 accumulatedData_.yAxis(y) = yBinCentres_[y];
 
-            for (int z = 0; z < nZBins_; ++z)
+            for (auto z = 0; z < nZBins_; ++z)
             {
                 if (x == 0)
                     accumulatedData_.zAxis(z) = zBinCentres_[z];
@@ -185,11 +185,11 @@ long int Histogram3D::nBinned() const { return nBinned_; }
 // Accumulate current histogram bins into averages
 void Histogram3D::accumulate()
 {
-    for (int x = 0; x < nXBins_; ++x)
+    for (auto x = 0; x < nXBins_; ++x)
     {
-        for (int y = 0; y < nYBins_; ++y)
+        for (auto y = 0; y < nYBins_; ++y)
         {
-            for (int z = 0; z < nZBins_; ++z)
+            for (auto z = 0; z < nZBins_; ++z)
                 averages_.at(x, y, z) += double(bins_.at(x, y, z));
         }
     }
@@ -217,11 +217,11 @@ void Histogram3D::add(Histogram3D &other, int factor)
         return;
     }
 
-    for (int x = 0; x < nXBins_; ++x)
+    for (auto x = 0; x < nXBins_; ++x)
     {
-        for (int y = 0; y < nYBins_; ++y)
+        for (auto y = 0; y < nYBins_; ++y)
         {
-            for (int z = 0; z < nZBins_; ++z)
+            for (auto z = 0; z < nZBins_; ++z)
                 bins_.at(x, y, z) += other.bins_.at(x, y, z) * factor;
         }
     }
@@ -278,11 +278,11 @@ bool Histogram3D::read(LineParser &parser, CoreData &coreData)
     nBinned_ = parser.argli(0);
     nMissed_ = parser.argli(1);
 
-    for (int x = 0; x < nXBins_; ++x)
+    for (auto x = 0; x < nXBins_; ++x)
     {
-        for (int y = 0; y < nYBins_; ++y)
+        for (auto y = 0; y < nYBins_; ++y)
         {
-            for (int z = 0; z < nZBins_; ++z)
+            for (auto z = 0; z < nZBins_; ++z)
                 if (!averages_.at(x, y, z).read(parser, coreData))
                     return false;
         }
@@ -301,11 +301,11 @@ bool Histogram3D::write(LineParser &parser)
         return false;
     if (!parser.writeLineF("{}  {}\n", nBinned_, nMissed_))
         return false;
-    for (int x = 0; x < nXBins_; ++x)
+    for (auto x = 0; x < nXBins_; ++x)
     {
-        for (int y = 0; y < nYBins_; ++y)
+        for (auto y = 0; y < nYBins_; ++y)
         {
-            for (int z = 0; z < nZBins_; ++z)
+            for (auto z = 0; z < nZBins_; ++z)
                 if (!averages_.at(x, y, z).write(parser))
                     return false;
         }
@@ -373,7 +373,7 @@ bool Histogram3D::broadcast(ProcessPool &procPool, const int root, const CoreDat
     if (!procPool.broadcast(bins_.linearArray(), bins_.linearArraySize(), root))
         return false;
     SampledDouble *avgs = averages_.linearArray();
-    for (int n = 0; n < averages_.linearArraySize(); ++n)
+    for (auto n = 0; n < averages_.linearArraySize(); ++n)
         if (!avgs[n].broadcast(procPool, root, coreData))
             return false;
 #endif
@@ -436,7 +436,7 @@ bool Histogram3D::equality(ProcessPool &procPool)
         return Messenger::error("Histogram3D nunmber of binned values is not equivalent (process {} has {}).\n",
                                 procPool.poolRank(), nBinned_);
     SampledDouble *avgs = averages_.linearArray();
-    for (int n = 0; n < averages_.linearArraySize(); ++n)
+    for (auto n = 0; n < averages_.linearArraySize(); ++n)
         if (!avgs[n].equality(procPool))
             return Messenger::error("Histogram3D average values not equivalent.\n");
 #endif

--- a/src/math/integrator.cpp
+++ b/src/math/integrator.cpp
@@ -23,7 +23,7 @@ double Integrator::trapezoid(const Data1D &data)
     const auto &y = data.constValues();
 
     double total = 0.0, y0 = y.firstValue(), y1, x0 = x.firstValue(), x1;
-    for (int n = 1; n < x.nItems(); ++n)
+    for (auto n = 1; n < x.nItems(); ++n)
     {
         x1 = x.constAt(n);
         y1 = y.constAt(n);
@@ -47,7 +47,7 @@ double Integrator::trapezoid(const Data1D &data, double xMin, double xMax)
 
     double total = 0.0, y0, y1, x0, x1;
     auto nPoints = 0;
-    for (int n = 0; n < x.nItems(); ++n)
+    for (auto n = 0; n < x.nItems(); ++n)
     {
         // Get current x and y values and check limit
         x1 = x.constAt(n);
@@ -89,7 +89,7 @@ double Integrator::absTrapezoid(const Data1D &data)
     const auto &y = data.constValues();
 
     double total = 0.0, y0 = y.firstValue(), y1, x0 = x.firstValue(), x1;
-    for (int n = 1; n < x.nItems(); ++n)
+    for (auto n = 1; n < x.nItems(); ++n)
     {
         x1 = x.constAt(n);
         y1 = y.constAt(n);
@@ -108,7 +108,7 @@ double Integrator::sum(const Data1D &data)
 
     double total = 0.0;
 
-    for (int n = 0; n < values.nItems(); ++n)
+    for (auto n = 0; n < values.nItems(); ++n)
         total += values.constAt(n);
 
     return total;
@@ -123,7 +123,7 @@ double Integrator::sum(const Data1D &data, double xMin, double xMax)
 
     double total = 0.0;
 
-    for (int n = 0; n < values.nItems(); ++n)
+    for (auto n = 0; n < values.nItems(); ++n)
     {
         if (x.constAt(n) < xMin)
             continue;
@@ -147,7 +147,7 @@ double Integrator::absSum(const Data1D &data)
 
     double total = 0.0;
 
-    for (int n = 0; n < values.nItems(); ++n)
+    for (auto n = 0; n < values.nItems(); ++n)
         total += fabs(values.constAt(n));
 
     return total;
@@ -162,7 +162,7 @@ double Integrator::absSum(const Data1D &data, double xMin, double xMax)
 
     double total = 0.0;
 
-    for (int n = 0; n < values.nItems(); ++n)
+    for (auto n = 0; n < values.nItems(); ++n)
     {
         if (x.constAt(n) < xMin)
             continue;
@@ -186,7 +186,7 @@ double Integrator::sumOfSquares(const Data1D &data)
 
     double total = 0.0;
 
-    for (int n = 0; n < values.nItems(); ++n)
+    for (auto n = 0; n < values.nItems(); ++n)
         total += values.constAt(n) * values.constAt(n);
 
     return total;
@@ -201,7 +201,7 @@ double Integrator::sumOfSquares(const Data1D &data, double xMin, double xMax)
 
     double total = 0.0;
 
-    for (int n = 0; n < values.nItems(); ++n)
+    for (auto n = 0; n < values.nItems(); ++n)
     {
         if (x.constAt(n) < xMin)
             continue;
@@ -228,7 +228,7 @@ double Integrator::sum(const Data2D &data)
 
     double total = 0.0;
 
-    for (int n = 0; n < values.linearArraySize(); ++n)
+    for (auto n = 0; n < values.linearArraySize(); ++n)
         total += values.constLinearValue(n);
 
     return total;
@@ -242,7 +242,7 @@ double Integrator::absSum(const Data2D &data)
 
     double total = 0.0;
 
-    for (int n = 0; n < values.linearArraySize(); ++n)
+    for (auto n = 0; n < values.linearArraySize(); ++n)
         total += fabs(values.constLinearValue(n));
 
     return total;
@@ -256,7 +256,7 @@ double Integrator::sum(const Data3D &data)
 
     double total = 0.0;
 
-    for (int n = 0; n < values.linearArraySize(); ++n)
+    for (auto n = 0; n < values.linearArraySize(); ++n)
         total += values.constLinearValue(n);
 
     return total;
@@ -270,7 +270,7 @@ double Integrator::absSum(const Data3D &data)
 
     double total = 0.0;
 
-    for (int n = 0; n < values.linearArraySize(); ++n)
+    for (auto n = 0; n < values.linearArraySize(); ++n)
         total += fabs(values.constLinearValue(n));
 
     return total;

--- a/src/math/interpolator.cpp
+++ b/src/math/interpolator.cpp
@@ -4,7 +4,7 @@
 #include "math/interpolator.h"
 #include "math/data1d.h"
 
-Interpolator::Interpolator(const Array<double> &x, const Array<double> &y, InterpolationScheme scheme) : x_(x), y_(x)
+Interpolator::Interpolator(const Array<double> &x, const Array<double> &y, InterpolationScheme scheme) : x_(x), y_(y)
 {
     interpolate(scheme);
 }
@@ -134,7 +134,7 @@ void Interpolator::interpolateSpline()
      * 					x(i) - x(i-1)
      */
 
-    int i, nPoints = x_.nItems();
+    unsigned int i, nPoints = x_.nItems();
 
     if (nPoints < 2)
         return;
@@ -265,12 +265,19 @@ void Interpolator::interpolateThreePoint() { lastInterval_ = 0; }
 // Regenerate using specified scheme
 void Interpolator::interpolate(Interpolator::InterpolationScheme scheme)
 {
+    scheme_ = scheme;
+
+    // Do we have any data to work with?
+    if (x_.nItems() < 2)
+    {
+        h_.clear();
+        return;
+    }
+
     // Calculate interval array 'h'
     h_.initialise(x_.nItems() - 1);
     for (auto i = 0; i < x_.nItems() - 1; ++i)
         h_[i] = x_.constAt(i + 1) - x_.constAt(i);
-
-    scheme_ = scheme;
 
     if (scheme_ == Interpolator::SplineInterpolation)
         interpolateSpline();

--- a/src/math/interpolator.cpp
+++ b/src/math/interpolator.cpp
@@ -134,7 +134,7 @@ void Interpolator::interpolateSpline()
      * 					x(i) - x(i-1)
      */
 
-    const int nPoints = x_.nItems();
+    const auto nPoints = x_.nItems();
 
     if (nPoints < 2)
         return;

--- a/src/math/interpolator.cpp
+++ b/src/math/interpolator.cpp
@@ -134,14 +134,14 @@ void Interpolator::interpolateSpline()
      * 					x(i) - x(i-1)
      */
 
-    unsigned int i, nPoints = x_.nItems();
+    const int nPoints = x_.nItems();
 
     if (nPoints < 2)
         return;
 
     // Calculate interval array 'h'
     h_.initialise(nPoints);
-    for (i = 0; i < nPoints - 1; ++i)
+    for (auto i = 0; i < nPoints - 1; ++i)
         h_[i] = x_.constAt(i + 1) - x_.constAt(i);
 
     // Initialise parameter arrays and working array
@@ -157,7 +157,7 @@ void Interpolator::interpolateSpline()
     rprime[0] = 0.0; // Would be 0.0 / 1.0 in the case of Natural spline
     sprime[0] = 0.0;
 
-    for (i = 1; i < nPoints - 1; ++i)
+    for (auto i = 1; i < nPoints - 1; ++i)
     {
         // For a given i, p(i) = h(i-1), q(i) = 2(h(i-1)+h(i)), r(i) = h(i), s(i) = 6 ((y(n+1) - y(n)) / h(n) - (y(n) -
         // y(n-1)) / h(n-1)
@@ -172,18 +172,18 @@ void Interpolator::interpolateSpline()
         sprime[i] = (s - sprime[i - 1] * p) / (q - rprime[i - 1] * p);
     }
     rprime[nPoints - 1] = 0.0;
-    sprime[nPoints - 1] = (0.0 - sprime[nPoints - 2] / h_[i - 1]) / (2.0 * h_[i - 1]);
+    sprime[nPoints - 1] = (0.0 - sprime[nPoints - 2] / h_[nPoints - 1]) / (2.0 * h_[nPoints - 1]);
 
     // -- Second stage - backsubstitution
     c_[nPoints - 1] = 0.0;
-    for (i = nPoints - 2; i >= 0; --i)
+    for (int i = nPoints - 2; i >= 0; --i)
     {
         // For a given i, m(i) = s'(i) - r'(i)m(i+1)
         c_[i] = sprime[i] - rprime[i] * c_[i + 1];
     }
 
     // c_ array now contains m(i)...
-    for (i = 0; i < nPoints - 1; ++i)
+    for (auto i = 0; i < nPoints - 1; ++i)
     {
         b_[i] = (y_.constAt(i + 1) - y_.constAt(i)) / h_[i] - 0.5 * h_[i] * c_[i] - (h_[i] * (c_[i + 1] - c_[i])) / 6.0;
         d_[i] = (c_[i + 1] - c_[i]) / (6.0 * h_[i]);

--- a/src/math/interpolator.cpp
+++ b/src/math/interpolator.cpp
@@ -253,7 +253,7 @@ void Interpolator::interpolateLinear()
 {
     // Calculate y interval array 'a'
     a_.initialise(y_.nItems() - 1);
-    for (int i = 0; i < y_.nItems() - 1; ++i)
+    for (auto i = 0; i < y_.nItems() - 1; ++i)
         a_[i] = y_.constAt(i + 1) - y_.constAt(i);
 
     lastInterval_ = 0;
@@ -267,7 +267,7 @@ void Interpolator::interpolate(Interpolator::InterpolationScheme scheme)
 {
     // Calculate interval array 'h'
     h_.initialise(x_.nItems() - 1);
-    for (int i = 0; i < x_.nItems() - 1; ++i)
+    for (auto i = 0; i < x_.nItems() - 1; ++i)
         h_[i] = x_.constAt(i + 1) - x_.constAt(i);
 
     scheme_ = scheme;
@@ -418,7 +418,7 @@ void Interpolator::addInterpolated(Data1D &A, const Data1D &B, double factor)
         // Generate interpolation of data B
         Interpolator interpolatedB(B);
 
-        for (int n = 0; n < aX.nItems(); ++n)
+        for (auto n = 0; n < aX.nItems(); ++n)
             aY[n] += interpolatedB.y(aX.constAt(n)) * factor;
     }
 }

--- a/src/math/matrix3.cpp
+++ b/src/math/matrix3.cpp
@@ -34,7 +34,7 @@ Matrix3 Matrix3::operator*(const Matrix3 &B) const
 Matrix3 Matrix3::operator*(const double a) const
 {
     Matrix3 AB;
-    for (int n = 0; n < 9; ++n)
+    for (auto n = 0; n < 9; ++n)
         AB.matrix_[n] = matrix_[n] * a;
     return AB;
 }
@@ -42,7 +42,7 @@ Matrix3 Matrix3::operator*(const double a) const
 Matrix3 Matrix3::operator+(const Matrix3 &B) const
 {
     Matrix3 A;
-    for (int n = 0; n < 9; ++n)
+    for (auto n = 0; n < 9; ++n)
         A[n] = matrix_[n] + B.matrix_[n];
     return A;
 }
@@ -50,7 +50,7 @@ Matrix3 Matrix3::operator+(const Matrix3 &B) const
 Matrix3 Matrix3::operator-(const Matrix3 &B) const
 {
     Matrix3 A;
-    for (int n = 0; n < 9; ++n)
+    for (auto n = 0; n < 9; ++n)
         A[n] = matrix_[n] - B.matrix_[n];
     return A;
 }
@@ -267,7 +267,7 @@ double Matrix3::value(int n) const { return matrix_[n]; }
 double Matrix3::max() const
 {
     auto maxId = 0;
-    for (int n = 1; n < 9; ++n)
+    for (auto n = 1; n < 9; ++n)
         if (matrix_[n] > matrix_[maxId])
             maxId = n;
     return matrix_[maxId];
@@ -352,8 +352,8 @@ void Matrix3::columnMultiply(Vec3<double> vec)
 // Normalise specified column to 1
 void Matrix3::columnNormalise(int col)
 {
-    double mag = 1.0 / sqrt(matrix_[col * 3] * matrix_[col * 3] + matrix_[col * 3 + 1] * matrix_[col * 3 + 1] +
-                            matrix_[col * 3 + 2] * matrix_[col * 3 + 2]);
+    auto mag = 1.0 / sqrt(matrix_[col * 3] * matrix_[col * 3] + matrix_[col * 3 + 1] * matrix_[col * 3 + 1] +
+                          matrix_[col * 3 + 2] * matrix_[col * 3 + 2]);
     matrix_[col * 3] *= mag;
     matrix_[col * 3 + 1] *= mag;
     matrix_[col * 3 + 2] *= mag;

--- a/src/math/matrix3.cpp
+++ b/src/math/matrix3.cpp
@@ -178,18 +178,14 @@ void Matrix3::invert()
 {
     // Gauss-Jordan Inversion
     // Invert the supplied matrix using Gauss-Jordan elimination
-    int pivotrows[3], pivotcols[3], pivotrow = 0, pivotcol = 0;
-    bool pivoted[3];
-    int row, col, n, m;
+    std::array<int, 3> pivotcols{0}, pivotrows{0};
+    std::array<bool, 3> pivoted{false};
+    int pivotrow = 0, pivotcol = 0;
+    int row, col, m;
     double large, element;
-    for (n = 0; n < 3; ++n)
-    {
-        pivotrows[n] = 0;
-        pivotcols[n] = 0;
-        pivoted[n] = false;
-    }
+
     // Loop over columns to be reduced
-    for (n = 0; n < 3; ++n)
+    for (auto n = 0; n < 3; ++n)
     {
         // Locate suitable pivot element - find largest value in the matrix A
         large = 0.0;
@@ -248,14 +244,14 @@ void Matrix3::invert()
         }
     }
     // Rearrange columns to undo row exchanges performed earlier
-    for (n = 2; n >= 0; --n)
+    for (auto i = 2; i >= 0; --i)
     {
-        if (pivotrows[n] != pivotcols[n])
+        if (pivotrows[i] != pivotcols[i])
             for (m = 0; m < 3; ++m)
             {
-                element = matrix_[m * 3 + pivotrows[n]];
-                matrix_[m * 3 + pivotrows[n]] = matrix_[m * 3 + pivotcols[n]];
-                matrix_[m * 3 + pivotcols[n]] = element;
+                element = matrix_[m * 3 + pivotrows[i]];
+                matrix_[m * 3 + pivotrows[i]] = matrix_[m * 3 + pivotcols[i]];
+                matrix_[m * 3 + pivotcols[i]] = element;
             }
     }
 }

--- a/src/math/matrix3.cpp
+++ b/src/math/matrix3.cpp
@@ -3,6 +3,7 @@
 
 #include "math/matrix3.h"
 #include "base/messenger.h"
+#include <array>
 
 Matrix3::Matrix3() { setIdentity(); }
 

--- a/src/math/matrix3.cpp
+++ b/src/math/matrix3.cpp
@@ -328,7 +328,7 @@ void Matrix3::adjustColumn(int col, const Vec3<double> vec)
 double Matrix3::columnMagnitude(int column) const
 {
     double mag = 0.0;
-    for (int n = column * 3; n < column * 3 + 3; ++n)
+    for (auto n = column * 3; n < column * 3 + 3; ++n)
         mag += (matrix_[n] * matrix_[n]);
     return sqrt(mag);
 }

--- a/src/math/matrix4.cpp
+++ b/src/math/matrix4.cpp
@@ -57,7 +57,7 @@ Matrix4 Matrix4::operator*(const Matrix4 &B) const
 Matrix4 Matrix4::operator*(const double a) const
 {
     Matrix4 AB;
-    for (int n = 0; n < 16; ++n)
+    for (auto n = 0; n < 16; ++n)
         AB.matrix_[n] = matrix_[n] * a;
     return AB;
 }
@@ -65,7 +65,7 @@ Matrix4 Matrix4::operator*(const double a) const
 Matrix4 Matrix4::operator+(const Matrix4 &B) const
 {
     Matrix4 A;
-    for (int n = 0; n < 16; ++n)
+    for (auto n = 0; n < 16; ++n)
         A[n] = matrix_[n] + B.matrix_[n];
     return A;
 }
@@ -73,7 +73,7 @@ Matrix4 Matrix4::operator+(const Matrix4 &B) const
 Matrix4 Matrix4::operator-(const Matrix4 &B) const
 {
     Matrix4 A;
-    for (int n = 0; n < 16; ++n)
+    for (auto n = 0; n < 16; ++n)
         A[n] = matrix_[n] - B.matrix_[n];
     return A;
 }
@@ -483,7 +483,7 @@ void Matrix4::adjustColumn(int col, Vec4<double> vec)
 double Matrix4::columnMagnitude(int column) const
 {
     double mag = 0.0;
-    for (int n = column * 4; n < column * 4 + 4; ++n)
+    for (auto n = column * 4; n < column * 4 + 4; ++n)
         mag += (matrix_[n] * matrix_[n]);
     return sqrt(mag);
 }
@@ -508,8 +508,8 @@ void Matrix4::columnMultiply(Vec3<double> vec)
 // Normalise specified column to 1
 void Matrix4::columnNormalise(int col)
 {
-    double mag = 1.0 / sqrt(matrix_[col * 4] * matrix_[col * 4] + matrix_[col * 4 + 1] * matrix_[col * 4 + 1] +
-                            matrix_[col * 4 + 2] * matrix_[col * 4 + 2] + matrix_[col * 4 + 3] * matrix_[col * 4 + 3]);
+    auto mag = 1.0 / sqrt(matrix_[col * 4] * matrix_[col * 4] + matrix_[col * 4 + 1] * matrix_[col * 4 + 1] +
+                          matrix_[col * 4 + 2] * matrix_[col * 4 + 2] + matrix_[col * 4 + 3] * matrix_[col * 4 + 3]);
     matrix_[col * 4] *= mag;
     matrix_[col * 4 + 1] *= mag;
     matrix_[col * 4 + 2] *= mag;

--- a/src/math/matrix4.cpp
+++ b/src/math/matrix4.cpp
@@ -4,6 +4,7 @@
 #include "math/matrix4.h"
 #include "base/messenger.h"
 #include "math/matrix3.h"
+#include <array>
 
 Matrix4::Matrix4() { setIdentity(); }
 

--- a/src/math/matrix4.cpp
+++ b/src/math/matrix4.cpp
@@ -300,18 +300,14 @@ void Matrix4::invert()
 {
     // Gauss-Jordan Inversion
     // Invert the supplied matrix using Gauss-Jordan elimination
-    int pivotrows[4], pivotcols[4], pivotrow = 0, pivotcol = 0;
-    bool pivoted[4];
-    int row, col, n, m;
+    std::array<int, 4> pivotcols{0}, pivotrows{0};
+    std::array<bool, 4> pivoted{false};
+    int pivotrow = 0, pivotcol = 0;
+    int row, col, m;
     double large, element;
-    for (n = 0; n < 4; ++n)
-    {
-        pivotrows[n] = 0;
-        pivotcols[n] = 0;
-        pivoted[n] = false;
-    }
+
     // Loop over columns to be reduced
-    for (n = 0; n < 4; ++n)
+    for (auto n = 0; n < 4; ++n)
     {
         // Locate suitable pivot element - find largest value in the matrix A
         large = 0.0;
@@ -370,14 +366,14 @@ void Matrix4::invert()
         }
     }
     // Rearrange columns to undo row exchanges performed earlier
-    for (n = 3; n >= 0; --n)
+    for (auto i = 3; i >= 0; --i)
     {
-        if (pivotrows[n] != pivotcols[n])
+        if (pivotrows[i] != pivotcols[i])
             for (m = 0; m < 4; ++m)
             {
-                element = matrix_[m * 4 + pivotrows[n]];
-                matrix_[m * 4 + pivotrows[n]] = matrix_[m * 4 + pivotcols[n]];
-                matrix_[m * 4 + pivotcols[n]] = element;
+                element = matrix_[m * 4 + pivotrows[i]];
+                matrix_[m * 4 + pivotrows[i]] = matrix_[m * 4 + pivotcols[i]];
+                matrix_[m * 4 + pivotcols[i]] = element;
             }
     }
 }

--- a/src/math/mc.h
+++ b/src/math/mc.h
@@ -43,7 +43,7 @@ template <class T> class MonteCarloMinimiser : public MinimiserBase<T>
     void smoothParameters(Array<double> &values)
     {
         // Apply Kolmogorov–Zurbenko filter
-        for (int k = 0; k < parameterSmoothingK_; ++k)
+        for (auto k = 0; k < parameterSmoothingK_; ++k)
         {
             Array<double> newY(values.nItems());
             newY = 0.0;
@@ -73,7 +73,7 @@ template <class T> class MonteCarloMinimiser : public MinimiserBase<T>
                 newY[n] /= (values.nItems() - n + i + 1);
             }
 
-            for (int n = 0; n < values.nItems(); ++n)
+            for (auto n = 0; n < values.nItems(); ++n)
                 values[n] = newY[n];
         }
     }
@@ -116,7 +116,7 @@ template <class T> class MonteCarloMinimiser : public MinimiserBase<T>
         int smoothingNAccepted = 0;
 
         // Outer loop
-        for (int iter = 0; iter < maxIterations_; ++iter)
+        for (auto iter = 0; iter < maxIterations_; ++iter)
         {
             // Copy current best alpha
             trialValues = values;

--- a/src/math/minimiser.h
+++ b/src/math/minimiser.h
@@ -51,7 +51,7 @@ template <class T> class MinimiserBase
         double x = (object_.*costFunction_)(alpha);
 
         // Add penalties from values exceeding set limits
-        for (int n = 0; n < alpha.nItems(); ++n)
+        for (auto n = 0; n < alpha.nItems(); ++n)
         {
             // Minimum limit
             if (minimumLimit_[n] && (alpha.constAt(n) < minimumValue_[n]))
@@ -91,7 +91,7 @@ template <class T> class MinimiserBase
     private:
     void pokeValues(const Array<double> &values)
     {
-        for (int n = 0; n < targets_.nItems(); ++n)
+        for (auto n = 0; n < targets_.nItems(); ++n)
             (*targets_[n]) = values.constAt(n);
     }
 
@@ -123,7 +123,7 @@ template <class T> class MinimiserBase
     void addTargets(Array<double *> vars, bool minLimit = false, double minValue = 0.0, bool maxLimit = false,
                     double maxValue = 0.0)
     {
-        for (int n = 0; n < vars.nItems(); ++n)
+        for (auto n = 0; n < vars.nItems(); ++n)
             addTarget(vars[n], minLimit, minValue, maxLimit, maxValue);
     }
     // Set penalty power for values outside of set limits
@@ -151,7 +151,7 @@ template <class T> class MinimiserBase
 
         // Create a local array of values to pass to the fitting routine
         Array<double> values;
-        for (int n = 0; n < targets_.nItems(); ++n)
+        for (auto n = 0; n < targets_.nItems(); ++n)
             values.add(*targets_[n]);
 
         // Minimise the function

--- a/src/math/pairbroadeningfunction.cpp
+++ b/src/math/pairbroadeningfunction.cpp
@@ -50,7 +50,7 @@ int PairBroadeningFunctionNParameters[] = {0, 1, 0, 2};
 // Return FunctionType from supplied string
 PairBroadeningFunction::FunctionType PairBroadeningFunction::functionType(std::string_view s)
 {
-    for (int n = 0; n < nFunctionTypes; ++n)
+    for (auto n = 0; n < nFunctionTypes; ++n)
         if (DissolveSys::sameString(s, PairBroadeningFunctionKeywords[n]))
             return (FunctionType)n;
     return PairBroadeningFunction::nFunctionTypes;
@@ -146,16 +146,16 @@ bool PairBroadeningFunction::writeAsKeyword(LineParser &parser, std::string_view
                 return false;
 
             // Count number of pairs/values to expect and write to file
-            for (int n = 0; n < elementPairGaussianFlags_.linearArraySize(); ++n)
+            for (auto n = 0; n < elementPairGaussianFlags_.linearArraySize(); ++n)
                 if (elementPairGaussianFlags_.constLinearValue(n))
                     ++count;
             if (!parser.writeLineF("{}{}\n", prefix, count))
                 return false;
 
             // Loop again and write the data proper
-            for (int i = 0; i < elementPairGaussianFlags_.nRows(); ++i)
+            for (auto i = 0; i < elementPairGaussianFlags_.nRows(); ++i)
             {
-                for (int j = i; j < elementPairGaussianFlags_.nColumns(); ++j)
+                for (auto j = i; j < elementPairGaussianFlags_.nColumns(); ++j)
                 {
                     if (elementPairGaussianFlags_.constAt(i, j))
                     {
@@ -214,7 +214,7 @@ Array<double *> PairBroadeningFunction::parameters()
             params.add(&gaussianFWHM_);
             break;
         case (PairBroadeningFunction::GaussianElementPairFunction):
-            for (int n = 0; n < elementPairGaussianFlags_.linearArraySize(); ++n)
+            for (auto n = 0; n < elementPairGaussianFlags_.linearArraySize(); ++n)
             {
                 if (elementPairGaussianFlags_.constLinearValue(n))
                     params.add(&elementPairGaussianFWHM_.linearValue(n));
@@ -360,7 +360,7 @@ bool PairBroadeningFunction::read(LineParser &parser, CoreData &coreData)
                 elementPairGaussianFlags_ = false;
 
                 auto nPairs = parser.argi(0);
-                for (int n = 0; n < nPairs; ++n)
+                for (auto n = 0; n < nPairs; ++n)
                 {
                     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                         return false;

--- a/src/math/poissonfit.cpp
+++ b/src/math/poissonfit.cpp
@@ -28,7 +28,7 @@ void PoissonFit::generateApproximation(FunctionSpace::SpaceType space)
     approximateData_.initialise(referenceData_);
 
     // Sum defined functions
-    for (int n = 0; n < nPoissons_; ++n)
+    for (auto n = 0; n < nPoissons_; ++n)
         addFunction(approximateData_, space, C_.constAt(n), n);
 }
 
@@ -37,13 +37,13 @@ void PoissonFit::addFunction(Data1D &data, FunctionSpace::SpaceType space, doubl
 {
     if (space == FunctionSpace::RealSpace)
     {
-        for (int m = 0; m < data.nValues(); ++m)
+        for (auto m = 0; m < data.nValues(); ++m)
             data.value(m) += C * poisson(data.xAxis(m), nIndex);
     }
     else
     {
         // We assume here that the supplied 'data' has abscissa consistent with the precalculated data
-        for (int m = 0; m < data.nValues(); ++m)
+        for (auto m = 0; m < data.nValues(); ++m)
             data.value(m) += C * poissonFT(m, nIndex);
     }
 }
@@ -123,7 +123,7 @@ Data1D PoissonFit::approximation(FunctionSpace::SpaceType space, double factor, 
     }
 
     // Loop over defined functions
-    for (int n = 0; n < nPoissons_; ++n)
+    for (auto n = 0; n < nPoissons_; ++n)
         addFunction(approx, space, C_.constAt(n), n);
 
     approx.values() *= factor;
@@ -191,7 +191,7 @@ bool PoissonFit::saveCoefficients(std::string_view filename) const
         return false;
 
     parser.writeLineF("#   C\n");
-    for (int n = 0; n < nPoissons_; ++n)
+    for (auto n = 0; n < nPoissons_; ++n)
         parser.writeLineF("{}\n", C_.constAt(n));
 
     parser.closeFiles();
@@ -211,7 +211,7 @@ void PoissonFit::preCalculateTerms()
     sqrtOnePlusQSqSigmaSq_.initialise(referenceData_.nValues());
     oneMinusQSqSigmaSq_.initialise(referenceData_.nValues());
     arcTanQSigma_.initialise(referenceData_.nValues());
-    for (int n = 0; n < referenceData_.nValues(); ++n)
+    for (auto n = 0; n < referenceData_.nValues(); ++n)
     {
         sqrtOnePlusQSqSigmaSq_[n] = sqrt(1.0 + Q.constAt(n) * Q.constAt(n) * sigmaQ_ * sigmaQ_);
         oneMinusQSqSigmaSq_[n] = 1.0 - Q.constAt(n) * Q.constAt(n) * sigmaQ_ * sigmaQ_;
@@ -231,7 +231,7 @@ void PoissonFit::preCalculateTerms()
     double r = rStep_;
     auto deltaN = floor(rStep_ / sigmaR_ + 0.5);
     auto n = deltaN - 1;
-    for (int i = 0; i < nPoissons_; ++i)
+    for (auto i = 0; i < nPoissons_; ++i)
     {
         // Store n at this r value
         n_.add((sigmaR_ > 0.0) && (sigmaR_ <= r) ? n : 0);
@@ -253,17 +253,17 @@ void PoissonFit::updatePrecalculatedFunctions(FunctionSpace::SpaceType space, do
 
     if (space == FunctionSpace::RealSpace)
     {
-        for (int n = 0; n < nPoissons_; ++n)
+        for (auto n = 0; n < nPoissons_; ++n)
         {
-            for (int m = 0; m < referenceData_.nValues(); ++m)
+            for (auto m = 0; m < referenceData_.nValues(); ++m)
                 functions_.at(n, m) = C * poisson(referenceData_.xAxis(m), n);
         }
     }
     else
     {
-        for (int n = 0; n < nPoissons_; ++n)
+        for (auto n = 0; n < nPoissons_; ++n)
         {
-            for (int m = 0; m < referenceData_.nValues(); ++m)
+            for (auto m = 0; m < referenceData_.nValues(); ++m)
                 functions_.at(n, m) = C * poissonFT(m, n);
         }
     }
@@ -284,7 +284,7 @@ double PoissonFit::sweepFitC(FunctionSpace::SpaceType space, double xMin, int sa
 
     currentError_ = 1.0e9;
 
-    for (int loop = 0; loop < nLoops; ++loop)
+    for (auto loop = 0; loop < nLoops; ++loop)
     {
         // Index of the function in the C_ array is given by 'p'
         auto p = loop * (sampleSize / nLoops);
@@ -303,7 +303,7 @@ double PoissonFit::sweepFitC(FunctionSpace::SpaceType space, double xMin, int sa
             alphaSpace_ = space;
 
             // Set-up fitting targets
-            for (int n = 0; n < sampleSize; ++n)
+            for (auto n = 0; n < sampleSize; ++n)
             {
                 // Add the Poisson coefficients to the fitting pool - ignore any whose x centre is below rMin
                 if (((p + 1) * sigmaR_) >= xMin)
@@ -371,7 +371,7 @@ double PoissonFit::constructReciprocal(double rMin, double rMax, int nPoissons, 
     alphaSpace_ = FunctionSpace::ReciprocalSpace;
 
     // Add coefficients for minimising
-    for (int n = (ignoreZerothTerm_ ? 1 : 0); n < nPoissons_; ++n)
+    for (auto n = (ignoreZerothTerm_ ? 1 : 0); n < nPoissons_; ++n)
     {
         if (((n + 1) * sigmaR_) < rMin)
             continue;
@@ -422,7 +422,7 @@ double PoissonFit::constructReciprocal(double rMin, double rMax, Array<double> c
     alphaSpace_ = FunctionSpace::ReciprocalSpace;
 
     // Add coefficients for minimising
-    for (int n = (ignoreZerothTerm_ ? 1 : 0); n < nPoissons_; ++n)
+    for (auto n = (ignoreZerothTerm_ ? 1 : 0); n < nPoissons_; ++n)
     {
         if (((n + 1) * sigmaR_) < rMin)
             continue;
@@ -459,14 +459,14 @@ double PoissonFit::costAnalyticC(const Array<double> &alpha)
 
     // Loop over data points, add in our Gaussian contributions, and
     double x, y, dy;
-    for (int i = 0; i < approximateData_.nValues(); ++i)
+    for (auto i = 0; i < approximateData_.nValues(); ++i)
     {
         // Get approximate data x and y for this point
         x = approximateData_.xAxis(i);
         y = approximateData_.value(i);
 
         // Add in contributions from our Gaussians
-        for (int n = 0; n < alpha.nItems(); ++n)
+        for (auto n = 0; n < alpha.nItems(); ++n)
         {
             nIndex = alphaIndex_[n];
             C = alpha.constAt(n);
@@ -488,13 +488,13 @@ double PoissonFit::costTabulatedC(const Array<double> &alpha)
 
     double y, dy;
     auto nAlpha = alpha.nItems();
-    for (int i = 0; i < approximateData_.nValues(); ++i)
+    for (auto i = 0; i < approximateData_.nValues(); ++i)
     {
         // Get approximate data x and y for this point
         y = approximateData_.value(i);
 
         // Add in contributions from our Gaussians
-        for (int n = 0; n < nAlpha; ++n)
+        for (auto n = 0; n < nAlpha; ++n)
             y += functions_.at(alphaIndex_[n], i) * alpha.constAt(n);
 
         dy = referenceData_.value(i) - y;

--- a/src/math/praxis.h
+++ b/src/math/praxis.h
@@ -261,7 +261,7 @@ template <class T> class PrAxisMinimiser : public MinimiserBase<T>
         double c;
         double *e;
         double eps;
-        double f;
+        double f = 0.0;
         double g;
         double h;
         int i;

--- a/src/math/regression.cpp
+++ b/src/math/regression.cpp
@@ -24,7 +24,7 @@ double Regression::linear(const Data1D &data, int nSamples, double &yBar)
     yBar = 0.0;
 
     // Calculate mean values of x and y
-    for (int n = data.nValues() - nSamples; n < data.nValues(); ++n)
+    for (auto n = data.nValues() - nSamples; n < data.nValues(); ++n)
     {
         xBar += x.constAt(n);
         yBar += y.constAt(n);
@@ -34,7 +34,7 @@ double Regression::linear(const Data1D &data, int nSamples, double &yBar)
 
     // Determine Sx, Sy, and Sxy
     double dx, dy;
-    for (int n = data.nValues() - nSamples; n < data.nValues(); ++n)
+    for (auto n = data.nValues() - nSamples; n < data.nValues(); ++n)
     {
         dx = x.constAt(n) - xBar;
         dy = y.constAt(n) - yBar;

--- a/src/math/sampleddouble.cpp
+++ b/src/math/sampleddouble.cpp
@@ -156,7 +156,7 @@ bool SampledDouble::allSum(ProcessPool &procPool)
 #ifdef PARALLEL
     // All processes in the pool send their data to the zero rank, which assembles the statistics and then broadcasts the
     // final result
-    for (int n = 1; n < procPool.nProcesses(); ++n)
+    for (auto n = 1; n < procPool.nProcesses(); ++n)
     {
         if (procPool.poolRank() == 0)
         {

--- a/src/math/sd.h
+++ b/src/math/sd.h
@@ -27,7 +27,7 @@ template <class T> class SteepestDescentMinimiser : public MinimiserBase<T>
         const double deltaFrac = 0.05;
         double delta;
         Array<double> gradient;
-        for (int n = 0; n < alpha.nItems(); ++n)
+        for (auto n = 0; n < alpha.nItems(); ++n)
         {
             Array<double> tempAlpha = alpha;
             tempAlpha[n] = alpha.value(n) * (1.0 - deltaFrac);
@@ -43,7 +43,7 @@ template <class T> class SteepestDescentMinimiser : public MinimiserBase<T>
     Array<double> gradientMove(const Array<double> &alpha, const Array<double> grad, double stepSize)
     {
         Array<double> newAlpha(alpha.nItems());
-        for (int n = 0; n < alpha.nItems(); ++n)
+        for (auto n = 0; n < alpha.nItems(); ++n)
             newAlpha[n] = alpha.value(n) * grad.value(n) * stepSize;
         return newAlpha;
     }
@@ -119,7 +119,7 @@ template <class T> class SteepestDescentMinimiser : public MinimiserBase<T>
             Messenger::print("Steepest descent did not converge within {} steps.", maxIterations);
 
         // Set minimised values back into their original variables
-        for (int n = 0; n < targets_.nItems(); ++n)
+        for (auto n = 0; n < targets_.nItems(); ++n)
             (*targets_[n]) = values_[n];
 
         return currentError;

--- a/src/math/svd.cpp
+++ b/src/math/svd.cpp
@@ -378,10 +378,10 @@ bool SVD::pseudoinverse(Array2D<double> &A)
     // Perform a quick sanity check on the decomposition
     Array2D<double> A2;
     A2 = U * S * Vt;
-    for (int n = 0; n < A.nRows(); ++n)
+    for (auto n = 0; n < A.nRows(); ++n)
     {
         // TODO Need better double comparison here
-        for (int m = 0; m < A.nColumns(); ++m)
+        for (auto m = 0; m < A.nColumns(); ++m)
             if (fabs(A.constAt(n, m) - A2.constAt(n, m)) > 1.0e-9)
                 return Messenger::error("DissolveMath::pseudoinverse() - SVD does not appear to be valid.\n");
     }
@@ -391,7 +391,7 @@ bool SVD::pseudoinverse(Array2D<double> &A)
     // Take the diagonal single-value matrix S and form its pseudoinverse.
     // This amounts to taking each non-zero diagonal element and replacing it with its reciprocal
     Array2D<double> Splus = S;
-    for (int n = 0; n < S.nRows(); ++n)
+    for (auto n = 0; n < S.nRows(); ++n)
         if (fabs(Splus.constAt(n, n)) > 1.0e-16)
             Splus.at(n, n) = 1.0 / Splus.constAt(n, n);
 

--- a/src/math/transformer.cpp
+++ b/src/math/transformer.cpp
@@ -70,7 +70,7 @@ void Transformer::transformValues(Data1D &data)
     Array<double> &values = data.values();
 
     // Data1D x and value (y) arrays are of same size - loop over number of values
-    for (int n = 0; n < data.nValues(); ++n)
+    for (auto n = 0; n < data.nValues(); ++n)
     {
         // Set values in equations
         x_->set(xAxis.constAt(n));
@@ -95,13 +95,13 @@ void Transformer::transformValues(Data2D &data)
     Array2D<double> &values = data.values();
 
     // Data2D x and y arrays may be of different sizes
-    for (int i = 0; i < xAxis.nItems(); ++i)
+    for (auto i = 0; i < xAxis.nItems(); ++i)
     {
         // Set x value in equation
         x_->set(xAxis.constAt(i));
 
         // Loop over Y axis points
-        for (int j = 0; j < yAxis.nItems(); ++j)
+        for (auto j = 0; j < yAxis.nItems(); ++j)
         {
             // Set y and value (z) values in equation
             y_->set(yAxis.constAt(j));
@@ -128,19 +128,19 @@ void Transformer::transformValues(Data3D &data)
     Array3D<double> &values = data.values();
 
     // Data3D x, y and z arrays may be of different sizes
-    for (int i = 0; i < xAxis.nItems(); ++i)
+    for (auto i = 0; i < xAxis.nItems(); ++i)
     {
         // Set x value in equation
         x_->set(xAxis.constAt(i));
 
         // Loop over Y axis points
-        for (int j = 0; j < yAxis.nItems(); ++j)
+        for (auto j = 0; j < yAxis.nItems(); ++j)
         {
             // Set y and value (z) values in equation
             y_->set(yAxis.constAt(j));
 
             // Loop over z values
-            for (int k = 0; k < zAxis.nItems(); ++k)
+            for (auto k = 0; k < zAxis.nItems(); ++k)
             {
                 z_->set(values.at(i, j, k));
                 value_->set(values.at(i, j, k));

--- a/src/math/windowfunction.cpp
+++ b/src/math/windowfunction.cpp
@@ -19,7 +19,7 @@ WindowFunction::WindowFunction(WindowFunction::FunctionType function, double p1,
 void WindowFunction::operator=(const WindowFunction &source)
 {
     function_ = source.function_;
-    for (int n = 0; n < MAXWINDOWFUNCTIONPARAMS; ++n)
+    for (auto n = 0; n < MAXWINDOWFUNCTIONPARAMS; ++n)
         parameters_[n] = source.parameters_[n];
 
     xMax_ = source.xMax_;
@@ -35,7 +35,7 @@ int WindowFunctionNParameters[] = {0, 0, 0, 0, 0, 0, 0};
 // Return FunctionType from supplied string
 WindowFunction::FunctionType WindowFunction::functionType(std::string_view s)
 {
-    for (int n = 0; n < nFunctionTypes; ++n)
+    for (auto n = 0; n < nFunctionTypes; ++n)
         if (DissolveSys::sameString(s, WindowFunctionKeywords[n]))
             return (FunctionType)n;
     return WindowFunction::nFunctionTypes;
@@ -260,7 +260,7 @@ bool WindowFunction::read(LineParser &parser, CoreData &coreData)
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     function_ = functionType(parser.argsv(0));
-    for (int n = 0; n < nFunctionParameters(function_); ++n)
+    for (auto n = 0; n < nFunctionParameters(function_); ++n)
         parameters_[n] = parser.argd(n + 1);
     return true;
 }
@@ -269,7 +269,7 @@ bool WindowFunction::read(LineParser &parser, CoreData &coreData)
 bool WindowFunction::write(LineParser &parser)
 {
     std::string line{functionType(function_)};
-    for (int n = 0; n < nFunctionParameters(function_); ++n)
+    for (auto n = 0; n < nFunctionParameters(function_); ++n)
         line += fmt::format(" {:16.9e}", parameters_[n]);
     return parser.writeLine(line);
 }

--- a/src/modules/atomshake/process.cpp
+++ b/src/modules/atomshake/process.cpp
@@ -64,7 +64,7 @@ bool AtomShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // Initialise the random number buffer so it is suitable for our parallel strategy within the main loop
         procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
 
-        int shake, n, m;
+        int shake, n;
         auto nAttempts = 0, nAccepted = 0;
         bool accept;
         double currentEnergy, currentIntraEnergy, newEnergy, newIntraEnergy, delta, totalDelta = 0.0;

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -40,7 +40,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (keywords_.asBool("TestGenerator"))
         {
             SampledDouble timing;
-            for (int n = 0; n < N; ++n)
+            for (auto n = 0; n < N; ++n)
             {
                 srand(dissolve.seed());
 
@@ -60,7 +60,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (keywords_.asBool("TestRDFCells"))
         {
             SampledDouble timing;
-            for (int n = 0; n < N; ++n)
+            for (auto n = 0; n < N; ++n)
             {
                 RDFModule rdfModule;
                 rdfModule.addTargetConfiguration(cfg);
@@ -86,7 +86,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (keywords_.asBool("TestRDFSimple"))
         {
             SampledDouble timing;
-            for (int n = 0; n < N; ++n)
+            for (auto n = 0; n < N; ++n)
             {
                 RDFModule rdfModule;
                 rdfModule.addTargetConfiguration(cfg);
@@ -112,7 +112,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (keywords_.asBool("TestIntraEnergy"))
         {
             SampledDouble timing;
-            for (int n = 0; n < N; ++n)
+            for (auto n = 0; n < N; ++n)
             {
                 Timer timer;
                 Messenger::mute();
@@ -130,7 +130,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (keywords_.asBool("TestInterEnergy"))
         {
             SampledDouble timing;
-            for (int n = 0; n < N; ++n)
+            for (auto n = 0; n < N; ++n)
             {
                 Timer timer;
                 Messenger::mute();
@@ -148,7 +148,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (keywords_.asBool("TestDistributors"))
         {
             SampledDouble timing;
-            for (int n = 0; n < N; ++n)
+            for (auto n = 0; n < N; ++n)
             {
                 // Create a Molecule distributor
                 auto &moleculeArray = cfg->molecules();

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -106,7 +106,7 @@ bool BraggModule::calculateBraggTerms(ProcessPool &procPool, Configuration *cfg,
 
         // Initialise Bragg reflections - Q values reflect the centre-bins of the reflection.
         double q = 0.5 * qDelta;
-        for (int n = 0; n < nBraggBins; ++n)
+        for (auto n = 0; n < nBraggBins; ++n)
         {
             tempReflections[n].initialise(q, -1, nTypes);
             q += qDelta;
@@ -149,13 +149,13 @@ bool BraggModule::calculateBraggTerms(ProcessPool &procPool, Configuration *cfg,
         // Renumber reflections in BraggReflection array, assigning an index only if there are KVectors associated with
         // it
         braggIndex = 0;
-        for (int n = 0; n < nBraggBins; ++n)
+        for (auto n = 0; n < nBraggBins; ++n)
             if (tempReflections[n].nKVectors() > 0)
                 tempReflections[n].setIndex(braggIndex++);
 
         // Collapse KVectors into a linear list, excluding any that weren't initialised
         KVector *kVectorsLinear = tempKVectors.linearArray();
-        for (int n = 0; n < tempKVectors.linearArraySize(); ++n)
+        for (auto n = 0; n < tempKVectors.linearArraySize(); ++n)
         {
             if (kVectorsLinear[n].braggReflectionIndex() == -1)
                 continue;
@@ -166,7 +166,7 @@ bool BraggModule::calculateBraggTerms(ProcessPool &procPool, Configuration *cfg,
         }
 
         // Prune BraggReflections array, putting them into a sequential Array that will reflect their new indexing
-        for (int n = 0; n < nBraggBins; ++n)
+        for (auto n = 0; n < nBraggBins; ++n)
         {
             if (tempReflections[n].nKVectors() == 0)
                 continue;
@@ -357,7 +357,7 @@ bool BraggModule::formReflectionFunctions(ProcessPool &procPool, Configuration *
         }
 
         // Set up Data1D array with our empty data
-        for (int n = 0; n < braggPartials.linearArraySize(); ++n)
+        for (auto n = 0; n < braggPartials.linearArraySize(); ++n)
             braggPartials.linearArray()[n] = temp;
     }
     auto &braggTotal = GenericListHelper<Data1D>::realise(cfg->moduleData(), "OriginalBraggTotal", "",
@@ -367,7 +367,7 @@ bool BraggModule::formReflectionFunctions(ProcessPool &procPool, Configuration *
     braggTotal.clear();
 
     // Zero Bragg partials
-    for (int n = 0; n < braggPartials.linearArraySize(); ++n)
+    for (auto n = 0; n < braggPartials.linearArraySize(); ++n)
         braggPartials.linearArray()[n].values() = 0.0;
 
     // Loop over pairs of atom types, adding in contributions from our calculated BraggReflections
@@ -381,7 +381,7 @@ bool BraggModule::formReflectionFunctions(ProcessPool &procPool, Configuration *
             fmt::format("{}//OriginalBragg//{}-{}", cfg->niceName(), atd1.atomTypeName(), atd2.atomTypeName()));
 
         // Loop over defined Bragg reflections
-        for (int n = 0; n < nReflections; ++n)
+        for (auto n = 0; n < nReflections; ++n)
         {
             // Get q value and intensity of reflection
             qCentre = braggReflections.constAt(n).q();
@@ -423,7 +423,7 @@ bool BraggModule::reBinReflections(ProcessPool &procPool, Configuration *cfg, Ar
     // Loop over defined Bragg reflections
     // TODO Prune reflections based on intensity to speed-up process?
     int bin;
-    for (int n = 0; n < nReflections; ++n)
+    for (auto n = 0; n < nReflections; ++n)
     {
         // Get Q bin (in the braggPartials) of the reflection
         bin = braggReflections.constAt(n).q() / qDelta;
@@ -450,11 +450,11 @@ bool BraggModule::reBinReflections(ProcessPool &procPool, Configuration *cfg, Ar
     }
 
     // Normalise data against number of intensities added to each bin
-    for (int typeI = 0; typeI < nTypes; ++typeI)
+    for (auto typeI = 0; typeI < nTypes; ++typeI)
     {
-        for (int typeJ = typeI; typeJ < nTypes; ++typeJ)
+        for (auto typeJ = typeI; typeJ < nTypes; ++typeJ)
         {
-            for (int n = 0; n < nBins; ++n)
+            for (auto n = 0; n < nBins; ++n)
                 if (nAdded[n] > 0)
                     braggPartials.at(typeI, typeJ).value(n) /= nAdded[n];
         }

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -371,7 +371,7 @@ bool BraggModule::formReflectionFunctions(ProcessPool &procPool, Configuration *
         braggPartials.linearArray()[n].values() = 0.0;
 
     // Loop over pairs of atom types, adding in contributions from our calculated BraggReflections
-    double qCentre, factor;
+    double qCentre;
     int bin;
     auto &types = cfg->usedAtomTypesList();
     for_each_pair(types.begin(), types.end(), [&](int typeI, const AtomTypeData &atd1, int typeJ, const AtomTypeData &atd2) {

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -97,7 +97,7 @@ bool BraggModule::process(Dissolve &dissolve, ProcessPool &procPool)
             if (!braggParser.openOutput(fmt::format("{}-Bragg.txt", cfg->niceName())))
                 return false;
             braggParser.writeLineF("#   ID      Q       nKVecs    Intensity(0,0)\n");
-            for (int n = 0; n < braggReflections.nItems(); ++n)
+            for (auto n = 0; n < braggReflections.nItems(); ++n)
             {
                 if (!braggParser.writeLineF("{:6d}  {:10.6f}  {:8d}  {:10.6e}\n", n, braggReflections.constAt(n).q(),
                                             braggReflections.constAt(n).nKVectors(),
@@ -116,7 +116,7 @@ bool BraggModule::process(Dissolve &dissolve, ProcessPool &procPool)
                             fmt::format("{}-Bragg-{}-{}.txt", cfg->niceName(), atd1.atomTypeName(), atd2.atomTypeName())))
                         return false;
                     intensityParser.writeLineF("#     Q      Intensity({},{})\n", atd1.atomTypeName(), atd2.atomTypeName());
-                    for (int n = 0; n < braggReflections.nItems(); ++n)
+                    for (auto n = 0; n < braggReflections.nItems(); ++n)
                     {
                         if (!intensityParser.writeLineF("{:10.6f}  {:10.6e}\n", braggReflections.constAt(n).q(),
                                                         braggReflections.constAt(n).intensity(i, j)))

--- a/src/modules/calculate_angle/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_angle/gui/modulewidget_funcs.cpp
@@ -177,12 +177,12 @@ void CalculateAngleModuleWidget::setGraphDataTargets(CalculateAngleModule *modul
     angle->setColour(StockColours::RedStockColour);
 
     // Calculated (A-B)-C distance-angle map
-    auto *dAngleAB = dAngleABGraph_->createRenderable(
-        Renderable::Data2DRenderable, fmt::format("{}//Process2D//{}//DAngle((A-B)-C)", module_->uniqueName(), cfg->niceName()),
-        "A-B vs A-B-C");
+    dAngleABGraph_->createRenderable(Renderable::Data2DRenderable,
+                                     fmt::format("{}//Process2D//{}//DAngle((A-B)-C)", module_->uniqueName(), cfg->niceName()),
+                                     "A-B vs A-B-C");
 
     // Calculated A-(B-C) distance-angle map
-    auto *dAngleBC = dAngleBCGraph_->createRenderable(
-        Renderable::Data2DRenderable, fmt::format("{}//Process2D//{}//DAngle(A-(B-C))", module_->uniqueName(), cfg->niceName()),
-        "B-C vs A-B-C");
+    dAngleBCGraph_->createRenderable(Renderable::Data2DRenderable,
+                                     fmt::format("{}//Process2D//{}//DAngle(A-(B-C))", module_->uniqueName(), cfg->niceName()),
+                                     "B-C vs A-B-C");
 }

--- a/src/modules/calculate_avgmol/functions.cpp
+++ b/src/modules/calculate_avgmol/functions.cpp
@@ -47,7 +47,7 @@ void CalculateAvgMolModule::updateSpecies(const Array<SampledDouble> &x, const A
                                           const Array<SampledDouble> &z)
 {
     // Loop over atoms in our species
-    for (int n = 0; n < averageSpecies_.nAtoms(); ++n)
+    for (auto n = 0; n < averageSpecies_.nAtoms(); ++n)
         averageSpecies_.setAtomCoordinates(n, x.constAt(n).value(), y.constAt(n).value(), z.constAt(n).value());
 }
 

--- a/src/modules/calculate_avgmol/process.cpp
+++ b/src/modules/calculate_avgmol/process.cpp
@@ -100,7 +100,7 @@ bool CalculateAvgMolModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
     // Loop over sites
     Vec3<double> r;
-    for (int n = 0; n < stack->nSites(); ++n)
+    for (auto n = 0; n < stack->nSites(); ++n)
     {
         const Site &s = stack->site(n);
 #ifdef CHECKS
@@ -116,7 +116,7 @@ bool CalculateAvgMolModule::process(Dissolve &dissolve, ProcessPool &procPool)
         inverseAxes.invert();
 
         // Loop over atoms, taking delta position with origin, and rotating into local axes
-        for (int i = 0; i < s.molecule()->nAtoms(); ++i)
+        for (auto i = 0; i < s.molecule()->nAtoms(); ++i)
         {
             r = inverseAxes * box->minimumVector(s.origin(), s.molecule()->atom(i)->r());
 

--- a/src/modules/calculate_dangle/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_dangle/gui/modulewidget_funcs.cpp
@@ -120,8 +120,8 @@ void CalculateDAngleModuleWidget::setGraphDataTargets(CalculateDAngleModule *mod
         angle->setColour(StockColours::RedStockColour);
 
         // Calculated distance-angle map
-        auto *dAngle = dAngleGraph_->createRenderable(
-            Renderable::Data2DRenderable,
-            fmt::format("{}//Process2D//{}//DAngle(A-BC)", module_->uniqueName(), cfg->niceName()), "B...C vs A-B...C");
+        dAngleGraph_->createRenderable(Renderable::Data2DRenderable,
+                                       fmt::format("{}//Process2D//{}//DAngle(A-BC)", module_->uniqueName(), cfg->niceName()),
+                                       "B...C vs A-B...C");
     }
 }

--- a/src/modules/calibration/functions.cpp
+++ b/src/modules/calibration/functions.cpp
@@ -26,8 +26,6 @@ CalibrationModuleCostFunctions::CalibrationModuleCostFunctions(
 double CalibrationModuleCostFunctions::intraBroadeningCost(const Array<double> &alpha)
 {
     // Store alpha parameters in the PairBroadeningFunction in the associated RDF modules
-    auto alphaIndex = 0;
-    const auto nAlpha = alpha.nItems();
     for (Module *rdfModule : intraBroadeningModules_)
     {
         // Retrieve the PairBroadeningFunction - new test values will already have been set (pokeBeforeCost = true)

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -42,10 +42,9 @@ double EnergyModule::interAtomicEnergy(ProcessPool &procPool, Configuration *cfg
 // Return total interatomic energy of Species
 double EnergyModule::interAtomicEnergy(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap)
 {
-    double r, angle;
     SpeciesAtom *i, *j;
     Vec3<double> rI;
-    double scale, energy = 0.0;
+    double r, scale, energy = 0.0;
     const auto cutoff = potentialMap.range();
 
     // Get start/end for loop

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -58,7 +58,7 @@ double EnergyModule::interAtomicEnergy(ProcessPool &procPool, Species *sp, const
         i = sp->atom(indexI);
         rI = i->r();
 
-        for (int indexJ = indexI + 1; indexJ < sp->nAtoms(); ++indexJ)
+        for (auto indexJ = indexI + 1; indexJ < sp->nAtoms(); ++indexJ)
         {
             j = sp->atom(indexJ);
 
@@ -145,7 +145,7 @@ double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Configuration *
 
     std::deque<std::shared_ptr<Molecule>> molecules = cfg->molecules();
     std::shared_ptr<const Molecule> mol;
-    for (int m = start; m < cfg->nMolecules(); m += stride)
+    for (auto m = start; m < cfg->nMolecules(); m += stride)
     {
         // Get Molecule pointer
         mol = molecules[m];

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -97,18 +97,18 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
             Timer testTimer;
 
             // Calculate interatomic energy in a loop over defined Molecules
-            for (int n = 0; n < cfg->nMolecules(); ++n)
+            for (auto n = 0; n < cfg->nMolecules(); ++n)
             {
                 molN = cfg->molecule(n);
 
                 // Molecule self-energy
-                for (int ii = 0; ii < molN->nAtoms() - 1; ++ii)
+                for (auto ii = 0; ii < molN->nAtoms() - 1; ++ii)
                 {
                     i = molN->atom(ii);
 
                     // 					Messenger::print("Atom {} r = {} {} {}\n", ii,
                     // molN->atom(ii)->r().x, molN->atom(ii)->r().y, molN->atom(ii)->r().z);
-                    for (int jj = ii + 1; jj < molN->nAtoms(); ++jj)
+                    for (auto jj = ii + 1; jj < molN->nAtoms(); ++jj)
                     {
                         j = molN->atom(jj);
 
@@ -130,16 +130,16 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 }
 
                 // Molecule-molecule energy
-                for (int m = n + 1; m < cfg->nMolecules(); ++m)
+                for (auto m = n + 1; m < cfg->nMolecules(); ++m)
                 {
                     molM = cfg->molecule(m);
 
                     // Double loop over atoms
-                    for (int ii = 0; ii < molN->nAtoms(); ++ii)
+                    for (auto ii = 0; ii < molN->nAtoms(); ++ii)
                     {
                         i = molN->atom(ii);
 
-                        for (int jj = 0; jj < molM->nAtoms(); ++jj)
+                        for (auto jj = 0; jj < molM->nAtoms(); ++jj)
                         {
                             j = molM->atom(jj);
 

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -48,12 +48,10 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::Exp
                                              double sigma2)
 {
     const auto nAtomTypes = dissolve.nAtomTypes();
-    int i, j;
 
     // Get coefficients array
     Array2D<Array<double>> &coefficients = potentialCoefficients(dissolve, nAtomTypes, ncoeffp);
 
-    i = 0;
     auto result = for_each_pair_early(
         dissolve.atomTypes().begin(), dissolve.atomTypes().end(), [&](int i, auto at1, int j, auto at2) -> EarlyReturn<bool> {
             Array<double> &potCoeff = coefficients.at(i, j);
@@ -107,8 +105,6 @@ Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int i,
     auto ncoeffp = keywords_.asInt("NCoeffP");
     const auto psigma1 = keywords_.asDouble("PSigma1");
     const auto psigma2 = keywords_.asDouble("PSigma2");
-    const auto qMax = keywords_.asDouble("QMax");
-    const auto qMin = keywords_.asDouble("QMin");
     double rmaxpt = keywords_.asDouble("RMaxPT");
     double rminpt = keywords_.asDouble("RMinPT");
 

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -32,7 +32,7 @@ Array2D<Array<double>> &EPSRModule::potentialCoefficients(Dissolve &dissolve, co
         ((ncoeffp != -1) && (ncoeffp != arrayNCoeffP)))
     {
         coefficients.initialise(nAtomTypes, nAtomTypes, true);
-        for (int n = 0; n < coefficients.linearArraySize(); ++n)
+        for (auto n = 0; n < coefficients.linearArraySize(); ++n)
         {
             coefficients.linearArray()[n].initialise(ncoeffp);
             coefficients.linearArray()[n] = 0.0;
@@ -167,7 +167,7 @@ double EPSRModule::absEnergyEP(Dissolve &dissolve)
 
         double cMin = potCoeff.nItems() == 0 ? 0.0 : potCoeff.constAt(0);
         double cMax = cMin;
-        for (int n = 1; n < potCoeff.nItems(); ++n)
+        for (auto n = 1; n < potCoeff.nItems(); ++n)
         {
             if (potCoeff.constAt(n) < cMin)
                 cMin = potCoeff.constAt(n);
@@ -193,7 +193,7 @@ void EPSRModule::truncate(Data1D &data, double rMin, double rMax)
     double x;
     Array<double> &y = data.values();
     const auto decay = rMax - rMin;
-    for (int n = 0; n < data.nValues(); ++n)
+    for (auto n = 0; n < data.nValues(); ++n)
     {
         x = data.xAxis(n);
 

--- a/src/modules/epsr/gui/modulewidget_funcs.cpp
+++ b/src/modules/epsr/gui/modulewidget_funcs.cpp
@@ -420,7 +420,7 @@ void EPSRModuleWidget::updateDebugEPFunctionsGraph(int from, int to)
         viewer->addRenderableToGroup(phi, id);
 
         // Generate data for function range specified
-        for (int n = from; n <= to; ++n)
+        for (auto n = from; n <= to; ++n)
         {
             Data1D *data = debugFunctionData_.add();
             (*data) = module_->generateEmpiricalPotentialFunction(dissolve_, i, j, n);

--- a/src/modules/epsr/gui/modulewidget_funcs.cpp
+++ b/src/modules/epsr/gui/modulewidget_funcs.cpp
@@ -283,8 +283,6 @@ void EPSRModuleWidget::setGraphDataTargets(EPSRModule *module)
     if (!module)
         return;
 
-    int n, m;
-
     // Add total R-Factor before any dataset R-Factors
     auto *rFacTot = rFactorGraph_->createRenderable(Renderable::Data1DRenderable,
                                                     fmt::format("{}//RFactor", module->uniqueName()), "Total", "Total");

--- a/src/modules/epsr/io.cpp
+++ b/src/modules/epsr/io.cpp
@@ -122,7 +122,7 @@ bool EPSRModule::readPCof(Dissolve &dissolve, ProcessPool &procPool, std::string
     auto &potentialCoefficients = GenericListHelper<Array2D<Array<double>>>::realise(
         dissolve.processingModuleData(), "PotentialCoefficients", uniqueName_, GenericItem::InRestartFileFlag);
     potentialCoefficients.initialise(dissolve.nAtomTypes(), dissolve.nAtomTypes(), true);
-    for (int n = 0; n < potentialCoefficients.linearArraySize(); ++n)
+    for (auto n = 0; n < potentialCoefficients.linearArraySize(); ++n)
     {
         potentialCoefficients.linearArray()[n].initialise(ncoeffp);
         potentialCoefficients.linearArray()[n] = 0.0;
@@ -134,7 +134,7 @@ bool EPSRModule::readPCof(Dissolve &dissolve, ProcessPool &procPool, std::string
         return Messenger::error("Failed to read number of pair potentials from pcof file.\n");
     auto nPots = parser.argi(0);
     Messenger::print("Number of potentials in pcof file = {}\n", nPots);
-    for (int n = 0; n < nPots; ++n)
+    for (auto n = 0; n < nPots; ++n)
     {
         // First line of potential contains the two atom types it is related to, and its index (in EPSR)
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
@@ -162,7 +162,7 @@ bool EPSRModule::readPCof(Dissolve &dissolve, ProcessPool &procPool, std::string
         if (parser.nArgs() != ncoeffp)
             return Messenger::error("Number of potential coefficients ({}) does not match ncoeffp ({}).\n", parser.nArgs(),
                                     ncoeffp);
-        for (int i = 0; i < ncoeffp; ++i)
+        for (auto i = 0; i < ncoeffp; ++i)
             coefficients[i] = parser.argd(i);
 
         // Zero the first coefficient, which EPSR ignores

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -342,7 +342,7 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
             deltaSQMax = std::min(x1.lastValue(), simulatedFQ.xAxis().lastValue());
 
         double x;
-        for (int n = 0; n < x1.nItems(); ++n)
+        for (auto n = 0; n < x1.nItems(); ++n)
         {
             // Grab experimental data x value
             x = x1.constAt(n);
@@ -636,7 +636,7 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (procPool.isMaster())
         {
             Data1D *generatedArray = estimatedSQ.linearArray();
-            for (int n = 0; n < estimatedSQ.linearArraySize(); ++n)
+            for (auto n = 0; n < estimatedSQ.linearArraySize(); ++n)
             {
                 // generatedArray[n].save(generatedArray[n].name());
                 Data1DExportFileFormat exportFormat(generatedArray[n].name());
@@ -709,7 +709,7 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 weight *= 0.5;
 
             // Store fluctuation coefficients ready for addition to potential coefficients later on.
-            for (int n = 0; n < ncoeffp; ++n)
+            for (auto n = 0; n < ncoeffp; ++n)
                 fluctuationCoefficients.at(i, j, n) += weight * fitCoefficients.constAt(n);
         });
 
@@ -733,12 +733,12 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
             // Perform smoothing of the fluctuation coefficients before we sum them into the potential (the
             // un-smoothed coefficients are stored)
             Data1D smoothedCoefficients;
-            for (int n = 0; n < ncoeffp; ++n)
+            for (auto n = 0; n < ncoeffp; ++n)
                 smoothedCoefficients.addPoint(n, fluctuationCoefficients.constAt(i, j, n));
             Filters::kolmogorovZurbenko(smoothedCoefficients, 3, 5);
 
             // Add in fluctuation coefficients
-            for (int n = 0; n < ncoeffp; ++n)
+            for (auto n = 0; n < ncoeffp; ++n)
                 potCoeff[n] += weighting * smoothedCoefficients.value(n);
 
             // Set first term to zero (following EPSR)
@@ -832,7 +832,7 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
                               LineParser fileParser;
                               if (!fileParser.openOutput(fmt::format("PCof-{}-{}.txt", at1->name(), at2->name())))
                                   return procPool.decideFalse();
-                              for (int n = 0; n < potCoeff.nItems(); ++n)
+                              for (auto n = 0; n < potCoeff.nItems(); ++n)
                                   if (!fileParser.writeLineF("{}\n", potCoeff[n]))
                                       return procPool.decideFalse();
                               fileParser.closeFiles();

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -33,7 +33,7 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, 
     auto start = procPool.interleavedLoopStart(strategy);
     auto stride = procPool.interleavedLoopStride(strategy);
 
-    for (int cellId = start; cellId < cellArray.nCells(); cellId += stride)
+    for (auto cellId = start; cellId < cellArray.nCells(); cellId += stride)
     {
         cell = cellArray.cell(cellId);
 
@@ -75,7 +75,7 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, 
 
     // Loop over supplied atom indices
     const DynamicArray<Atom> &atoms = cfg->atoms();
-    for (int n = start; n < targetIndices.nItems(); n += stride)
+    for (auto n = start; n < targetIndices.nItems(); n += stride)
     {
         const Atom *i = atoms.constValue(targetIndices.constAt(n));
 
@@ -96,7 +96,7 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Species *sp, const P
     {
         auto *i = sp->atom(indexI);
 
-        for (int indexJ = indexI + 1; indexJ < sp->nAtoms(); ++indexJ)
+        for (auto indexJ = indexI + 1; indexJ < sp->nAtoms(); ++indexJ)
         {
             j = sp->atom(indexJ);
 
@@ -148,7 +148,7 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
 
     // Loop over supplied atom indices
     const DynamicArray<Atom> &atoms = cfg->atoms();
-    for (int n = start; n < targetIndices.nItems(); n += stride)
+    for (auto n = start; n < targetIndices.nItems(); n += stride)
     {
         const Atom *i = atoms.constValue(targetIndices.constAt(n));
         const SpeciesAtom *spAtom = i->speciesAtom();
@@ -198,7 +198,7 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
     // Loop over Molecules
     std::deque<std::shared_ptr<Molecule>> molecules = cfg->molecules();
     std::shared_ptr<const Molecule> mol;
-    for (int m = start; m < cfg->nMolecules(); m += stride)
+    for (auto m = start; m < cfg->nMolecules(); m += stride)
     {
         // Get Molecule pointer
         mol = molecules[m];
@@ -339,11 +339,11 @@ void ForcesModule::totalForces(ProcessPool &procPool, Configuration *cfg,
     // TODO Calculating forces for whole molecule at once may be more efficient
     // TODO Partitioning atoms of target molecules into cells and running a distributor may be more efficient
     Array<int> indices;
-    for (int n = 0; n < targetMolecules.nItems(); ++n)
+    for (auto n = 0; n < targetMolecules.nItems(); ++n)
     {
         std::shared_ptr<Molecule> mol = targetMolecules.constAt(n);
 
-        for (int i = 0; i < mol->nAtoms(); ++i)
+        for (auto i = 0; i < mol->nAtoms(); ++i)
         {
             indices.add(mol->atom(i)->arrayIndex());
         }

--- a/src/modules/geomopt/geomopt.h
+++ b/src/modules/geomopt/geomopt.h
@@ -111,7 +111,7 @@ class GeometryOptimisationModule : public Module
         Vec3<int> order(1, xyLargest ? 0 : 2, xyLargest ? 2 : 0);
 
         // Check each energy to see if our new energy is lower. If it is, overwrite it and recurse
-        for (int n = 0; n < 3; ++n)
+        for (auto n = 0; n < 3; ++n)
         {
             if (eNew < energies[order[n]])
             {
@@ -246,7 +246,7 @@ class GeometryOptimisationModule : public Module
                          stepSize);
 
         auto nStepSizeResets = 0;
-        for (int cycle = 1; cycle <= nCycles_; ++cycle)
+        for (auto cycle = 1; cycle <= nCycles_; ++cycle)
         {
             // Copy current target coordinates as our reference (they will be modified by lineMinimise())
             setReferenceCoordinates(target);

--- a/src/modules/md/functions.cpp
+++ b/src/modules/md/functions.cpp
@@ -10,7 +10,7 @@ int MDModule::capForces(Configuration *cfg, double maxForce, Array<double> &fx, 
     double fMag;
     const auto maxForceSq = maxForce * maxForce;
     auto nCapped = 0;
-    for (int n = 0; n < cfg->nAtoms(); ++n)
+    for (auto n = 0; n < cfg->nAtoms(); ++n)
     {
         fMag = fx[n] * fx[n] + fy[n] * fy[n] + fz[n] * fz[n];
         if (fMag < maxForceSq)

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -99,7 +99,7 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         Array<std::shared_ptr<Molecule>> targetMolecules;
         if (restrictToSpecies_.nItems() > 0)
         {
-            for (int n = 0; n < cfg->nMolecules(); ++n)
+            for (auto n = 0; n < cfg->nMolecules(); ++n)
             {
                 std::shared_ptr<Molecule> mol = cfg->molecule(n);
                 if (restrictToSpecies_.contains(mol->species()))
@@ -226,7 +226,7 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         }
 
         // Ready to do MD propagation of system
-        for (int step = 1; step <= nSteps; ++step)
+        for (auto step = 1; step <= nSteps; ++step)
         {
             // Variable timestep?
             if (variableTimestep)
@@ -332,7 +332,7 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     }
 
                     // Write Atoms
-                    for (int n = 0; n < cfg->nAtoms(); ++n)
+                    for (auto n = 0; n < cfg->nAtoms(); ++n)
                     {
                         Atom *i = atoms[n];
                         if (!trajParser.writeLineF("{:<3}   {:10.3f}  {:10.3f}  {:10.3f}\n",

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -215,23 +215,6 @@ bool RDFModule::calculateGRCells(ProcessPool &procPool, Configuration *cfg, Part
                     partialSet.fullHistogram(typeI, j->localTypeIndex()).bin(distance);
                 }
             }
-            // 			else
-            // 			{
-            // 				for (ii = 0; ii < nI; ++ii)
-            // 				{
-            // 					i = atomsI[ii];
-            // 					typeI = i->localTypeIndex();
-            // 					rI = i->r();
-            //
-            // 					for (jj = 0; jj < nJ; ++jj)
-            // 					{
-            // 						j = atomsJ[jj];
-            // 						distance = (rI - j->r()).magnitude();
-            // 						partialSet.fullHistogram(typeI,
-            // j->localTypeIndex()).bin(distance);
-            // 					}
-            // 				}
-            // 			}
         }
     }
 

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -145,7 +145,7 @@ bool RDFModule::calculateGRSimple(ProcessPool &procPool, Configuration *cfg, Par
     }
 
     // Delete temporary arrays
-    for (int n = 0; n < nTypes; ++n)
+    for (auto n = 0; n < nTypes; ++n)
     {
         delete[] r[n];
         delete[] binss[n];
@@ -310,7 +310,7 @@ bool RDFModule::calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule
 
     // Loop over molecules...
     Atom *i, *j;
-    for (int m = start; m < cfg->nMolecules(); m += stride)
+    for (auto m = start; m < cfg->nMolecules(); m += stride)
     {
         std::shared_ptr<Molecule> mol = cfg->molecule(m);
         std::vector<Atom *> atoms = mol->atoms();
@@ -392,9 +392,9 @@ bool RDFModule::calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg,
         unweightedgr = originalgr;
     else
     {
-        for (int i = 0; i < unweightedgr.nAtomTypes(); ++i)
+        for (auto i = 0; i < unweightedgr.nAtomTypes(); ++i)
         {
-            for (int j = i; j < unweightedgr.nAtomTypes(); ++j)
+            for (auto j = i; j < unweightedgr.nAtomTypes(); ++j)
             {
                 unweightedgr.boundPartial(i, j).copyArrays(originalgr.boundPartial(i, j));
                 unweightedgr.unboundPartial(i, j).copyArrays(originalgr.unboundPartial(i, j));
@@ -405,9 +405,9 @@ bool RDFModule::calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg,
     }
 
     // Remove bound partial from full partial
-    for (int i = 0; i < unweightedgr.nAtomTypes(); ++i)
+    for (auto i = 0; i < unweightedgr.nAtomTypes(); ++i)
     {
-        for (int j = i; j < unweightedgr.nAtomTypes(); ++j)
+        for (auto j = i; j < unweightedgr.nAtomTypes(); ++j)
             unweightedgr.partial(i, j) -= originalgr.boundPartial(i, j);
     }
 
@@ -479,9 +479,9 @@ bool RDFModule::calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg,
         // 			// Add contributions from this SpeciesIntra only
         // 			std::shared_ptr<const Molecule>* molecules = cfg->molecules().array();
         // 			std::shared_ptr<const Molecule> mol;
-        // 			for (int n=0; n<molecules.nItems(); ++n, mol = molecules.at(n))
+        // 			for (auto n=0; n<molecules.nItems(); ++n, mol = molecules.at(n))
         // 			{
-        // 				for (int n=bondPointers.nItems()-1; n>=0; --n)
+        // 				for (auto n=bondPointers.nItems()-1; n>=0; --n)
         // 				{
         // 					Bond* b = bondPointers[n];
         // 					if (b->speciesBond()->parameterSource() != intra) continue;
@@ -507,7 +507,7 @@ bool RDFModule::calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg,
         // i=0; i<tempgr.nAtomTypes(); ++i, typeI = typeI->next())
         // 			{
         // 				typeJ = typeI;
-        // 				for (int j=i; j<tempgr.nAtomTypes(); ++j, typeJ = typeJ->next())
+        // 				for (auto j=i; j<tempgr.nAtomTypes(); ++j, typeJ = typeJ->next())
         // 				{
         // 					if (tempgr.isBoundPartialEmpty(i, j)) continue;
         //
@@ -535,11 +535,11 @@ bool RDFModule::calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg,
         // 		PointerArray<Angle> anglePointers;
         // 		anglePointers.initialise(cfg->nAngles());
         // 		Angle** angles = cfg->angles().array();
-        // 		for (int n=0; n<cfg->nAngles(); ++n) anglePointers.append(angles[n]);
+        // 		for (auto n=0; n<cfg->nAngles(); ++n) anglePointers.append(angles[n]);
         //
         // 		// 1) Assemble a list of unique (in terms of parameters) SpeciesIntra pointers, accompanied by
         // their associated SpeciesBond 		RefDataList<SpeciesIntra,SpeciesAngle*> angleIntra;
-        // for (int n=0; n<cfg->nAngles(); ++n)
+        // for (auto n=0; n<cfg->nAngles(); ++n)
         // 		{
         // 			SpeciesAngle* sa = angles[n]->speciesAngle();
         // 			angleIntra.addUnique(sa->parameterSource(), sa);
@@ -554,7 +554,7 @@ bool RDFModule::calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg,
         // 			tempgr.reset();
         //
         // 			// Add contributions from this SpeciesIntra only
-        // 			for (int n=anglePointers.nItems()-1; n>=0; --n)
+        // 			for (auto n=anglePointers.nItems()-1; n>=0; --n)
         // 			{
         // 				Angle* a = anglePointers[n];
         // 				if (a->speciesAngle()->parameterSource() != intra) continue;
@@ -580,7 +580,7 @@ bool RDFModule::calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg,
         // i=0; i<tempgr.nAtomTypes(); ++i, typeI = typeI->next())
         // 			{
         // 				typeJ = typeI;
-        // 				for (int j=i; j<tempgr.nAtomTypes(); ++j, typeJ = typeJ->next())
+        // 				for (auto j=i; j<tempgr.nAtomTypes(); ++j, typeJ = typeJ->next())
         // 				{
         // 					if (tempgr.isBoundPartialEmpty(i, j)) continue;
         //

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -158,7 +158,7 @@ bool RDFModule::calculateGRSimple(ProcessPool &procPool, Configuration *cfg, Par
 bool RDFModule::calculateGRCells(ProcessPool &procPool, Configuration *cfg, PartialSet &partialSet, const double rdfRange)
 {
     Atom *i, *j;
-    int n, m, ii, jj, nI, nJ, typeI;
+    int n, m, typeI;
     Cell *cellI, *cellJ;
     double distance;
     Vec3<double> rI;
@@ -301,7 +301,6 @@ bool RDFModule::calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule
 
     double distance;
     const Box *box = cfg->box();
-    CellArray &cellArray = cfg->cells();
 
     // Set start/stride for parallel loop (pool solo)
     auto start = (method == RDFModule::TestMethod ? 0 : procPool.interleavedLoopStart(ProcessPool::PoolStrategy));
@@ -310,7 +309,7 @@ bool RDFModule::calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule
     timer.start();
 
     // Loop over molecules...
-    Atom *i, *j, *k;
+    Atom *i, *j;
     for (int m = start; m < cfg->nMolecules(); m += stride)
     {
         std::shared_ptr<Molecule> mol = cfg->molecule(m);
@@ -435,12 +434,6 @@ bool RDFModule::calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg,
          * according to the PairBroadeningFunction 4) Sum the broadened version back into the bound partial in
          * 'unweightedgr'
          */
-
-        Atom *i, *j, *k;
-
-        double distance;
-        const Box *box = cfg->box();
-        CellArray &cellArray = cfg->cells();
 
         // Set up working PartialSets to use when calculating our g(r)
         PartialSet tempgr, broadgr = unweightedgr;

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -101,7 +101,7 @@ bool RDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
             Averaging::average<PartialSet>(cfg->moduleData(), "OriginalGR", uniqueName_, averaging, averagingScheme);
 
             // Need to rename data within the contributing datasets to avoid clashes with the averaged data
-            for (int n = averaging; n > 0; --n)
+            for (auto n = averaging; n > 0; --n)
             {
                 if (!cfg->moduleData().contains(fmt::format("OriginalGR_{}", n), uniqueName_))
                     continue;

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -31,7 +31,6 @@ bool RDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
     const auto useHalfCellRange = keywords_.asBool("UseHalfCellRange");
     const auto specifiedRange = keywords_.asDouble("Range");
     const auto binWidth = keywords_.asDouble("BinWidth");
-    const bool allIntra = true;
     const bool internalTest = keywords_.asBool("InternalTest");
     const bool saveData = keywords_.asBool("Save");
     const auto smoothing = keywords_.asInt("Smoothing");

--- a/src/modules/refine/functions.cpp
+++ b/src/modules/refine/functions.cpp
@@ -35,7 +35,7 @@ Data1D RefineModule::calculateCR(const Data1D &sq, double normFactor, double rMi
     while (omega <= rMax)
     {
         ft = 0.0;
-        for (int m = 0; m < nQ; ++m)
+        for (auto m = 0; m < nQ; ++m)
         {
             // Get window value at this point in the function
             window = windowFunction.y(sq.constXAxis(m), omega);
@@ -354,7 +354,7 @@ double RefineModule::costFunction2Exp(const Array<double> &alpha)
 // Sum fitting equation with the specified parameters into the specified Data1D
 void RefineModule::sumFitEquation(Data1D &target, double xCentre, double delta, double width, double AL, double AC, double AR)
 {
-    for (int n = 0; n < target.nValues(); ++n)
+    for (auto n = 0; n < target.nValues(); ++n)
         target.value(n) += fitEquation(target.xAxis(n), xCentre, delta, width, AL, AC, AR);
 }
 

--- a/src/modules/refine/functions.cpp
+++ b/src/modules/refine/functions.cpp
@@ -70,8 +70,8 @@ bool RefineModule::modifyBondTerms(CoreData &coreData, const Data1D &deltaGR, st
     // exp(-(((x-r)-delta)**2)/width**2)-exp(-(((x-r)+delta)**2)/width**2) w l
 
     // Scan through master bond terms searching for those that involve the AtomTypes specified
-    const auto idI = typeI->index();
-    const auto idJ = typeJ->index();
+    //     const auto idI = typeI->index();
+    //     const auto idJ = typeJ->index();
     RefList<MasterIntra> masterBonds;
     // 	for (MasterIntra* b = coreData.masterBonds().first(); b != nullptr; b = b->next()) if (b->usageCount(idI, idJ) > 0)
     // masterBonds.append(b);

--- a/src/modules/refine/gui/modulewidget_funcs.cpp
+++ b/src/modules/refine/gui/modulewidget_funcs.cpp
@@ -207,8 +207,6 @@ void RefineModuleWidget::setGraphDataTargets(RefineModule *module)
     if (!module)
         return;
 
-    int n, m;
-
     // Loop over groups
     ListIterator<ModuleGroup> groupIterator(module_->groupedTargets().groups());
     while (ModuleGroup *group = groupIterator.iterate())
@@ -305,7 +303,7 @@ void RefineModuleWidget::setGraphDataTargets(RefineModule *module)
              */
 
             // Generated potential
-            Renderable *deltaPhiR = deltaPhiRGraph_->createRenderable(
+            deltaPhiRGraph_->createRenderable(
                 Renderable::Data1DRenderable,
                 fmt::format("{}//DeltaPhiR//{}//{}//Full", module_->uniqueName(), group->name(), atomTypes),
                 fmt::format("DeltaPhiR//{}//{}", group->name(), atomTypes), fmt::format("{} dphi(r)", id));

--- a/src/modules/refine/process.cpp
+++ b/src/modules/refine/process.cpp
@@ -436,7 +436,7 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
             Data1D refSQTrimmed;
             double x;
-            for (int n = 0; n < x1.nItems(); ++n)
+            for (auto n = 0; n < x1.nItems(); ++n)
             {
                 x = x1.constAt(n);
                 if (x < deltaSQMin)
@@ -624,7 +624,7 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     // possibility to get NaNs when taking the ln later on
 
                     /*
-                    for (int n=0; n<dGR.nPoints(); ++n) crgr.add(cr.y(n) / (fabs(dGR.y(n)-1.0)+1.0));
+                    for (auto n=0; n<dGR.nPoints(); ++n) crgr.add(cr.y(n) / (fabs(dGR.y(n)-1.0)+1.0));
 
                     scaleFactor = crgr.maxAbs() * 1.01;
                     if (scaleFactor < 1.0) scaleFactor = 1.01;
@@ -633,12 +633,12 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     crgr /= scaleFactor;
 
                     // Original PY
-                  // 					for (int n=0; n<deltaGR.nPoints(); ++n)
+                  // 					for (auto n=0; n<deltaGR.nPoints(); ++n)
                   dU.addPoint(deltaGR.x(n), log(1.0
                   - cr.y(n)/(deltaGR.y(n)+1.0));
 
                     // Modified PY
-                    for (int n=0; n<dGR.nPoints(); ++n) dPhiR.addPoint(dGR.x(n), log(1.0 - crgr[n]));
+                    for (auto n=0; n<dGR.nPoints(); ++n) dPhiR.addPoint(dGR.x(n), log(1.0 - crgr[n]));
                   //cr.y(n) / (fabs(dGR.y(n)-1.0)+1.0)));
 
                     // Rescale the resulting potential to account for the reduction we made earlier
@@ -667,7 +667,7 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
                     cr.arrayY() /= scaleFactor;
 
-                    for (int n=0; n<dGR.nPoints(); ++n) dPhiR.addPoint(dGR.x(n), dGR.y(n) - cr.y(n) - 1.0 -
+                    for (auto n=0; n<dGR.nPoints(); ++n) dPhiR.addPoint(dGR.x(n), dGR.y(n) - cr.y(n) - 1.0 -
                     log(dGR.y(n) + 1.0));
                     */
                 }
@@ -679,7 +679,7 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 const auto truncationStart = minimumRadius - truncationWidth;
                 double r;
                 Array<double> &y = dPhiR.values();
-                for (int n = 0; n < dPhiR.nValues(); ++n)
+                for (auto n = 0; n < dPhiR.nValues(); ++n)
                 {
                     r = dPhiR.xAxis(n);
                     if (r < truncationStart)
@@ -695,7 +695,7 @@ bool RefineModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     Filters::kolmogorovZurbenko(dPhiR, phiRSmoothK, phiRSmoothM);
 
                 // Make sure we go smoothly to zero at the limit of the potential
-                for (int n = 0; n < dPhiR.nValues(); ++n)
+                for (auto n = 0; n < dPhiR.nValues(); ++n)
                     dPhiR.value(n) *= 1.0 - double(n) / (dPhiR.nValues() - 1);
 
                 // Apply factor to additional potential

--- a/src/modules/sanitycheck/process.cpp
+++ b/src/modules/sanitycheck/process.cpp
@@ -51,7 +51,7 @@ bool SanityCheckModule::process(Dissolve &dissolve, ProcessPool &procPool)
         Messenger::printVerbose("Sanity checking Configuration {} atoms...\n", cfg->name());
         if (!procPool.equality(cfg->nAtoms()))
             return Messenger::error("Failed sanity check for Configuration '{}' nAtoms ({}).\n", cfg->name(), cfg->nAtoms());
-        for (int n = 0; n < cfg->nAtoms(); ++n)
+        for (auto n = 0; n < cfg->nAtoms(); ++n)
         {
             auto r = cfg->atom(n)->r();
             if (!procPool.equality(cfg->atom(n)->r()))

--- a/src/modules/sq/functions.cpp
+++ b/src/modules/sq/functions.cpp
@@ -27,9 +27,9 @@ bool SQModule::calculateUnweightedSQ(ProcessPool &procPool, const PartialSet &un
     Timer timer;
     timer.start();
     auto nTypes = unweightedgr.nAtomTypes();
-    for (int n = 0; n < nTypes; ++n)
+    for (auto n = 0; n < nTypes; ++n)
     {
-        for (int m = n; m < nTypes; ++m)
+        for (auto m = n; m < nTypes; ++m)
         {
             // Total partial
             unweightedsq.partial(n, m).copyArrays(unweightedgr.partial(n, m));

--- a/src/modules/sq/gui/modulewidget_funcs.cpp
+++ b/src/modules/sq/gui/modulewidget_funcs.cpp
@@ -140,7 +140,6 @@ bool SQModuleWidget::readState(LineParser &parser)
 void SQModuleWidget::setGraphDataTargets(SQModule *module)
 {
     // Add partials
-    auto n = 0;
     for_each_pair(dissolve_.atomTypes().begin(), dissolve_.atomTypes().end(), [&](int n, auto at1, int m, auto at2) {
         const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
 

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -146,9 +146,9 @@ bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
         //             return false;
         //
         //         // Apply necessary broadening
-        //         for (int i = 0; i < unweightedsq.nAtomTypes(); ++i)
+        //         for (auto i = 0; i < unweightedsq.nAtomTypes(); ++i)
         //         {
-        //             for (int j = i; j < unweightedsq.nAtomTypes(); ++j)
+        //             for (auto j = i; j < unweightedsq.nAtomTypes(); ++j)
         //             {
         //                 // Bragg-specific broadening
         //                 Filters::convolve(braggPartials.at(i, j), braggQBroadening, true);
@@ -160,9 +160,9 @@ bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
         //
         //         // Remove self-scattering level from partials between the same atom type and remove normalisation from
         //         // atomic fractions
-        //         for (int i = 0; i < unweightedsq.nAtomTypes(); ++i)
+        //         for (auto i = 0; i < unweightedsq.nAtomTypes(); ++i)
         //         {
-        //             for (int j = i; j < unweightedsq.nAtomTypes(); ++j)
+        //             for (auto j = i; j < unweightedsq.nAtomTypes(); ++j)
         //             {
         //                 // Subtract self-scattering level if types are equivalent
         //                 if (i == j)
@@ -183,7 +183,7 @@ bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
             auto &partial = unweightedsq.partial(i, j);
             auto &bragg = braggPartials.at(i, j);
 
-            for (int n = 0; n < bound.nValues(); ++n)
+            for (auto n = 0; n < bound.nValues(); ++n)
             {
                 const auto q = bound.xAxis(n);
                 if (q <= braggQMax)
@@ -209,7 +209,7 @@ bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
                                        averagingScheme);
 
         // Need to rename data within the contributing datasets to avoid clashes with the averaged data
-        for (int n = averaging; n > 0; --n)
+        for (auto n = averaging; n > 0; --n)
         {
             if (!dissolve.processingModuleData().contains(fmt::format("UnweightedSQ_{}", n), uniqueName_))
                 continue;

--- a/src/modules/xraysq/functions.cpp
+++ b/src/modules/xraysq/functions.cpp
@@ -74,13 +74,13 @@ bool XRaySQModule::calculateWeightedSQ(const PartialSet &unweightedsq, PartialSe
     if (normalisation == XRaySQModule::SquareOfAverageNormalisation)
     {
         Array<double> bbar = weights.boundCoherentSquareOfAverage(unweightedsq.boundPartial(0, 0).constXAxis());
-        for (int n = 0; n < bbar.nItems(); ++n)
+        for (auto n = 0; n < bbar.nItems(); ++n)
             weightedsq.total().value(n) /= bbar[n];
     }
     else if (normalisation == XRaySQModule::AverageOfSquaresNormalisation)
     {
         Array<double> bbar = weights.boundCoherentAverageOfSquares(unweightedsq.boundPartial(0, 0).constXAxis());
-        for (int n = 0; n < bbar.nItems(); ++n)
+        for (auto n = 0; n < bbar.nItems(); ++n)
             weightedsq.total().value(n) /= bbar[n];
     }
 

--- a/src/neta/ring.cpp
+++ b/src/neta/ring.cpp
@@ -135,7 +135,7 @@ int NETARingNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &
 
     // Loop over rings
     auto nMatches = 0, totalScore = 0;
-    int nodeScore;
+    int nodeScore = NETANode::NoMatch;
     for (auto ring : rings)
     {
         // Check through atoms in the ring - either in order or not - to see if the ring matches

--- a/src/procedure/nodes/addspecies.cpp
+++ b/src/procedure/nodes/addspecies.cpp
@@ -198,7 +198,7 @@ ProcedureNode::NodeExecutionResult AddSpeciesProcedureNode::execute(ProcessPool 
     CoordinateSet *coordSet = sp->coordinateSets().first();
     Matrix3 transform;
     const Box *box = cfg->box();
-    for (int n = 0; n < requestedPopulation; ++n)
+    for (auto n = 0; n < requestedPopulation; ++n)
     {
         // Add the Molecule
         std::shared_ptr<Molecule> mol = cfg->addMolecule(sp, coordSet);

--- a/src/procedure/nodes/calculateangle.cpp
+++ b/src/procedure/nodes/calculateangle.cpp
@@ -43,7 +43,7 @@ ProcedureNode::NodeExecutionResult CalculateAngleProcedureNode::execute(ProcessP
                                                                         std::string_view prefix, GenericList &targetList)
 {
 #ifdef CHECKS
-    for (int n = 0; n < nSitesRequired(); ++n)
+    for (auto n = 0; n < nSitesRequired(); ++n)
     {
         if (sites_[n]->currentSite() == nullptr)
         {

--- a/src/procedure/nodes/calculateaxisangle.cpp
+++ b/src/procedure/nodes/calculateaxisangle.cpp
@@ -61,7 +61,7 @@ ProcedureNode::NodeExecutionResult CalculateAxisAngleProcedureNode::execute(Proc
                                                                             std::string_view prefix, GenericList &targetList)
 {
 #ifdef CHECKS
-    for (int n = 0; n < nSitesRequired(); ++n)
+    for (auto n = 0; n < nSitesRequired(); ++n)
     {
         if (sites_[n]->currentSite() == nullptr)
         {

--- a/src/procedure/nodes/calculatebase.cpp
+++ b/src/procedure/nodes/calculatebase.cpp
@@ -63,7 +63,7 @@ Vec3<double> CalculateProcedureNodeBase::values() const { return value_; }
 bool CalculateProcedureNodeBase::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
 {
     // Check that the sites have been properly defined
-    for (int n = 0; n < nSitesRequired(); ++n)
+    for (auto n = 0; n < nSitesRequired(); ++n)
     {
         sites_[n] = siteKeywords_[n] ? siteKeywords_[n]->node() : nullptr;
         if (!sites_[n])

--- a/src/procedure/nodes/calculatedistance.cpp
+++ b/src/procedure/nodes/calculatedistance.cpp
@@ -40,7 +40,7 @@ ProcedureNode::NodeExecutionResult CalculateDistanceProcedureNode::execute(Proce
                                                                            std::string_view prefix, GenericList &targetList)
 {
 #ifdef CHECKS
-    for (int n = 0; n < nSitesRequired(); ++n)
+    for (auto n = 0; n < nSitesRequired(); ++n)
     {
         if (sites_[n]->currentSite() == nullptr)
         {

--- a/src/procedure/nodes/calculatevector.cpp
+++ b/src/procedure/nodes/calculatevector.cpp
@@ -57,7 +57,7 @@ ProcedureNode::NodeExecutionResult CalculateVectorProcedureNode::execute(Process
                                                                          std::string_view prefix, GenericList &targetList)
 {
 #ifdef CHECKS
-    for (int n = 0; n < nSitesRequired(); ++n)
+    for (auto n = 0; n < nSitesRequired(); ++n)
     {
         if (sites_[n]->currentSite() == nullptr)
         {

--- a/src/procedure/nodes/dynamicsite.cpp
+++ b/src/procedure/nodes/dynamicsite.cpp
@@ -49,7 +49,7 @@ bool DynamicSiteProcedureNode::mustBeNamed() const { return false; }
 void DynamicSiteProcedureNode::generateSites(std::shared_ptr<const Molecule> molecule)
 {
     // Loop over Atoms in the Molecule
-    for (int n = 0; n < molecule->nAtoms(); ++n)
+    for (auto n = 0; n < molecule->nAtoms(); ++n)
     {
         // If the element is listed in our target elements list, add this atom as a site
         if (elements_.contains(molecule->atom(n)->speciesAtom()->element()))

--- a/src/procedure/nodes/fit1d.cpp
+++ b/src/procedure/nodes/fit1d.cpp
@@ -71,7 +71,7 @@ double Fit1DProcedureNode::equationCost(const Array<double> &alpha)
     const auto &x = referenceData_.xAxis();
     const auto &y = referenceData_.values();
     double equationY;
-    for (int n = 0; n < referenceData_.nValues(); ++n)
+    for (auto n = 0; n < referenceData_.nValues(); ++n)
     {
         // Set axis value
         xVariable_->set(x.constAt(n));
@@ -174,7 +174,7 @@ bool Fit1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std
     data.clear();
 
     const auto &x = referenceData_.xAxis();
-    for (int n = 0; n < referenceData_.nValues(); ++n)
+    for (auto n = 0; n < referenceData_.nValues(); ++n)
     {
         // Set axis value
         xVariable_->set(x.constAt(n));

--- a/src/procedure/nodes/fit1d.cpp
+++ b/src/procedure/nodes/fit1d.cpp
@@ -173,9 +173,7 @@ bool Fit1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std
     data.setObjectTag(fmt::format("{}//Fit1D//{}//{}", prefix, cfg->name(), name()));
     data.clear();
 
-    double cost = 0.0;
     const auto &x = referenceData_.xAxis();
-    bool success;
     for (int n = 0; n < referenceData_.nValues(); ++n)
     {
         // Set axis value

--- a/src/procedure/nodes/nodereference.cpp
+++ b/src/procedure/nodes/nodereference.cpp
@@ -11,7 +11,7 @@
 ProcedureNodeReference::ProcedureNodeReference(ProcedureNode *node) : ListItem<ProcedureNodeReference>()
 {
     node_ = node;
-    for (int n = 0; n < ProcedureNode::nNodeTypes; ++n)
+    for (auto n = 0; n < ProcedureNode::nNodeTypes; ++n)
         allowedTypes_[n] = false;
 
     analyseModuleParent_ = nullptr;
@@ -35,7 +35,7 @@ void ProcedureNodeReference::addAllowableNodeType(ProcedureNode::NodeType nt) { 
 // Allow all node types
 void ProcedureNodeReference::setAllowAllNodeTypes()
 {
-    for (int n = 0; n < ProcedureNode::nNodeTypes; ++n)
+    for (auto n = 0; n < ProcedureNode::nNodeTypes; ++n)
         allowedTypes_[n] = true;
 }
 
@@ -51,7 +51,7 @@ void ProcedureNodeReference::operator=(ProcedureNode *node) { node_ = node; }
 void ProcedureNodeReference::operator=(const ProcedureNodeReference &nodeRef)
 {
     node_ = nodeRef.node_;
-    for (int n = 0; n < ProcedureNode::nNodeTypes; ++n)
+    for (auto n = 0; n < ProcedureNode::nNodeTypes; ++n)
         allowedTypes_[n] = nodeRef.allowedTypes_[n];
 }
 

--- a/src/procedure/nodes/operateexpression.cpp
+++ b/src/procedure/nodes/operateexpression.cpp
@@ -38,7 +38,7 @@ bool OperateExpressionProcedureNode::operateData1D(ProcessPool &procPool, Config
     z_->set(0.0);
 
     // Evaluate the expression over all values
-    for (int i = 0; i < x.nItems(); ++i)
+    for (auto i = 0; i < x.nItems(); ++i)
     {
         // Set variables in expression
         x_->set(x.constAt(i));
@@ -61,12 +61,12 @@ bool OperateExpressionProcedureNode::operateData2D(ProcessPool &procPool, Config
     z_->set(0.0);
 
     // Evaluate the expression over all values
-    for (int i = 0; i < x.nItems(); ++i)
+    for (auto i = 0; i < x.nItems(); ++i)
     {
         // Set x value in expression
         x_->set(x.constAt(i));
 
-        for (int j = 0; j < y.nItems(); ++j)
+        for (auto j = 0; j < y.nItems(); ++j)
         {
             // Set y and value in expression
             y_->set(y.constAt(j));
@@ -91,17 +91,17 @@ bool OperateExpressionProcedureNode::operateData3D(ProcessPool &procPool, Config
     z_->set(0.0);
 
     // Evaluate the expression over all values
-    for (int i = 0; i < x.nItems(); ++i)
+    for (auto i = 0; i < x.nItems(); ++i)
     {
         // Set x value in expression
         x_->set(x.constAt(i));
 
-        for (int j = 0; j < y.nItems(); ++j)
+        for (auto j = 0; j < y.nItems(); ++j)
         {
             // Set y value in expression
             y_->set(y.constAt(j));
 
-            for (int k = 0; k < z.nItems(); ++k)
+            for (auto k = 0; k < z.nItems(); ++k)
             {
                 // Set z and  value in expression
                 z_->set(z.constAt(k));

--- a/src/procedure/nodes/operatesphericalshellnormalise.cpp
+++ b/src/procedure/nodes/operatesphericalshellnormalise.cpp
@@ -33,7 +33,7 @@ bool OperateSphericalShellNormaliseProcedureNode::operateData1D(ProcessPool &pro
     // Derive first left-bin boundary from the delta betwen points 0 and 1
     double leftBin = xAxis.constAt(0) - (xAxis.constAt(1) - xAxis.constAt(0)) * 0.5, rightBin, divisor;
     double r1Cubed = pow(leftBin, 3), r2Cubed;
-    for (int n = 0; n < xAxis.nItems(); ++n)
+    for (auto n = 0; n < xAxis.nItems(); ++n)
     {
         // Get new right-bin from existing left bin boundary and current bin centre
         rightBin = leftBin + 2 * (xAxis.constAt(n) - leftBin);

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -205,7 +205,7 @@ ProcedureNode::NodeExecutionResult SelectProcedureNode::execute(ProcessPool &pro
         if (siteStack == nullptr)
             return ProcedureNode::Failure;
 
-        for (int n = 0; n < siteStack->nSites(); ++n)
+        for (auto n = 0; n < siteStack->nSites(); ++n)
         {
             const Site *site = &siteStack->site(n);
 
@@ -246,7 +246,7 @@ ProcedureNode::NodeExecutionResult SelectProcedureNode::execute(ProcessPool &pro
             return ProcedureNode::Failure;
 
         const Array<Site> &generatedSites = dynamicNode->generatedSites();
-        for (int n = 0; n < generatedSites.nItems(); ++n)
+        for (auto n = 0; n < generatedSites.nItems(); ++n)
             sites_.add(&generatedSites.constAt(n));
     }
 

--- a/src/templates/array.h
+++ b/src/templates/array.h
@@ -41,7 +41,7 @@ template <class A> class Array : public ListItem<Array<A>>
         nItems_ = 0;
         initialise(source.size_);
         nItems_ = source.nItems_;
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             array_[n] = source.array_[n];
     }
     void operator=(const Array<A> &source)
@@ -50,7 +50,7 @@ template <class A> class Array : public ListItem<Array<A>>
         clear();
         resize(source.size_);
         nItems_ = source.nItems_;
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             array_[n] = source.array_[n];
     }
     operator A *() { return array_; }
@@ -81,7 +81,7 @@ template <class A> class Array : public ListItem<Array<A>>
         if (nItems_ > 0)
         {
             oldItems = new A[nItems_];
-            for (int n = 0; n < nItems_; ++n)
+            for (auto n = 0; n < nItems_; ++n)
                 oldItems[n] = array_[n];
         }
 
@@ -101,7 +101,7 @@ template <class A> class Array : public ListItem<Array<A>>
         }
 
         // Copy old data into new array
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             array_[n] = oldItems[n];
         delete[] oldItems;
     }
@@ -125,7 +125,7 @@ template <class A> class Array : public ListItem<Array<A>>
         nItems_ = size;
 
         // ...and finally set all elements to default value
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             array_[n] = A();
     }
     // Create empty array of specified size
@@ -149,7 +149,7 @@ template <class A> class Array : public ListItem<Array<A>>
         {
             resize(nItemsToCopy);
             nItems_ = nItemsToCopy;
-            for (int n = 0; n < nItems_; ++n)
+            for (auto n = 0; n < nItems_; ++n)
                 array_[n] = source.array_[n + firstIndex];
         }
     }
@@ -185,7 +185,7 @@ template <class A> class Array : public ListItem<Array<A>>
             resize(size_ + chunkSize_);
 
         // Working from the top of the array, shift all items after or at 'position' up one place
-        for (int n = nItems_; n > position; --n)
+        for (auto n = nItems_; n > position; --n)
             array_[n] = array_[n - 1];
 
         array_[position] = data;
@@ -211,7 +211,7 @@ template <class A> class Array : public ListItem<Array<A>>
             return;
         }
 
-        for (int n = 0; n < nItems_ - 1; ++n)
+        for (auto n = 0; n < nItems_ - 1; ++n)
             array_[n] = array_[n + 1];
 
         --nItems_;
@@ -237,7 +237,7 @@ template <class A> class Array : public ListItem<Array<A>>
             return;
         }
 #endif
-        for (int n = position; n < nItems_ - 1; ++n)
+        for (auto n = position; n < nItems_ - 1; ++n)
             array_[n] = array_[n + 1];
 
         --nItems_;
@@ -379,36 +379,36 @@ template <class A> class Array : public ListItem<Array<A>>
     // Operator= (set all)
     void operator=(const A value)
     {
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             array_[n] = value;
     }
     // Operator+= (add to all)
     void operator+=(const A value)
     {
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             array_[n] += value;
     }
     void operator+=(const Array<A> array)
     {
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             array_[n] += array.constAt(n);
     }
     // Operator-= (subtract from all)
     void operator-=(const A value)
     {
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             array_[n] -= value;
     }
     // Operator*= (multiply all)
     void operator*=(const A value)
     {
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             array_[n] *= value;
     }
     // Operator/= (divide all)
     void operator/=(const A value)
     {
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             array_[n] /= value;
     }
     // Operator- (subtraction)
@@ -421,7 +421,7 @@ template <class A> class Array : public ListItem<Array<A>>
     Array<A> operator-(const Array<A> array)
     {
         Array<A> result(nItems_);
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             result[n] = array_[n] - array.constAt(n);
         return result;
     }
@@ -435,7 +435,7 @@ template <class A> class Array : public ListItem<Array<A>>
     Array<A> operator+(const Array<A> array)
     {
         Array<A> result(nItems_);
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             result[n] = array_[n] + array.constAt(n);
         return result;
     }
@@ -462,7 +462,7 @@ template <class A> class Array : public ListItem<Array<A>>
     A sum()
     {
         A result = 0.0;
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             result += array_[n];
         return result;
     }
@@ -471,7 +471,7 @@ template <class A> class Array : public ListItem<Array<A>>
     {
         A result = 0.0;
         A temp;
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
         {
             temp = array_[n];
             if (temp < 0)

--- a/src/templates/array2d.h
+++ b/src/templates/array2d.h
@@ -49,13 +49,13 @@ template <class A> class Array2D
     void operator=(const A value)
     {
         // Copy source data elements
-        for (int row = 0; row < nRows_; ++row)
+        for (auto row = 0; row < nRows_; ++row)
         {
             if (half_)
-                for (int column = row; column < nColumns_; ++column)
+                for (auto column = row; column < nColumns_; ++column)
                     array_[rowOffsets_[row] + column - row] = value;
             else
-                for (int column = 0; column < nColumns_; ++column)
+                for (auto column = 0; column < nColumns_; ++column)
                     array_[rowOffsets_[row] + column] = value;
         }
     }
@@ -66,13 +66,13 @@ template <class A> class Array2D
         initialise(source.nRows_, source.nColumns_, source.half_);
 
         // Copy source data elements
-        for (int row = 0; row < nRows_; ++row)
+        for (auto row = 0; row < nRows_; ++row)
         {
             if (half_)
-                for (int column = row; column < nColumns_; ++column)
+                for (auto column = row; column < nColumns_; ++column)
                     array_[rowOffsets_[row] + column - row] = source.array_[rowOffsets_[row] + column - row];
             else
-                for (int column = 0; column < nColumns_; ++column)
+                for (auto column = 0; column < nColumns_; ++column)
                     array_[rowOffsets_[row] + column] = source.array_[rowOffsets_[row] + column];
         }
     }
@@ -125,7 +125,7 @@ template <class A> class Array2D
         {
             linearSize_ = nRows_ * nColumns_;
             array_ = new A[linearSize_];
-            for (int n = 0; n < nRows_; ++n)
+            for (auto n = 0; n < nRows_; ++n)
                 rowOffsets_[n] = n * nColumns_;
         }
     }
@@ -170,16 +170,16 @@ template <class A> class Array2D
             initialise(nRows_ + 1, nCols, half_);
 
         // Copy old data back in
-        for (int n = 0; n < oldArray.nRows_; ++n)
+        for (auto n = 0; n < oldArray.nRows_; ++n)
         {
-            for (int m = 0; m < oldArray.nColumns_; ++m)
+            for (auto m = 0; m < oldArray.nColumns_; ++m)
                 at(n, m) = oldArray.at(n, m);
         }
     }
     // Set row
     void setRow(int row, A value)
     {
-        for (int n = 0; n < nColumns_; ++n)
+        for (auto n = 0; n < nColumns_; ++n)
             at(row, n) = value;
     }
     // Return specified element as reference
@@ -315,25 +315,25 @@ template <class A> class Array2D
     // Operator+= (add to all)
     void operator+=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] += value;
     }
     // Operator-= (subtract from all)
     void operator-=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] -= value;
     }
     // Operator*= (multiply all)
     void operator*=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] *= value;
     }
     // Operator/= (divide all)
     void operator/=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] /= value;
     }
     // Operator+= (matrix addition)
@@ -346,7 +346,7 @@ template <class A> class Array2D
                              nColumns_, B.nRows_, B.nColumns_);
             return;
         }
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] += B.constLinearValue(n);
     }
     // Operator-= (matrix subtraction)
@@ -359,7 +359,7 @@ template <class A> class Array2D
                              nColumns_, B.nRows_, B.nColumns_);
             return;
         }
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] -= B.constLinearValue(n);
     }
     // Operator* (matrix multiply)
@@ -376,7 +376,7 @@ template <class A> class Array2D
         Array2D<A> C(nRows_, B.nColumns_);
         int colB, i;
         double x;
-        for (int rowA = 0; rowA < nRows_; ++rowA)
+        for (auto rowA = 0; rowA < nRows_; ++rowA)
         {
             for (colB = 0; colB < B.nColumns_; ++colB)
             {
@@ -400,10 +400,10 @@ template <class A> class Array2D
     void print(std::string_view title = "Array2D<A>") const
     {
         Messenger::print("'{}' : {} rows x {} columns:\n", title, nRows_, nColumns_);
-        for (int row = 0; row < nRows_; ++row)
+        for (auto row = 0; row < nRows_; ++row)
         {
             std::string line;
-            for (int column = 0; column < nColumns_; ++column)
+            for (auto column = 0; column < nColumns_; ++column)
                 line += fmt::format(" {:e}", constAt(row, column));
             Messenger::print("R{:2d} :{}\n", row, line);
         }
@@ -414,9 +414,9 @@ template <class A> class Array2D
     Array2D<A> transposed() const
     {
         Array2D<A> result(nColumns_, nRows_);
-        for (int r = 0; r < nRows_; ++r)
+        for (auto r = 0; r < nRows_; ++r)
         {
-            for (int c = 0; c < nColumns_; ++c)
+            for (auto c = 0; c < nColumns_; ++c)
                 result.at(c, r) = constAt(r, c);
         }
         return result;

--- a/src/templates/array2d.h
+++ b/src/templates/array2d.h
@@ -141,7 +141,7 @@ template <class A> class Array2D
             resize(nrows, ncolumns);
     }
     // Add empty row to array
-    void addRow(int nCols = -1)
+    void addRow(std::optional<unsigned int> nCols = std::nullopt)
     {
         // Copy current Array
         Array2D<A> oldArray = *this;
@@ -150,7 +150,7 @@ template <class A> class Array2D
         if (nColumns_ == 0)
         {
             // Must have been supplied the column size if we currently have no data
-            if (nCols == -1)
+            if (!nCols)
             {
                 Messenger::error("Array2D<A>::addRow() - Array is currently empty, so column size must be provided.\n");
                 return;
@@ -160,14 +160,14 @@ template <class A> class Array2D
             nCols = nColumns_;
 
         // Reinitialise the present matrix to the new size
-        if (half_ && (nRows_ == nCols))
+        if (half_ && (nRows_ == nCols.value()))
         {
             Messenger::warn("Adding a row to this Array2D<A> will force it to be rectangular, so it will no longer "
                             "be halved.\n");
-            initialise(nRows_ + 1, nCols, false);
+            initialise(nRows_ + 1, nCols.value(), false);
         }
         else
-            initialise(nRows_ + 1, nCols, half_);
+            initialise(nRows_ + 1, nCols.value(), half_);
 
         // Copy old data back in
         for (auto n = 0; n < oldArray.nRows_; ++n)

--- a/src/templates/array2d.h
+++ b/src/templates/array2d.h
@@ -6,6 +6,7 @@
 #include "base/messenger.h"
 #include "templates/list.h"
 #include "templates/vector3.h"
+#include <optional>
 
 // Array2D
 template <class A> class Array2D

--- a/src/templates/array3d.h
+++ b/src/templates/array3d.h
@@ -50,7 +50,7 @@ template <class A> class Array3D
     void operator=(const A value)
     {
         // Copy source data elements
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] = value;
     }
     void operator=(const Array3D<A> &source)
@@ -59,7 +59,7 @@ template <class A> class Array3D
         clear();
         initialise(source.nX_, source.nY_, source.nZ_);
 
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] = source.array_[n];
     }
 
@@ -92,7 +92,7 @@ template <class A> class Array3D
 
         // Create slice offsets array
         sliceOffsets_ = new int[nZ_];
-        for (int n = 0; n < nZ_; ++n)
+        for (auto n = 0; n < nZ_; ++n)
             sliceOffsets_[n] = n * nX_ * nY_;
     }
 
@@ -220,25 +220,25 @@ template <class A> class Array3D
     // Operator+= (add to all)
     void operator+=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] += value;
     }
     // Operator-= (subtract from all)
     void operator-=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] -= value;
     }
     // Operator*= (multiply all)
     void operator*=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] *= value;
     }
     // Operator/= (divide all)
     void operator/=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] /= value;
     }
 };
@@ -295,7 +295,7 @@ template <class A> class OffsetArray3D
     void operator=(const A value)
     {
         // Copy source data elements
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] = value;
     }
     void operator=(const Array3D<A> &source)
@@ -304,7 +304,7 @@ template <class A> class OffsetArray3D
         clear();
         initialise(source.nX_, source.nY_, source.nZ_);
 
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] = source.array_[n];
     }
 
@@ -346,7 +346,7 @@ template <class A> class OffsetArray3D
 
             // Create slice offsets array
             sliceOffsets_ = new int[nZ_];
-            for (int n = 0; n < nZ_; ++n)
+            for (auto n = 0; n < nZ_; ++n)
                 sliceOffsets_[n] = n * nX_ * nY_;
         }
     }
@@ -485,25 +485,25 @@ template <class A> class OffsetArray3D
     // Operator+= (add to all)
     void operator+=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] += value;
     }
     // Operator-= (subtract from all)
     void operator-=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] -= value;
     }
     // Operator*= (multiply all)
     void operator*=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] *= value;
     }
     // Operator/= (divide all)
     void operator/=(const A value)
     {
-        for (int n = 0; n < linearSize_; ++n)
+        for (auto n = 0; n < linearSize_; ++n)
             array_[n] /= value;
     }
 };

--- a/src/templates/broadcastarray.h
+++ b/src/templates/broadcastarray.h
@@ -23,7 +23,7 @@ template <class T> class BroadcastArray
             count = array.nItems();
             if (!procPool.broadcast(count, root))
                 return;
-            for (int n = 0; n < count; ++n)
+            for (auto n = 0; n < count; ++n)
                 array[n].broadcast(procPool, root, coreData);
         }
         else
@@ -34,7 +34,7 @@ template <class T> class BroadcastArray
 
             // Clear list and reconstruct
             array.initialise(count);
-            for (int n = 0; n < count; ++n)
+            for (auto n = 0; n < count; ++n)
                 array[n].broadcast(procPool, root, coreData);
         }
 

--- a/src/templates/broadcastlist.h
+++ b/src/templates/broadcastlist.h
@@ -40,7 +40,7 @@ template <class T> class BroadcastList
 
             // Clear list and reconstruct
             items.clear();
-            for (int n = 0; n < count; ++n)
+            for (auto n = 0; n < count; ++n)
             {
                 // Slaves must create a suitable structure first, and then join the broadcast
                 T *item = items.add();

--- a/src/templates/broadcastvector.h
+++ b/src/templates/broadcastvector.h
@@ -39,7 +39,7 @@ template <class T> class BroadcastVector
 
             // Clear list and reconstruct
             items.clear();
-            for (int n = 0; n < count; ++n)
+            for (auto n = 0; n < count; ++n)
             {
                 // Slaves must create a suitable structure first, and then join the broadcast
                 items.emplace_back();

--- a/src/templates/dynamicarray.h
+++ b/src/templates/dynamicarray.h
@@ -89,7 +89,7 @@ template <class T> class ArrayChunk : public ListItem<ArrayChunk<T>>
         }
 
         objectSize_ = sizeof(T);
-        for (int n = 0; n < nObjects_; ++n)
+        for (auto n = 0; n < nObjects_; ++n)
             objectUsed_[n] = false;
         nextAvailableObject_ = 0;
         nUnusedObjects_ = nObjects_;
@@ -99,7 +99,7 @@ template <class T> class ArrayChunk : public ListItem<ArrayChunk<T>>
     // Clear entire chunk
     void clear()
     {
-        for (int n = 0; n < nObjects_; ++n)
+        for (auto n = 0; n < nObjects_; ++n)
         {
             objectArray_[n].clear();
             objectUsed_[n] = false;
@@ -274,7 +274,7 @@ template <class T> class DynamicArray
     {
         array_.initialise(nItems);
         T *newItem;
-        for (int n = 0; n < nItems; ++n)
+        for (auto n = 0; n < nItems; ++n)
         {
             newItem = produce();
             newItem->setArrayIndex(n);
@@ -298,7 +298,7 @@ template <class T> class DynamicArray
     void add(int count)
     {
         T *newItem;
-        for (int n = 0; n < count; ++n)
+        for (auto n = 0; n < count; ++n)
         {
             newItem = produce();
             newItem->setArrayIndex(array_.nItems());
@@ -353,7 +353,7 @@ template <class T> class DynamicArray
     // Return whether the specified object pointer is in the array
     bool contains(const T *object)
     {
-        for (int n = 0; n < array_.nItems(); ++n)
+        for (auto n = 0; n < array_.nItems(); ++n)
             if (array_.constAt(n) == object)
                 return true;
 
@@ -362,7 +362,7 @@ template <class T> class DynamicArray
     // Return index of the specified object pointer (if it exists in the array)
     bool indexOf(const T *object)
     {
-        for (int n = 0; n < array_.nItems(); ++n)
+        for (auto n = 0; n < array_.nItems(); ++n)
             if (array_.constAt(n) == object)
                 return n;
 

--- a/src/templates/factory.h
+++ b/src/templates/factory.h
@@ -124,7 +124,7 @@ template <class T> class ObjectChunk : public ListItem<ObjectChunk<T>>
     // Mark all objects as unused
     void markAllObjectsUnused()
     {
-        for (int n = 0; n < nObjects_; ++n)
+        for (auto n = 0; n < nObjects_; ++n)
             objectUsed_[n] = false;
         nextAvailableObject_ = 0;
         nUnusedObjects_ = nObjects_;

--- a/src/templates/list.h
+++ b/src/templates/list.h
@@ -110,7 +110,7 @@ template <class T> class List
     void createEmpty(int size)
     {
         clear();
-        for (int n = 0; n < size; ++n)
+        for (auto n = 0; n < size; ++n)
             add();
         regenerate_ = true;
     }
@@ -619,7 +619,7 @@ template <class T> class List
         }
         // Get pointer to item that we're moving and shift it
         T *olditem = array()[target];
-        for (int n = 0; n < abs(delta); n++)
+        for (auto n = 0; n < abs(delta); n++)
             (delta < 0 ? shiftUp(olditem) : shiftDown(olditem));
         // Flag for regeneration
         regenerate_ = true;

--- a/src/templates/orderedlist.h
+++ b/src/templates/orderedlist.h
@@ -530,9 +530,9 @@ void OrderedList<T>::difference(OrderedList<T> &listB, OrderedList<T> &uniqueToA
     }
 
     // If we have not yet gone through all the items in either list, add them to the relevant unique results list
-    for (int n = indexA; n < nItems_; ++n)
+    for (auto n = indexA; n < nItems_; ++n)
         uniqueToA.addAtEnd(itemsA[n]);
-    for (int n = indexB; n < listB.nItems_; ++n)
+    for (auto n = indexB; n < listB.nItems_; ++n)
         uniqueToB.addAtEnd(itemsB[n]);
 }
 

--- a/src/templates/orderedpointerdataarray.h
+++ b/src/templates/orderedpointerdataarray.h
@@ -43,7 +43,7 @@ template <class T, class D> class OrderedPointerDataArray
 
         initialise(source.nItems());
 
-        for (int n = 0; n < source.nItems(); ++n)
+        for (auto n = 0; n < source.nItems(); ++n)
             add(source.value(n), source.data(n));
 
         return *this;
@@ -106,7 +106,7 @@ template <class T, class D> class OrderedPointerDataArray
             data_ = new D[arraySize_];
         }
 
-        for (int n = 0; n < arraySize_; ++n)
+        for (auto n = 0; n < arraySize_; ++n)
         {
             items_[n] = nullptr;
             data_[n] = D();
@@ -238,14 +238,14 @@ template <class T, class D> class OrderedPointerDataArray
     bool remove(T *ptr)
     {
         // Step through the items until we find the specified pointer
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
         {
             if (items_[n] > ptr)
                 return false;
             if (items_[n] == ptr)
             {
                 // Found it. Move all items from this point forward back one place
-                for (int m = n + 1; m < nItems_; ++m)
+                for (auto m = n + 1; m < nItems_; ++m)
                 {
                     items_[m - 1] = items_[m];
                     data_[m - 1] = data_[m];
@@ -263,7 +263,7 @@ template <class T, class D> class OrderedPointerDataArray
     // Return array index of pointer within the list
     int indexOf(const T *ptr) const
     {
-        for (int n = 0; n < nItems_; ++n)
+        for (auto n = 0; n < nItems_; ++n)
             if (items_[n] == ptr)
                 return n;
 

--- a/src/templates/orderedpointerdatalist.h
+++ b/src/templates/orderedpointerdatalist.h
@@ -484,9 +484,9 @@ template <class T, class D> class OrderedPointerDataList
         }
 
         // If we have not yet gone through all the items in either list, add them to the relevant unique results list
-        for (int n = indexA; n < nItems_; ++n)
+        for (auto n = indexA; n < nItems_; ++n)
             uniqueToA.addAtEnd(itemsA[n]);
-        for (int n = indexB; n < listB.nItems_; ++n)
+        for (auto n = indexB; n < listB.nItems_; ++n)
             uniqueToB.addAtEnd(itemsB[n]);
     }
 

--- a/src/templates/simplex.h
+++ b/src/templates/simplex.h
@@ -210,7 +210,7 @@ template <class T> class Simplex
     {
         // Shrink vertices of current simplex, leaving only the first (x(1)) as-is: x(n) = x(1) + sigma(x(n) - x(1)),
         // n=2,nalpha+1
-        for (int n = 0; n < nVertices_; ++n)
+        for (auto n = 0; n < nVertices_; ++n)
         {
             if (n == vBest_)
                 continue;
@@ -259,13 +259,13 @@ template <class T> class Simplex
     {
         // Get average cost of all vertices
         double average = 0.0;
-        for (int n = 0; n < nVertices_; ++n)
+        for (auto n = 0; n < nVertices_; ++n)
             average += costs_[n];
         average /= nVertices_;
 
         // Now calculate SD of individual costs with mean value
         double serror = 0.0;
-        for (int n = 0; n < nVertices_; ++n)
+        for (auto n = 0; n < nVertices_; ++n)
             serror += (costs_[n] - average) * (costs_[n] - average);
         return sqrt(serror / nVertices_);
     }
@@ -276,7 +276,7 @@ template <class T> class Simplex
     // Print vertex information
     void printVertexInformation()
     {
-        for (int n = 0; n < nVertices_; ++n)
+        for (auto n = 0; n < nVertices_; ++n)
             Messenger::print("[SMPLX]\t\tVertex {} has cold cost value = {:12.6e}\n", n, costs_[n]);
     }
 


### PR DESCRIPTION
THis PR attempts to win the award for the most boring piece of work so far, and deals with:

- Removing all warnings associated with unused variables.
- Removing many warnings associated to comparison between signed and unsigned ints.
- Replaces some magic numbers with `std::optional` where appropriate.
- Fixes some initialisation order warnings, and moves to initialiser lists where appropriate.
- Removes a couple of other errors related to polymorphic class destructors and potential variable use when uninitialised.
- Sprinkles many `auto` in `for` loops.

Not all signed/unsigned int warnings are removed, since some required more fundamental changes to classes beyond the scope of this PR (e.g. `Module::nTargetConfigurations()`).

**Builds on #412 - do not merge until #412 is resolved.**
