### PR TITLE
Bugfix 06/11/20 IsotopologueSet Keywords

### DIFF
--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -23,7 +23,7 @@ IsotopologueSetKeywordWidget::IsotopologueSetKeywordWidget(QWidget *parent, Keyw
     ui_.IsotopologueTree->setItemDelegateForColumn(0, new NullDelegate(this));
     ui_.IsotopologueTree->setItemDelegateForColumn(1, new CustomComboDelegate<IsotopologueSetKeywordWidget>(
                                                           this, &IsotopologueSetKeywordWidget::availableIsotopologueNames));
-    ui_.IsotopologueTree->setItemDelegateForColumn(2, new ExponentialSpinDelegate(this));
+    ui_.IsotopologueTree->setItemDelegateForColumn(2, new ExponentialSpinDelegate(this, 0.0));
 
     // Connect signals / slots
     connect(ui_.AddButton, SIGNAL(clicked(bool)), this, SLOT(addButton_clicked(bool)));

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -7,6 +7,7 @@
 #include "gui/delegates/combolist.hui"
 #include "gui/delegates/customcombodelegate.h"
 #include "gui/delegates/exponentialspin.hui"
+#include "gui/delegates/null.h"
 #include "gui/delegates/usedspeciescombo.hui"
 #include "gui/keywordwidgets/dropdown.h"
 #include "gui/keywordwidgets/isotopologueset.h"
@@ -19,6 +20,7 @@ IsotopologueSetKeywordWidget::IsotopologueSetKeywordWidget(QWidget *parent, Keyw
     ui_.setupUi(dropWidget());
 
     // Set delegates for table
+    ui_.IsotopologueTree->setItemDelegateForColumn(0, new NullDelegate(this));
     ui_.IsotopologueTree->setItemDelegateForColumn(1, new CustomComboDelegate<IsotopologueSetKeywordWidget>(
                                                           this, &IsotopologueSetKeywordWidget::availableIsotopologueNames));
     ui_.IsotopologueTree->setItemDelegateForColumn(2, new ExponentialSpinDelegate(this));

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -254,7 +254,7 @@ void IsotopologueSetKeywordWidget::isotopologueTree_itemChanged(QTreeWidgetItem 
     IsotopologueWeight &weight = *weightData;
 
     // Column of passed item tells us the type of data we need to change
-    if (column == 2)
+    if (column == 1)
     {
         // Editing the Isotopologue - need the parent item in order to validate it
         auto topesData = isotopologuesItemManager_.reference(item->parent());
@@ -277,7 +277,7 @@ void IsotopologueSetKeywordWidget::isotopologueTree_itemChanged(QTreeWidgetItem 
 
         emit(keywordValueChanged(keyword_->optionMask()));
     }
-    else if (column == 3)
+    else if (column == 2)
     {
         weight.setWeight(item->text(column).toDouble());
 
@@ -307,7 +307,7 @@ void IsotopologueSetKeywordWidget::updateIsotopologueTreeRootItem(QTreeWidgetIte
         item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
 
     // Set item data
-    item->setText(1, QString::fromStdString(std::string(topes.species()->name())));
+    item->setText(0, QString::fromStdString(std::string(topes.species()->name())));
 
     // Update child (IsotopologueWeight) items
     isotopologueWeightItemManager_.updateChildren(item, topes.mix(),
@@ -321,8 +321,8 @@ void IsotopologueSetKeywordWidget::updateIsotopologueTreeChildItem(QTreeWidgetIt
     if (itemIsNew)
         item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable);
 
-    item->setText(2, QString::fromStdString(std::string(isoWeight.isotopologue()->name())));
-    item->setText(3, QString::number(isoWeight.weight()));
+    item->setText(1, QString::fromStdString(std::string(isoWeight.isotopologue()->name())));
+    item->setText(2, QString::number(isoWeight.weight()));
 }
 
 // Update value displayed in widget

--- a/src/gui/modulecontrolwidget.h
+++ b/src/gui/modulecontrolwidget.h
@@ -31,13 +31,6 @@ class ModuleControlWidget : public QWidget
     Lock refreshLock_;
 
     /*
-     * Setup
-     */
-    public:
-    // Set up links to main window
-    void setUp(DissolveWindow *dissolveWindow);
-
-    /*
      * Module Target
      */
     private:

--- a/src/gui/modulecontrolwidget_funcs.cpp
+++ b/src/gui/modulecontrolwidget_funcs.cpp
@@ -23,20 +23,13 @@ ModuleControlWidget::ModuleControlWidget(QWidget *parent)
     module_ = nullptr;
     configurationsWidget_ = nullptr;
     moduleWidget_ = nullptr;
-}
 
-ModuleControlWidget::~ModuleControlWidget() {}
-
-/*
- * SetUp
- */
-
-// Set up links to main window
-void ModuleControlWidget::setUp(DissolveWindow *dissolveWindow)
-{
+    // Connect signals from keywords widget
     connect(ui_.ModuleKeywordsWidget, SIGNAL(dataModified()), this, SLOT(keywordDataModified()));
     connect(ui_.ModuleKeywordsWidget, SIGNAL(setUpRequired()), this, SLOT(setUpModule()));
 }
+
+ModuleControlWidget::~ModuleControlWidget() {}
 
 /*
  * Module Target

--- a/src/gui/modulelisteditor_funcs.cpp
+++ b/src/gui/modulelisteditor_funcs.cpp
@@ -222,6 +222,7 @@ void ModuleListEditor::moduleSelectionChanged(const QString &blockIdentifier)
         // Create a new widget to display this Module
         ModuleControlWidget *mcw = new ModuleControlWidget;
         mcw->setModule(module, &dissolveWindow_->dissolve());
+        connect(mcw, SIGNAL(dataModified()), dissolveWindow_, SLOT(setModified()));
         widgetIndex = ui_.ModuleControlsStack->addWidget(mcw);
     }
 


### PR DESCRIPTION
Bugfix PR to address issues with editability of data within the IsotopologueSetKeywordWidget.

The PR also fixes a general issue with updating the GUI modification status on change of any keyword data.

Closes #430.
