### PR TITLE
Update continuous pipeline

### DIFF
--- a/.azure-pipelines/continuous.yml
+++ b/.azure-pipelines/continuous.yml
@@ -3,12 +3,17 @@ trigger:
     include:
     - develop
   paths:
-    exclude:
-    - examples/*
-    - web/*
-    - README.md
     include:
-    - /
+    - src/*
+    - ci/*
+    - cmake/*
+    - icon/*
+    - tests/*
+    - CMakeLists.txt
+    - conanfile.txt
+    - .azure-pipelines/*
+    - .clang-format
+    - .cmake-format.json
 
 pr: none
 


### PR DESCRIPTION
Quick fix to explicitly include triggering paths / files for the continuous build, rather than exclude an incomplete set.
