### PR TITLE
Bugfix 09/11/20 - CLI nIterations

### DIFF
--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -78,14 +78,14 @@ int main(int args, char **argv)
         }
 
         // Iterate before launching the GUI?
-        if (options.nIterations() > 0)
+        if (options.nIterations())
         {
             // Prepare for run
             if (!dissolve.prepare())
                 return 1;
 
             // Run main simulation
-            auto result = dissolve.iterate(options.nIterations());
+            auto result = dissolve.iterate(options.nIterations().value());
             if (!result)
                 return 1;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,7 +113,7 @@ int main(int args, char **argv)
     }
 
     // If were just checking the input and restart files, exit now
-    if (options.checkInputOnly())
+    if (!options.nIterations())
     {
         ProcessPool::finalise();
         Messenger::ceaseRedirect();
@@ -149,8 +149,8 @@ int main(int args, char **argv)
                      ProcessPool::nWorldProcesses());
 #endif
 
-    // Run main simulation
-    auto result = dissolve.iterate(options.nIterations());
+    // Run main simulation?
+    auto result = dissolve.iterate(options.nIterations().value());
 
     // Print timing information
     dissolve.printTiming();

--- a/src/main/cli.cpp
+++ b/src/main/cli.cpp
@@ -9,7 +9,11 @@
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
 
-CLIOptions::CLIOptions() : checkInputOnly_(false), ignoreRestartFile_(false), ignoreStateFile_(false), writeNoFiles_(false) {}
+CLIOptions::CLIOptions()
+    : nIterations_(std::nullopt), restartFileFrequency_(10), ignoreRestartFile_(false), ignoreStateFile_(false),
+      writeNoFiles_(false)
+{
+}
 
 // Parse CLI options
 int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
@@ -34,9 +38,6 @@ int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
         ->group("Basic Control");
 
     // Input Files
-    if (!isGUI)
-        app.add_flag("-c,--check", checkInputOnly_, "Only check input and restart files for validity, then quit")
-            ->group("Input Files");
     app.add_flag("-i,--ignore-restart", ignoreRestartFile_, "Ignore restart file (if it exists)")->group("Input Files");
     if (!isGUI)
         app.add_option("-w,--write-input", writeInputFilename_,
@@ -85,7 +86,7 @@ int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
 std::optional<std::string> CLIOptions::inputFile() const { return inputFile_; }
 
 // Return number of iterations to perform
-int CLIOptions::nIterations() const { return nIterations_; }
+std::optional<int> CLIOptions::nIterations() const { return nIterations_; }
 
 // Return frequency at which to write restart file
 int CLIOptions::restartFileFrequency() const { return restartFileFrequency_; }
@@ -98,9 +99,6 @@ std::optional<std::string> CLIOptions::restartFilename() const { return restartF
 
 // Return new input file to write (after reading supplied file)
 std::optional<std::string> CLIOptions::writeInputFilename() const { return writeInputFilename_; }
-
-// Return whether to just check the input file, and then quit
-bool CLIOptions::checkInputOnly() const { return checkInputOnly_; }
 
 // Return whether to ignore restart file if it exists
 bool CLIOptions::ignoreRestartFile() const { return ignoreRestartFile_; }

--- a/src/main/cli.h
+++ b/src/main/cli.h
@@ -20,7 +20,7 @@ class CLIOptions
     // Input file to load
     std::optional<std::string> inputFile_;
     // Number of iterations to perform
-    int nIterations_;
+    std::optional<int> nIterations_;
     // Frequency at which to write restart file
     int restartFileFrequency_;
     // Redirection basename (for per-process output)
@@ -29,8 +29,6 @@ class CLIOptions
     std::optional<std::string> restartFilename_;
     // New input file to write (after reading supplied file)
     std::optional<std::string> writeInputFilename_;
-    // Whether to just check the input file, and then quit
-    bool checkInputOnly_;
     // Whether to ignore restart file (if it exists)
     bool ignoreRestartFile_;
     // Whether to ignore GUI state file (if it exists)
@@ -49,7 +47,7 @@ class CLIOptions
     // Return input file to load
     std::optional<std::string> inputFile() const;
     // Return number of iterations to perform
-    int nIterations() const;
+    std::optional<int> nIterations() const;
     // Return frequency at which to write restart file
     int restartFileFrequency() const;
     // Return redirection basename (for per-process output)
@@ -58,8 +56,6 @@ class CLIOptions
     std::optional<std::string> restartFilename() const;
     // Return new input file to write (after reading supplied file)
     std::optional<std::string> writeInputFilename() const;
-    // Return whether to just check the input file, and then quit
-    bool checkInputOnly() const;
     // Return whether to ignore restart file if it exists
     bool ignoreRestartFile() const;
     // Return whether to ignore GUI state file (if it exists)

--- a/web/content/docs/userguide/run/cli.md
+++ b/web/content/docs/userguide/run/cli.md
@@ -14,7 +14,7 @@ Note that an input file must be provided for the serial and parallel codes - it 
 The following options are recognised by the serial and parallel codes, as well as the GUI.
 
 #### `-n <n>`, `--niterations <n>`
-Run Dissolve for the specified number of iterations, and then quit. The default number of iterations if the `-n` flag is not specified is 5. For the GUI version, the specified number of iterations will be run, and then the GUI launched.
+Run Dissolve for the specified number of iterations, and then quit. For the GUI version, the specified number of iterations will be run, and then the GUI launched. The default number of iterations if the `-n` flag is not specified is zero - in this case Dissolve will load the input file (and any associated restart file) and then quit, essentially corresponding to a sanity check of the input files.
 
 #### `-q`, `--quiet`
 Don't print any output to the console whatsoever. Output files such as the restart file, heartbeat, and any data output requested in individual modules will still be written. Use the [`-x`](#-x---no-files) flag to prevent the restart and heartbeat files being written.
@@ -23,11 +23,6 @@ Don't print any output to the console whatsoever. Output files such as the resta
 Print lots more output, mostly useful for debugging
 
 ### Input Files
-
-#### `-c`, `--check`
-Dissolve will read in the supplied input file, and the restart file if it exists, and then exit without performing any simulation. Mostly useful for checking the validity of an input file before committing to a production run.
-
-Not available in the GUI code.
 
 #### `-i`, `--ignore-restart`
 Ignore the restart file (i.e. don't read it in) if it exists. The name of the expected restart file is the input file name suffixed with `.restart`.


### PR DESCRIPTION
This bugfix PR addresses an issue with the number of iterations specified from the CLI. The containing `nIterations_` var was uninitialised, and so random numbers of iterations could be run if the flag was not specified on the command line.

To address this:
- The `nIterations_` variable is now a `std::optional<int>`.
- The `checkInputOnly_` flag (`-c`) has been removed, since this behaviour is now the default if `-n` is not specified (zero iterations == check and quit).

The `restartFileFrequency_` var is now also initialised correctly.

Closes #436.
