### PR TITLE
Fix types on EarlyReturn switch

### DIFF
--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -42,6 +42,7 @@ template <typename T> class EarlyReturn
     std::optional<T> value_;
 
     public:
+    using inner = T;
     EarlyReturn(Type t = Type::Continue, std::optional<T> v = std::nullopt) : type_(t), value_(v){};
     EarlyReturn(const T &val) : type_(Type::Return), value_(val){};
     Type type() const { return type_; }
@@ -61,11 +62,11 @@ auto for_each_pair_early(Iter begin, Iter end, Lam lambda) -> decltype(lambda(0,
             auto result = lambda(i, *elem1, j, *elem2);
             switch (result.type())
             {
-                case EarlyReturn<decltype(lambda(0, *begin, 0, *end).value())>::Return:
+                case EarlyReturn<typename decltype(result)::inner>::Return:
                     return result.value();
-                case EarlyReturn<decltype(lambda(0, *begin, 0, *end).value())>::Break:
+                case EarlyReturn<typename decltype(result)::inner>::Break:
                     break;
-                case EarlyReturn<decltype(lambda(0, *begin, 0, *end).value())>::Continue:
+                case EarlyReturn<typename decltype(result)::inner>::Continue:
                     continue;
             }
         }
@@ -82,11 +83,11 @@ template <class Lam> auto for_each_pair_early(int begin, int end, Lam lambda) ->
             auto result = lambda(i, j);
             switch (result.type())
             {
-                case EarlyReturn<decltype(lambda(0, 0).value())>::Return:
+                case EarlyReturn<typename decltype(result)::inner>::Return:
                     return result.value();
-                case EarlyReturn<decltype(lambda(0, 0).value())>::Break:
+                case EarlyReturn<typename decltype(result)::inner>::Break:
                     break;
-                case EarlyReturn<decltype(lambda(0, 0).value())>::Continue:
+                case EarlyReturn<typename decltype(result)::inner>::Continue:
                     continue;
             }
         }


### PR DESCRIPTION
The original warning was pedantic, but it should be fixed.  This ensures that we switch over `EarlyReturn<T>::Type` and not `EarlyReturn<std::optional<T>>::Type`, even if they are identical.

This closes #422.