### PR TITLE
Bugfix 06/11/20 Correctly handle empty NETA Rings

### DIFF
--- a/src/neta/ring.cpp
+++ b/src/neta/ring.cpp
@@ -141,22 +141,32 @@ int NETARingNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &
         // Check through atoms in the ring - either in order or not - to see if the ring matches
         // Disordered search - try to match the branch definition against this ring, in any order (provide a copy of all
         // atoms in the ring at once)
+
+        auto ringScore = 0;
         std::vector<const SpeciesAtom *> ringAtoms = ring.atoms();
         for (auto node : branch_)
         {
             nodeScore = node->score(nullptr, ringAtoms);
             if (nodeScore == NETANode::NoMatch)
+            {
+                ringScore = NETANode::NoMatch;
                 break;
+            }
 
             // Match found
-            totalScore += nodeScore;
+            ringScore += nodeScore;
         }
 
         // If we didn't find a match for the ring, continue to the next one
-        if (nodeScore == NETANode::NoMatch)
+        if (ringScore == NETANode::NoMatch)
             continue;
 
         ++nMatches;
+
+        // Increase the total score - ringScore (contained atoms) + 1 (for the ring) + 1 (for the size, if specified)
+        totalScore += ringScore + 1;
+        if (sizeValue_ != -1)
+            ++totalScore;
 
         // Don't match more than we need to - check the repeatCount
         if (compareValues(nMatches, repeatCountOperator_, repeatCount_))


### PR DESCRIPTION
Bugfix PR to address an issue with NETA ring matching, where not specifying the complete set of atoms within a ring (as is the case for, e.g., benzene in the OPLSAA/Aromatics forcefield) would result in a failure to match the ring.

This has been patched, and the scoring of rings made more consistent.
