### PR TITLE
Prevent running simulation in the GUI if no file name has been saved.

### DIFF
--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -68,7 +68,8 @@ int main(int args, char **argv)
     DissolveWindow dissolveWindow(dissolve);
 
     // If an input file was specified, load it here
-    if (!dissolveWindow.openLocalFile(options.inputFile().value_or(""), options.restartFilename().value_or(""),
+    if (options.inputFile() &&
+        !dissolveWindow.openLocalFile(options.inputFile().value_or(""), options.restartFilename().value_or(""),
                                       options.ignoreRestartFile(), options.ignoreStateFile()))
     {
         ProcessPool::finalise();
@@ -76,7 +77,7 @@ int main(int args, char **argv)
     }
 
     // Iterate before launching the GUI?
-    if (options.nIterations() > 0)
+    if (options.inputFile() && options.nIterations() > 0)
     {
         // Prepare for run
         if (!dissolve.prepare())

--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -68,25 +68,27 @@ int main(int args, char **argv)
     DissolveWindow dissolveWindow(dissolve);
 
     // If an input file was specified, load it here
-    if (options.inputFile() &&
-        !dissolveWindow.openLocalFile(options.inputFile().value_or(""), options.restartFilename().value_or(""),
-                                      options.ignoreRestartFile(), options.ignoreStateFile()))
+    if (options.inputFile())
     {
-        ProcessPool::finalise();
-        return 1;
-    }
-
-    // Iterate before launching the GUI?
-    if (options.inputFile() && options.nIterations() > 0)
-    {
-        // Prepare for run
-        if (!dissolve.prepare())
+        if (!dissolveWindow.openLocalFile(options.inputFile().value_or(""), options.restartFilename().value_or(""),
+                                          options.ignoreRestartFile(), options.ignoreStateFile()))
+        {
+            ProcessPool::finalise();
             return 1;
+        }
 
-        // Run main simulation
-        auto result = dissolve.iterate(options.nIterations());
-        if (!result)
-            return 1;
+        // Iterate before launching the GUI?
+        if (options.nIterations() > 0)
+        {
+            // Prepare for run
+            if (!dissolve.prepare())
+                return 1;
+
+            // Run main simulation
+            auto result = dissolve.iterate(options.nIterations());
+            if (!result)
+                return 1;
+        }
     }
 
     // Update and show the main window

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -105,6 +105,8 @@ class DissolveWindow : public QMainWindow
     private:
     // Initialise system templates from the main resource
     void initialiseSystemTemplates();
+    // Prepare the simulation and run for a set count
+    void setupIteration(int count);
 
     /*
      * Reference Points

--- a/src/gui/menu_simulation.cpp
+++ b/src/gui/menu_simulation.cpp
@@ -17,7 +17,7 @@ void DissolveWindow::setupIteration(int count)
     // Ensure that the simulation can run
     if (dissolve_.inputFilename().empty())
     {
-        Messenger::error("Cannot run the simulation until the file is saved.");
+        QMessageBox::warning(this, "No Input File", "You must save the file before running the simulation");
         return;
     }
 

--- a/src/gui/menu_simulation.cpp
+++ b/src/gui/menu_simulation.cpp
@@ -8,11 +8,18 @@
 #include <QInputDialog>
 #include <QMessageBox>
 
-void DissolveWindow::on_SimulationRunAction_triggered(bool checked)
+void DissolveWindow::setupIteration(int count)
 {
     // Prepare the simulation
     if (!dissolve_.prepare())
         return;
+
+    // Ensure that the simulation can run
+    if (dissolve_.inputFilename().empty())
+    {
+        Messenger::error("Cannot run the simulation until the file is saved.");
+        return;
+    }
 
     // Prepare the GUI
     disableSensitiveControls();
@@ -22,8 +29,10 @@ void DissolveWindow::on_SimulationRunAction_triggered(bool checked)
     // Update the controls
     updateControlsFrame();
 
-    emit iterate(-1);
+    emit iterate(count);
 }
+
+void DissolveWindow::on_SimulationRunAction_triggered(bool checked) { setupIteration(-1); }
 
 void DissolveWindow::on_SimulationRunForAction_triggered(bool checked)
 {
@@ -33,55 +42,12 @@ void DissolveWindow::on_SimulationRunForAction_triggered(bool checked)
         QInputDialog::getInt(this, "Iterate Simulation...", "Enter the number of iterations to run", 10, 1, 1000000, 10, &ok);
     if (!ok)
         return;
-
-    // Prepare the simulation
-    if (!dissolve_.prepare())
-        return;
-
-    // Prepare the GUI
-    disableSensitiveControls();
-    Renderable::setSourceDataAccessEnabled(false);
-    dissolveState_ = DissolveWindow::RunningState;
-
-    // Update the controls
-    updateControlsFrame();
-
-    emit iterate(nIterations);
+    setupIteration(nIterations);
 }
 
-void DissolveWindow::on_SimulationStepAction_triggered(bool checked)
-{
-    // Prepare the simulation
-    if (!dissolve_.prepare())
-        return;
+void DissolveWindow::on_SimulationStepAction_triggered(bool checked) { setupIteration(1); }
 
-    // Prepare the GUI
-    disableSensitiveControls();
-    Renderable::setSourceDataAccessEnabled(false);
-    dissolveState_ = DissolveWindow::RunningState;
-
-    // Update the controls
-    updateControlsFrame();
-
-    emit iterate(1);
-}
-
-void DissolveWindow::on_SimulationStepFiveAction_triggered(bool checked)
-{
-    // Prepare the simulation
-    if (!dissolve_.prepare())
-        return;
-
-    // Prepare the GUI
-    disableSensitiveControls();
-    Renderable::setSourceDataAccessEnabled(false);
-    dissolveState_ = DissolveWindow::RunningState;
-
-    // Update the controls
-    updateControlsFrame();
-
-    emit iterate(5);
-}
+void DissolveWindow::on_SimulationStepFiveAction_triggered(bool checked) { setupIteration(5); }
 
 void DissolveWindow::on_SimulationPauseAction_triggered(bool checked)
 {


### PR DESCRIPTION
This will close #409.

A couple of comments on the commit.  First, I've refactored a good bit of menu_simulation.cpp to reuse  more code when possible.  In this combined code, I've also added a check that there is a proper project file before running the simulation.  If there is not one, an error message is popped in the try and the simulation is not started.

A final change is in the CLI handling of dissolve-gui.cpp, fixing a regression that I mentioned in the stand-up.  Previously, it was possible to start the GUI with no file given on the command line.  This was because there was a check if a file name had been given before running `dissolveWindow.openLocalFile`.  When switching to the new CLI, this check was removed and `openLocalFile` was called directly on the file name.  Within `openLocalFile`, there is a safety check that confirms that the file isn't empty and bails out of the program if it is.  Therefore, to resume our original behaviour, I've re-implemented the original check.

Two possible changes that might be added atop this
1. Display an error dialog if trying to run the simulation with no file, instead of just an error in the message centre.
2. Possible take advantage of the new <filesystem> library for the input file, though this is probably a large change to warrant its own PR.