### PR TITLE
Bugfix 06/11/20 Load AtomTypeList from restart file

### DIFF
--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -115,6 +115,7 @@ void Dissolve::registerGenericItems()
     GenericItem::addItemClass(new GenericItemContainer<Array<Vec3<int>>>("Array<Vec3<int>>"));
     GenericItem::addItemClass(new GenericItemContainer<Array<Vec3<double>>>("Array<Vec3<double>>"));
 
+    GenericItem::addItemClass(new GenericItemContainer<AtomTypeList>(AtomTypeList::itemClassName()));
     GenericItem::addItemClass(new GenericItemContainer<BraggReflection>(BraggReflection::itemClassName()));
     GenericItem::addItemClass(new GenericItemContainer<Data1D>(Data1D::itemClassName()));
     GenericItem::addItemClass(new GenericItemContainer<Data2D>(Data2D::itemClassName()));


### PR DESCRIPTION
A one-liner PR to fix reading of AtomTypeList data from the restart file, which was not added during PR #402.
