### PR TITLE
Bugfix 02/11/20 - Enum return and for_each_pair_early

### DIFF
--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -108,21 +108,25 @@ bool BraggModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
             // Save intensity data
             auto &types = cfg->usedAtomTypesList();
-            for_each_pair(types.begin(), types.end(), [&](int i, const AtomTypeData &atd1, int j, const AtomTypeData &atd2) {
-                LineParser intensityParser(&procPool);
-                if (!intensityParser.openOutput(
-                        fmt::format("{}-Bragg-{}-{}.txt", cfg->niceName(), atd1.atomTypeName(), atd2.atomTypeName())))
-                    return false;
-                intensityParser.writeLineF("#     Q      Intensity({},{})\n", atd1.atomTypeName(), atd2.atomTypeName());
-                for (int n = 0; n < braggReflections.nItems(); ++n)
-                {
-                    if (!intensityParser.writeLineF("{:10.6f}  {:10.6e}\n", braggReflections.constAt(n).q(),
-                                                    braggReflections.constAt(n).intensity(i, j)))
+            for_each_pair_early(
+                types.begin(), types.end(),
+                [&](int i, const AtomTypeData &atd1, int j, const AtomTypeData &atd2) -> EarlyReturn<bool> {
+                    LineParser intensityParser(&procPool);
+                    if (!intensityParser.openOutput(
+                            fmt::format("{}-Bragg-{}-{}.txt", cfg->niceName(), atd1.atomTypeName(), atd2.atomTypeName())))
                         return false;
                     intensityParser.writeLineF("#     Q      Intensity({},{})\n", atd1.atomTypeName(), atd2.atomTypeName());
-                }
-                intensityParser.closeFiles();
-            });
+                    for (int n = 0; n < braggReflections.nItems(); ++n)
+                    {
+                        if (!intensityParser.writeLineF("{:10.6f}  {:10.6e}\n", braggReflections.constAt(n).q(),
+                                                        braggReflections.constAt(n).intensity(i, j)))
+                            return false;
+                        intensityParser.writeLineF("#     Q      Intensity({},{})\n", atd1.atomTypeName(), atd2.atomTypeName());
+                    }
+                    intensityParser.closeFiles();
+
+                    return EarlyReturn<bool>::Continue;
+                });
         }
     }
 

--- a/src/modules/epsr/io.cpp
+++ b/src/modules/epsr/io.cpp
@@ -22,6 +22,10 @@ EnumOptions<EPSRModule::EPSRPCofKeyword> &EPSRModule::epsrPCofKeywords()
         << EnumOption(EPSRModule::RepPotTypePCofKeyword, "reppottype") << EnumOption(EPSRModule::RMaxPtPCofKeyword, "rmaxpt")
         << EnumOption(EPSRModule::RMinFacPCofKeyword, "rminfac") << EnumOption(EPSRModule::RMinPtPCofKeyword, "rminpt")
         << EnumOption(EPSRModule::ROverlapPCofKeyword, "roverlap");
+
+    static EnumOptions<EPSRModule::EPSRPCofKeyword> options("PCOFKeywords", PCOFKeywordOptions);
+
+    return options;
 }
 
 // Read data from supplied pcof file

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -811,34 +811,38 @@ bool RDFModule::testReferencePartials(PartialSet &setA, PartialSet &setB, double
     AtomTypeList atomTypes = setA.atomTypes();
     double error;
 
-    for_each_pair(atomTypes.begin(), atomTypes.end(), [&](int n, const AtomTypeData &typeI, int m, const AtomTypeData &typeJ) {
-        // Full partial
-        error = Error::percent(setA.partial(n, m), setB.partial(n, m));
-        Messenger::print("Test reference full partial '{}-{}' has error of {:7.3f}% with calculated data and is "
-                         "{} (threshold is {:6.3f}%)\n\n",
-                         typeI.atomTypeName(), typeJ.atomTypeName(), error, error <= testThreshold ? "OK" : "NOT OK",
-                         testThreshold);
-        if (error > testThreshold)
-            return false;
+    for_each_pair_early(
+        atomTypes.begin(), atomTypes.end(),
+        [&](int n, const AtomTypeData &typeI, int m, const AtomTypeData &typeJ) -> EarlyReturn<bool> {
+            // Full partial
+            error = Error::percent(setA.partial(n, m), setB.partial(n, m));
+            Messenger::print("Test reference full partial '{}-{}' has error of {:7.3f}% with calculated data and is "
+                             "{} (threshold is {:6.3f}%)\n\n",
+                             typeI.atomTypeName(), typeJ.atomTypeName(), error, error <= testThreshold ? "OK" : "NOT OK",
+                             testThreshold);
+            if (error > testThreshold)
+                return false;
 
-        // Bound partial
-        error = Error::percent(setA.boundPartial(n, m), setB.boundPartial(n, m));
-        Messenger::print("Test reference bound partial '{}-{}' has error of {:7.3f}% with calculated data and "
-                         "is {} (threshold is {:6.3f}%)\n\n",
-                         typeI.atomTypeName(), typeJ.atomTypeName(), error, error <= testThreshold ? "OK" : "NOT OK",
-                         testThreshold);
-        if (error > testThreshold)
-            return false;
+            // Bound partial
+            error = Error::percent(setA.boundPartial(n, m), setB.boundPartial(n, m));
+            Messenger::print("Test reference bound partial '{}-{}' has error of {:7.3f}% with calculated data and "
+                             "is {} (threshold is {:6.3f}%)\n\n",
+                             typeI.atomTypeName(), typeJ.atomTypeName(), error, error <= testThreshold ? "OK" : "NOT OK",
+                             testThreshold);
+            if (error > testThreshold)
+                return false;
 
-        // Unbound reference
-        error = Error::percent(setA.unboundPartial(n, m), setB.unboundPartial(n, m));
-        Messenger::print("Test reference unbound partial '{}-{}' has error of {:7.3f}% with calculated data and "
-                         "is {} (threshold is {:6.3f}%)\n\n",
-                         typeI.atomTypeName(), typeJ.atomTypeName(), error, error <= testThreshold ? "OK" : "NOT OK",
-                         testThreshold);
-        if (error > testThreshold)
-            return false;
-    });
+            // Unbound reference
+            error = Error::percent(setA.unboundPartial(n, m), setB.unboundPartial(n, m));
+            Messenger::print("Test reference unbound partial '{}-{}' has error of {:7.3f}% with calculated data and "
+                             "is {} (threshold is {:6.3f}%)\n\n",
+                             typeI.atomTypeName(), typeJ.atomTypeName(), error, error <= testThreshold ? "OK" : "NOT OK",
+                             testThreshold);
+            if (error > testThreshold)
+                return false;
+
+            return EarlyReturn<bool>::Continue;
+        });
 
     // Total reference data supplied?
     error = Error::percent(setA.total(), setB.total());


### PR DESCRIPTION
This small PR addresses a couple of bugs:

- EnumOptions for potential coefficient keywords were never returned.
- Some Uses of `for_each_pair` have been replaced with `for_each_pair_early` to better suit the application and remove compiler warnings.
