### PR TITLE
Bugfix 13/11/20 RDF/SQ display and calculation

### DIFF
--- a/src/classes/atomtypedata.cpp
+++ b/src/classes/atomtypedata.cpp
@@ -65,7 +65,7 @@ void AtomTypeData::add(Isotope *tope, double nAdd)
     // Increase Isotope population
     topeData->add(nAdd);
 
-    // Increase total integer population
+    // Increase total population
     population_ += nAdd;
 }
 
@@ -120,6 +120,9 @@ void AtomTypeData::naturalise()
     topeData->finalise(population_);
     boundCoherent_ = topeData->isotope()->boundCoherent();
 }
+
+// Return the number of defined Isotopes
+int AtomTypeData::nIsotopes() const { return isotopes_.nItems(); }
 
 // Return if specified Isotope is already in the list
 bool AtomTypeData::hasIsotope(Isotope *tope)

--- a/src/classes/atomtypedata.h
+++ b/src/classes/atomtypedata.h
@@ -63,6 +63,8 @@ class AtomTypeData
     void finalise(double nWorldAtoms);
     // Remove any existing isotopes, and add only the natural isotope
     void naturalise();
+    // Return the number of defined Isotopes
+    int nIsotopes() const;
     // Return if specified Isotope is already in the list
     bool hasIsotope(Isotope *tope);
     // Set this AtomType to have only the single Isotope provided

--- a/src/classes/atomtypelist.cpp
+++ b/src/classes/atomtypelist.cpp
@@ -71,13 +71,16 @@ AtomTypeData &AtomTypeList::add(std::shared_ptr<AtomType> atomType, double popul
 void AtomTypeList::add(const AtomTypeList &source)
 {
     // Loop over AtomTypes in the source list
-    for (auto &newType : source)
+    for (auto &otherType : source)
     {
-        AtomTypeData &atd = add(newType.atomType());
+        AtomTypeData &atd = add(otherType.atomType());
 
-        // Now add Isotope data
-        for (auto *topeData = newType.isotopeData(); topeData != nullptr; topeData = topeData->next())
-            atd.add(topeData->isotope(), topeData->population());
+        // If no Isotope data are present, add the population now. Otherwise, add it via the isotopes...
+        if (otherType.nIsotopes() == 0)
+            atd.add(otherType.population());
+        else
+            for (auto *topeData = otherType.isotopeData(); topeData != nullptr; topeData = topeData->next())
+                atd.add(topeData->isotope(), topeData->population());
     }
 }
 
@@ -91,7 +94,7 @@ void AtomTypeList::remove(std::shared_ptr<AtomType> atomType)
 // Add/increase this AtomType/Isotope pair
 void AtomTypeList::addIsotope(std::shared_ptr<AtomType> atomType, Isotope *tope, double popAdd)
 {
-    auto &atd = add(atomType, 0);
+    auto &atd = add(atomType);
 
     // Add / increase isotope population
     if (tope != nullptr)

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -98,8 +98,6 @@ class Configuration : public ListItem<Configuration>, public ObjectStore<Configu
     public:
     // Empty contents of Configuration, leaving core definitions intact
     void empty();
-    // Initialise content array
-    void initialiseArrays(int nMolecules);
     // Return specified used type
     std::shared_ptr<AtomType> usedAtomType(int index);
     // Return specified used type data

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -27,13 +27,6 @@ void Configuration::empty()
     ++contentsVersion_;
 }
 
-// Initialise content arrays
-void Configuration::initialiseArrays(int nMolecules)
-{
-    // Clear current contents
-    empty();
-}
-
 // Return specified used type
 std::shared_ptr<AtomType> Configuration::usedAtomType(int index) { return usedAtomTypes_.atomType(index); }
 

--- a/src/modules/neutronsq/gui/modulewidget_funcs.cpp
+++ b/src/modules/neutronsq/gui/modulewidget_funcs.cpp
@@ -72,9 +72,6 @@ NeutronSQModuleWidget::NeutronSQModuleWidget(QWidget *parent, NeutronSQModule *m
     totalGRGraph_->view().axes().setMax(1, 1.0);
     totalGRGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
     totalGRGraph_->view().setAutoFollowType(View::AllAutoFollow);
-    // -- Set group styling
-    totalGRGraph_->groupManager().setGroupColouring("Reference", RenderableGroup::FixedGroupColouring);
-    totalGRGraph_->groupManager().setGroupFixedColour("Reference", StockColours::RedStockColour);
 
     // Set up total F(Q) graph
     totalFQGraph_ = ui_.TotalSQPlotWidget->dataViewer();
@@ -87,9 +84,6 @@ NeutronSQModuleWidget::NeutronSQModuleWidget(QWidget *parent, NeutronSQModule *m
     totalFQGraph_->view().axes().setMax(1, 1.0);
     totalFQGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
     totalFQGraph_->view().setAutoFollowType(View::AllAutoFollow);
-    // -- Set group styling
-    totalFQGraph_->groupManager().setGroupColouring("Reference", RenderableGroup::FixedGroupColouring);
-    totalFQGraph_->groupManager().setGroupFixedColour("Reference", StockColours::RedStockColour);
 
     setGraphDataTargets(module_);
 
@@ -215,33 +209,34 @@ void NeutronSQModuleWidget::setGraphDataTargets(NeutronSQModule *module)
     });
 
     // Add calculated total G(r)
-    auto *totalGR = totalGRGraph_->createRenderable(
-        Renderable::Data1DRenderable, fmt::format("{}//WeightedGR//Total", module_->uniqueName()), "Calculated (Direct)");
-    totalGRGraph_->addRenderableToGroup(totalGR, "Calculated");
+    totalGRGraph_->createRenderable(Renderable::Data1DRenderable, fmt::format("{}//WeightedGR//Total", module_->uniqueName()),
+                                    "Calculated G(r) (Direct)", "Calculated");
 
     // Add calculated total representative G(r) (from FT of S(Q))
-    auto *repGR = totalGRGraph_->createRenderable(
-        Renderable::Data1DRenderable, fmt::format("{}//RepresentativeTotalGR", module_->uniqueName()), "Calculated (via FT)");
+    auto *repGR = totalGRGraph_->createRenderable(Renderable::Data1DRenderable,
+                                                  fmt::format("{}//RepresentativeTotalGR", module_->uniqueName()),
+                                                  "Calculated G(r) (via FT)", "Calculated");
     repGR->lineStyle().setStipple(LineStipple::HalfDashStipple);
-    totalGRGraph_->addRenderableToGroup(repGR, "Calculated");
+    repGR->setColour(StockColours::GreenStockColour);
 
     // Add calculate total F(Q)
-    auto *totalFQ = totalFQGraph_->createRenderable(Renderable::Data1DRenderable,
-                                                    fmt::format("{}//WeightedSQ//Total", module_->uniqueName()), "Calculated");
-    totalFQGraph_->addRenderableToGroup(totalFQ, "Calculated");
+    totalFQGraph_->createRenderable(Renderable::Data1DRenderable, fmt::format("{}//WeightedSQ//Total", module_->uniqueName()),
+                                    "Calculated F(Q)", "Calculated");
 
     // Add on reference data if present
     const Data1DImportFileFormat &referenceFileAndFormat = module->referenceFQFileAndFormat();
     if (referenceFileAndFormat.hasValidFileAndFormat())
     {
         // Add FT of reference data total G(r)
-        auto *refGR = totalGRGraph_->createRenderable(Renderable::Data1DRenderable,
-                                                      fmt::format("{}//ReferenceDataFT", module_->uniqueName()), "Reference");
-        totalGRGraph_->addRenderableToGroup(refGR, "Reference");
+        totalGRGraph_
+            ->createRenderable(Renderable::Data1DRenderable, fmt::format("{}//ReferenceDataFT", module_->uniqueName()),
+                               "Reference G(r) (via FT)", "Reference")
+            ->setColour(StockColours::RedStockColour);
 
         // Add calculate total F(Q)
-        auto *refFQ = totalFQGraph_->createRenderable(Renderable::Data1DRenderable,
-                                                      fmt::format("{}//ReferenceData", module_->uniqueName()), "Reference");
-        totalFQGraph_->addRenderableToGroup(refFQ, "Reference");
+        totalFQGraph_
+            ->createRenderable(Renderable::Data1DRenderable, fmt::format("{}//ReferenceData", module_->uniqueName()),
+                               "Reference F(Q)", "Reference")
+            ->setColour(StockColours::RedStockColour);
     }
 }

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -191,7 +191,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     const auto &unweightedSQ =
         GenericListHelper<PartialSet>::value(dissolve.processingModuleData(), "UnweightedSQ", sqModule->uniqueName());
 
-    // Get weights (from underlying source configurations)
+    // Calculate and store weights
     auto &weights = GenericListHelper<NeutronWeights>::realise(dissolve.processingModuleData(), "FullWeights", uniqueName_,
                                                                GenericItem::InRestartFileFlag);
     if (!calculateWeights(rdfModule, weights))

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -109,11 +109,11 @@ bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
         storedDataFT = referenceData;
         auto rho = 0.1;
         if (dissolve.processingModuleData().contains("EffectiveRho", rdfModule->uniqueName()))
+            rho = GenericListHelper<double>::value(dissolve.processingModuleData(), "EffectiveRho", rdfModule->uniqueName());
+        else
             Messenger::warn("Couldn't locate effective atomic density from '{}', so Fourier transform of reference data will "
                             "use assumed atomic density of 0.1.\n",
                             rdfModule->uniqueName());
-        else
-            rho = GenericListHelper<double>::value(dissolve.processingModuleData(), "EffectiveRho", rdfModule->uniqueName());
         Fourier::sineFT(storedDataFT, 1.0 / (2.0 * PI * PI * rho), 0.0, 0.05, 30.0, referenceWindowFunction);
 
         // Save data?
@@ -248,10 +248,15 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     auto &repGR = GenericListHelper<Data1D>::realise(dissolve.processingModuleData(), "RepresentativeTotalGR", uniqueName_,
                                                      GenericItem::InRestartFileFlag);
     repGR = weightedSQ.total();
-    auto qMin = weightedSQ.total().values().firstValue();
-    auto qMax = weightedSQ.total().values().lastValue();
-    auto rho = nTargetConfigurations() == 0 ? 0.1 : RDFModule::summedRho(this, dissolve.processingModuleData());
-    Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * rho), qMin, 0.05, qMax, referenceWindowFunction);
+    auto rMin = weightedGR.total().xAxis().firstValue();
+    auto rMax = weightedGR.total().xAxis().lastValue();
+    auto rho = 0.1;
+    if (dissolve.processingModuleData().contains("EffectiveRho", rdfModule->uniqueName()))
+        rho = GenericListHelper<double>::value(dissolve.processingModuleData(), "EffectiveRho", rdfModule->uniqueName());
+    else
+        Messenger::warn("Couldn't locate effective atomic density for RDF module.\n");
+
+    Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * rho), rMin, 0.05, rMax, referenceWindowFunction);
     repGR.setObjectTag(fmt::format("{}//RepresentativeTotalGR", uniqueName_));
 
     return true;

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -86,8 +86,7 @@ bool RDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
         rdfRange = int(rdfRange / binWidth) * binWidth;
         Messenger::print("Cutoff (snapped to bin width) is {} Angstroms.\n", rdfRange);
 
-        // Calculate unweighted partials for this Configuration (under generic Module name 'Partials', rather than the
-        // uniqueName_)
+        // Calculate unweighted partials for this Configuration
         bool alreadyUpToDate;
         calculateGR(procPool, cfg, method, rdfRange, binWidth, alreadyUpToDate);
         auto &originalgr = GenericListHelper<PartialSet>::retrieve(cfg->moduleData(), "OriginalGR", uniqueName_);

--- a/src/modules/sq/functions.cpp
+++ b/src/modules/sq/functions.cpp
@@ -6,6 +6,7 @@
 #include "genericitems/listhelper.h"
 #include "math/ft.h"
 #include "modules/sq/sq.h"
+#include "templates/algorithms.h"
 
 /*
  * Public Functions
@@ -26,31 +27,21 @@ bool SQModule::calculateUnweightedSQ(ProcessPool &procPool, const PartialSet &un
     procPool.resetAccumulatedTime();
     Timer timer;
     timer.start();
-    auto nTypes = unweightedgr.nAtomTypes();
-    for (auto n = 0; n < nTypes; ++n)
-    {
-        for (auto m = n; m < nTypes; ++m)
-        {
-            // Total partial
-            unweightedsq.partial(n, m).copyArrays(unweightedgr.partial(n, m));
-            unweightedsq.partial(n, m).values() -= 1.0;
-            if (!Fourier::sineFT(unweightedsq.partial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction, broadening))
-                return false;
+    for_each_pair(0, unweightedgr.nAtomTypes(), [&](int n, int m) {
+        // Total partial
+        unweightedsq.partial(n, m).copyArrays(unweightedgr.partial(n, m));
+        unweightedsq.partial(n, m).values() -= 1.0;
+        Fourier::sineFT(unweightedsq.partial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction, broadening);
 
-            // Bound partial
-            unweightedsq.boundPartial(n, m).copyArrays(unweightedgr.boundPartial(n, m));
-            if (!Fourier::sineFT(unweightedsq.boundPartial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction,
-                                 broadening))
-                return false;
+        // Bound partial
+        unweightedsq.boundPartial(n, m).copyArrays(unweightedgr.boundPartial(n, m));
+        Fourier::sineFT(unweightedsq.boundPartial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction, broadening);
 
-            // Unbound partial
-            unweightedsq.unboundPartial(n, m).copyArrays(unweightedgr.unboundPartial(n, m));
-            unweightedsq.unboundPartial(n, m).values() -= 1.0;
-            if (!Fourier::sineFT(unweightedsq.unboundPartial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction,
-                                 broadening))
-                return false;
-        }
-    }
+        // Unbound partial
+        unweightedsq.unboundPartial(n, m).copyArrays(unweightedgr.unboundPartial(n, m));
+        unweightedsq.unboundPartial(n, m).values() -= 1.0;
+        Fourier::sineFT(unweightedsq.unboundPartial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction, broadening);
+    });
 
     // Sum into total
     unweightedsq.formTotal(true);
@@ -58,52 +49,6 @@ bool SQModule::calculateUnweightedSQ(ProcessPool &procPool, const PartialSet &un
     timer.stop();
     Messenger::print("Finished Fourier transform and summation of partial g(r) into partial S(Q) ({} elapsed, {} comms).\n",
                      timer.totalTimeString(), procPool.accumulatedTimeString());
-
-    return true;
-}
-
-// Sum unweighted S(Q) over the supplied Module's target Configurations
-bool SQModule::sumUnweightedSQ(ProcessPool &procPool, Module *parentModule, const SQModule *sqModule, GenericList &moduleData,
-                               PartialSet &summedUnweightedSQ)
-{
-    // Create an AtomTypeList containing all AtomTypes present in all target configurations
-    AtomTypeList combinedAtomTypes;
-    for (Configuration *cfg : parentModule->targetConfigurations())
-        combinedAtomTypes.add(cfg->usedAtomTypesList());
-    combinedAtomTypes.finalise();
-
-    // Set up PartialSet container
-    summedUnweightedSQ.setUpPartials(combinedAtomTypes, parentModule->uniqueName(), "unweighted", "sq", "Q, 1/Angstroms");
-    summedUnweightedSQ.setObjectTags(fmt::format("{}//UnweightedSQ", parentModule->uniqueName()));
-
-    // Loop over Configurations again, summing into the PartialSet we have just set up
-    // We will keep a running total of the weights associated with each Configuration, and re-weight the entire set of
-    // partials at the end.
-    double totalWeight = 0.0;
-    std::string fingerprint;
-    for (Configuration *cfg : parentModule->targetConfigurations())
-    {
-        // Update fingerprint
-        fingerprint +=
-            fingerprint.empty() ? fmt::format("{}", cfg->contentsVersion()) : fmt::format("_{}", cfg->contentsVersion());
-
-        // Get weighting factor for this Configuration to contribute to the summed partials
-        auto weight = GenericListHelper<double>::value(moduleData, fmt::format("ConfigurationWeight_{}", cfg->niceName()),
-                                                       parentModule->uniqueName(), 1.0);
-        totalWeight += weight;
-        Messenger::print("Weight for Configuration '{}' is {} (total weight is now {}).\n", cfg->name(), weight, totalWeight);
-
-        // Grab partials for Configuration and add into our set
-        if (!cfg->moduleData().contains("UnweightedSQ", sqModule->uniqueName()))
-            return Messenger::error("Couldn't find UnweightedSQ data for Configuration '{}'.\n", cfg->name());
-        auto cfgPartialSQ = GenericListHelper<PartialSet>::value(cfg->moduleData(), "UnweightedSQ", sqModule->uniqueName());
-        summedUnweightedSQ.addPartials(cfgPartialSQ, weight);
-    }
-    summedUnweightedSQ.setFingerprint(fingerprint);
-
-    // Now must normalise our partials to the overall weight of the source configurations
-    // TODO CHECK Is this correct?
-    summedUnweightedSQ *= 1.0 / totalWeight;
 
     return true;
 }

--- a/src/modules/sq/gui/modulewidget.h
+++ b/src/modules/sq/gui/modulewidget.h
@@ -27,7 +27,7 @@ class SQModuleWidget : public ModuleWidget
     // Associated Module
     SQModule *module_;
     // DataViewers contained within this widget
-    DataViewer *partialGRGraph_, *partialSQGraph_, *totalGRGraph_, *totalSQGraph_;
+    DataViewer *partialsGraph_, *totalGraph_;
     // Reference to Dissolve
     Dissolve &dissolve_;
 

--- a/src/modules/sq/gui/modulewidget.ui
+++ b/src/modules/sq/gui/modulewidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>255</width>
-    <height>300</height>
+    <height>192</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -47,7 +47,7 @@
      </property>
      <widget class="QWidget" name="TotalsTab">
       <attribute name="title">
-       <string>Totals</string>
+       <string>Total F(Q)</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
        <property name="spacing">
@@ -65,45 +65,6 @@
        <property name="bottomMargin">
         <number>4</number>
        </property>
-       <item>
-        <widget class="QFrame" name="TotalGRPlotFrame">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="acceptDrops">
-          <bool>true</bool>
-         </property>
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Sunken</enum>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_6">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="DataWidget" name="TotalGRPlotWidget" native="true"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item>
         <widget class="QFrame" name="TotalSQPlotFrame">
          <property name="sizePolicy">
@@ -138,68 +99,7 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="DataWidget" name="TotalSQPlotWidget" native="true"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="PartialGRTab">
-      <attribute name="title">
-       <string>Partial g(r)</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="spacing">
-        <number>4</number>
-       </property>
-       <property name="leftMargin">
-        <number>4</number>
-       </property>
-       <property name="topMargin">
-        <number>4</number>
-       </property>
-       <property name="rightMargin">
-        <number>4</number>
-       </property>
-       <property name="bottomMargin">
-        <number>4</number>
-       </property>
-       <item>
-        <widget class="QFrame" name="PartialGRPlotFrame">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="acceptDrops">
-          <bool>true</bool>
-         </property>
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Sunken</enum>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="DataWidget" name="PartialGRPlotWidget" native="true"/>
+           <widget class="DataWidget" name="TotalFQPlotWidget" native="true"/>
           </item>
          </layout>
         </widget>

--- a/src/modules/sq/gui/modulewidget_funcs.cpp
+++ b/src/modules/sq/gui/modulewidget_funcs.cpp
@@ -17,57 +17,33 @@ SQModuleWidget::SQModuleWidget(QWidget *parent, SQModule *module, Dissolve &diss
     // Set up user interface
     ui_.setupUi(this);
 
-    // Set up partial g(r) graph
-
-    partialGRGraph_ = ui_.PartialGRPlotWidget->dataViewer();
-
-    partialGRGraph_->view().setViewType(View::FlatXYView);
-    partialGRGraph_->view().axes().setTitle(0, "\\it{r}, \\sym{angstrom}");
-    partialGRGraph_->view().axes().setMax(0, 10.0);
-    partialGRGraph_->view().axes().setTitle(1, "g(r)");
-    partialGRGraph_->view().axes().setMin(1, -1.0);
-    partialGRGraph_->view().axes().setMax(1, 1.0);
-    partialGRGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::HalfVerticalShift);
-    partialGRGraph_->view().setAutoFollowType(View::AllAutoFollow);
-
     // Set up partial S(Q) graph
 
-    partialSQGraph_ = ui_.PartialSQPlotWidget->dataViewer();
+    partialsGraph_ = ui_.PartialSQPlotWidget->dataViewer();
 
-    partialSQGraph_->view().setViewType(View::FlatXYView);
-    partialSQGraph_->view().axes().setTitle(0, "\\it{Q}, \\sym{angstrom}\\sup{-1}");
-    partialSQGraph_->view().axes().setMax(0, 10.0);
-    partialSQGraph_->view().axes().setTitle(1, "S(Q)");
-    partialSQGraph_->view().axes().setMin(1, -1.0);
-    partialSQGraph_->view().axes().setMax(1, 1.0);
-    partialSQGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::HalfVerticalShift);
-    partialSQGraph_->view().setAutoFollowType(View::AllAutoFollow);
+    partialsGraph_->view().setViewType(View::FlatXYView);
+    partialsGraph_->view().axes().setTitle(0, "\\it{Q}, \\sym{angstrom}\\sup{-1}");
+    partialsGraph_->view().axes().setMax(0, 10.0);
+    partialsGraph_->view().axes().setTitle(1, "S(Q)");
+    partialsGraph_->view().axes().setMin(1, -1.0);
+    partialsGraph_->view().axes().setMax(1, 1.0);
+    partialsGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::TwoVerticalShift);
+    partialsGraph_->view().setAutoFollowType(View::AllAutoFollow);
+    partialsGraph_->groupManager().setGroupColouring("Partial S(Q)", RenderableGroup::AutomaticIndividualColouring);
+    partialsGraph_->groupManager().setGroupVerticalShifting("Partial S(Q)", RenderableGroup::IndividualVerticalShifting);
 
-    // Set up total G(r) graph
+    // Set up total F(Q) graph
 
-    totalGRGraph_ = ui_.TotalGRPlotWidget->dataViewer();
+    totalGraph_ = ui_.TotalFQPlotWidget->dataViewer();
 
-    totalGRGraph_->view().setViewType(View::FlatXYView);
-    totalGRGraph_->view().axes().setTitle(0, "\\it{r}, \\sym{angstrom}");
-    totalGRGraph_->view().axes().setMax(0, 10.0);
-    totalGRGraph_->view().axes().setTitle(1, "g(r)");
-    totalGRGraph_->view().axes().setMin(1, -1.0);
-    totalGRGraph_->view().axes().setMax(1, 1.0);
-    totalGRGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
-    totalGRGraph_->view().setAutoFollowType(View::AllAutoFollow);
-
-    // Set up total S(Q) graph
-
-    totalSQGraph_ = ui_.TotalSQPlotWidget->dataViewer();
-
-    totalSQGraph_->view().setViewType(View::FlatXYView);
-    totalSQGraph_->view().axes().setTitle(0, "\\it{Q}, \\sym{angstrom}\\sup{-1}");
-    totalSQGraph_->view().axes().setMax(0, 10.0);
-    totalSQGraph_->view().axes().setTitle(1, "S(Q)");
-    totalSQGraph_->view().axes().setMin(1, -1.0);
-    totalSQGraph_->view().axes().setMax(1, 1.0);
-    totalSQGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
-    totalSQGraph_->view().setAutoFollowType(View::AllAutoFollow);
+    totalGraph_->view().setViewType(View::FlatXYView);
+    totalGraph_->view().axes().setTitle(0, "\\it{Q}, \\sym{angstrom}\\sup{-1}");
+    totalGraph_->view().axes().setMax(0, 10.0);
+    totalGraph_->view().axes().setTitle(1, "S(Q)");
+    totalGraph_->view().axes().setMin(1, -1.0);
+    totalGraph_->view().axes().setMax(1, 1.0);
+    totalGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
+    totalGraph_->view().setAutoFollowType(View::AllAutoFollow);
 
     setGraphDataTargets(module_);
 
@@ -85,15 +61,11 @@ SQModuleWidget::~SQModuleWidget() {}
 // Update controls within widget
 void SQModuleWidget::updateControls(int flags)
 {
-    ui_.PartialGRPlotWidget->updateToolbar();
     ui_.PartialSQPlotWidget->updateToolbar();
-    ui_.TotalGRPlotWidget->updateToolbar();
-    ui_.TotalSQPlotWidget->updateToolbar();
+    ui_.TotalFQPlotWidget->updateToolbar();
 
-    partialGRGraph_->postRedisplay();
-    partialSQGraph_->postRedisplay();
-    totalGRGraph_->postRedisplay();
-    totalSQGraph_->postRedisplay();
+    partialsGraph_->postRedisplay();
+    totalGraph_->postRedisplay();
 }
 
 /*
@@ -104,13 +76,9 @@ void SQModuleWidget::updateControls(int flags)
 bool SQModuleWidget::writeState(LineParser &parser) const
 {
     // Write DataViewer sessions
-    if (!partialGRGraph_->writeSession(parser))
+    if (!partialsGraph_->writeSession(parser))
         return false;
-    if (!partialSQGraph_->writeSession(parser))
-        return false;
-    if (!totalGRGraph_->writeSession(parser))
-        return false;
-    if (!totalSQGraph_->writeSession(parser))
+    if (!totalGraph_->writeSession(parser))
         return false;
 
     return true;
@@ -120,13 +88,9 @@ bool SQModuleWidget::writeState(LineParser &parser) const
 bool SQModuleWidget::readState(LineParser &parser)
 {
     // Read DataViewer sessions
-    if (!partialGRGraph_->readSession(parser))
+    if (!partialsGraph_->readSession(parser))
         return false;
-    if (!partialSQGraph_->readSession(parser))
-        return false;
-    if (!totalGRGraph_->readSession(parser))
-        return false;
-    if (!totalSQGraph_->readSession(parser))
+    if (!totalGraph_->readSession(parser))
         return false;
 
     return true;
@@ -139,46 +103,16 @@ bool SQModuleWidget::readState(LineParser &parser)
 // Set data targets in graphs
 void SQModuleWidget::setGraphDataTargets(SQModule *module)
 {
-    // Add partials
+    // Partial S(Q)
     for_each_pair(dissolve_.atomTypes().begin(), dissolve_.atomTypes().end(), [&](int n, auto at1, int m, auto at2) {
         const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
 
-        // Partial g(r)
-
-        Renderable *fullGR = partialGRGraph_->createRenderable(
-            Renderable::Data1DRenderable, fmt::format("{}//UnweightedGR//{}//Full", module_->uniqueName(), id),
-            fmt::format("GR//%", id), id);
-        partialGRGraph_->addRenderableToGroup(fullGR, id);
-
-        // Partial S(Q)
-
-        Renderable *fullSQ = partialSQGraph_->createRenderable(
-            Renderable::Data1DRenderable, fmt::format("{}//UnweightedSQ//{}//Full", module_->uniqueName(), id),
-            fmt::format("SQ//{}", id), id);
-        partialSQGraph_->addRenderableToGroup(fullSQ, id);
+        partialsGraph_->createRenderable(Renderable::Data1DRenderable,
+                                         fmt::format("{}//UnweightedSQ//{}//Full", module_->uniqueName(), id), id,
+                                         "Partial S(Q)");
     });
 
-    // Add calculated total G(r)
-    Renderable *totalGR = totalGRGraph_->createRenderable(
-        Renderable::Data1DRenderable, fmt::format("{}//WeightedGR//Total", module_->uniqueName()), "G(r) Calc");
-    totalGRGraph_->addRenderableToGroup(totalGR, "Calc");
-
-    // Add calculate total F(Q)
-    Renderable *totalFQ = totalSQGraph_->createRenderable(
-        Renderable::Data1DRenderable, fmt::format("{}//WeightedSQ//Total", module_->uniqueName()), "F(Q) Calc");
-    totalSQGraph_->addRenderableToGroup(totalFQ, "Calc");
-
-    // Add on reference data if present
-    if (module->keywords().find("Reference"))
-    {
-        // Add FT of reference data total G(r)
-        Renderable *refGR = totalGRGraph_->createRenderable(
-            Renderable::Data1DRenderable, fmt::format("{}//ReferenceDataFT", module_->uniqueName()), "G(r) Exp");
-        totalGRGraph_->addRenderableToGroup(refGR, "Exp");
-
-        // Add calculate total F(Q)
-        Renderable *refFQ = totalSQGraph_->createRenderable(
-            Renderable::Data1DRenderable, fmt::format("{}//ReferenceData", module_->uniqueName()), "F(Q) Exp");
-        totalSQGraph_->addRenderableToGroup(refFQ, "Exp");
-    }
+    // Add calculated total F(Q)
+    totalGraph_->createRenderable(Renderable::Data1DRenderable, fmt::format("{}//UnweightedSQ//Total", module_->uniqueName()),
+                                  "Calculated", "Total F(Q)");
 }

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -25,14 +25,14 @@ bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     if (!rdfModule)
         return Messenger::error("A source RDF module must be provided.\n");
     const auto averaging = keywords_.asInt("Averaging");
-    const bool includeBragg = keywords_.asBool("IncludeBragg");
+    const auto includeBragg = keywords_.asBool("IncludeBragg");
     const auto &braggQBroadening = keywords_.retrieve<BroadeningFunction>("BraggQBroadening", BroadeningFunction());
-    auto averagingScheme = keywords_.enumeration<Averaging::AveragingScheme>("AveragingScheme");
+    const auto averagingScheme = keywords_.enumeration<Averaging::AveragingScheme>("AveragingScheme");
     const auto &qBroadening = keywords_.retrieve<BroadeningFunction>("QBroadening", BroadeningFunction());
     const auto qDelta = keywords_.asDouble("QDelta");
     const auto qMin = keywords_.asDouble("QMin");
     const auto qMax = keywords_.asDouble("QMax");
-    const bool saveData = keywords_.asBool("Save");
+    const auto saveData = keywords_.asBool("Save");
     const auto &windowFunction = keywords_.retrieve<WindowFunction>("WindowFunction", WindowFunction());
 
     // Print argument/parameter summary

--- a/src/modules/sq/sq.h
+++ b/src/modules/sq/sq.h
@@ -65,9 +65,6 @@ class SQModule : public Module
     static bool calculateUnweightedSQ(ProcessPool &procPool, const PartialSet &unweightedgr, PartialSet &unweightedsq,
                                       double qMin, double qDelta, double qMax, double rho, const WindowFunction &windowFunction,
                                       const BroadeningFunction &broadening);
-    // Sum unweighted S(Q) over the supplied Module's target Configurations
-    static bool sumUnweightedSQ(ProcessPool &procPool, Module *parentModule, const SQModule *sqModule, GenericList &moduleData,
-                                PartialSet &summedUnweightedSQ);
 
     /*
      * GUI Widget

--- a/src/modules/xraysq/gui/modulewidget_funcs.cpp
+++ b/src/modules/xraysq/gui/modulewidget_funcs.cpp
@@ -72,9 +72,6 @@ XRaySQModuleWidget::XRaySQModuleWidget(QWidget *parent, XRaySQModule *module, Di
     totalGRGraph_->view().axes().setMax(1, 1.0);
     totalGRGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
     totalGRGraph_->view().setAutoFollowType(View::AllAutoFollow);
-    // -- Set group styling
-    totalGRGraph_->groupManager().setGroupColouring("Reference", RenderableGroup::FixedGroupColouring);
-    totalGRGraph_->groupManager().setGroupFixedColour("Reference", StockColours::RedStockColour);
 
     // Set up total F(Q) graph
     totalFQGraph_ = ui_.TotalSQPlotWidget->dataViewer();
@@ -87,9 +84,6 @@ XRaySQModuleWidget::XRaySQModuleWidget(QWidget *parent, XRaySQModule *module, Di
     totalFQGraph_->view().axes().setMax(1, 1.0);
     totalFQGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
     totalFQGraph_->view().setAutoFollowType(View::AllAutoFollow);
-    // -- Set group styling
-    totalFQGraph_->groupManager().setGroupColouring("Reference", RenderableGroup::FixedGroupColouring);
-    totalFQGraph_->groupManager().setGroupFixedColour("Reference", StockColours::RedStockColour);
 
     setGraphDataTargets(module_);
 
@@ -215,33 +209,34 @@ void XRaySQModuleWidget::setGraphDataTargets(XRaySQModule *module)
     });
 
     // Add calculated total G(r)
-    Renderable *totalGR = totalGRGraph_->createRenderable(
-        Renderable::Data1DRenderable, fmt::format("{}//WeightedGR//Total", module_->uniqueName()), "Calculated (Direct)");
-    totalGRGraph_->addRenderableToGroup(totalGR, "Calculated");
+    totalGRGraph_->createRenderable(Renderable::Data1DRenderable, fmt::format("{}//WeightedGR//Total", module_->uniqueName()),
+                                    "Calculated G(r) (Direct)", "Calculated");
 
     // Add calculated total representative G(r) (from FT of S(Q))
-    Renderable *repGR = totalGRGraph_->createRenderable(
-        Renderable::Data1DRenderable, fmt::format("{}//RepresentativeTotalGR", module_->uniqueName()), "Calculated (via FT)");
+    Renderable *repGR = totalGRGraph_->createRenderable(Renderable::Data1DRenderable,
+                                                        fmt::format("{}//RepresentativeTotalGR", module_->uniqueName()),
+                                                        "Calculated G(r) (via FT)", "Calculated");
     repGR->lineStyle().setStipple(LineStipple::HalfDashStipple);
-    totalGRGraph_->addRenderableToGroup(repGR, "Calculated");
+    repGR->setColour(StockColours::RedStockColour);
 
     // Add calculate total F(Q)
-    Renderable *totalFQ = totalFQGraph_->createRenderable(
-        Renderable::Data1DRenderable, fmt::format("{}//WeightedSQ//Total", module_->uniqueName()), "Calculated");
-    totalFQGraph_->addRenderableToGroup(totalFQ, "Calculated");
+    totalFQGraph_->createRenderable(Renderable::Data1DRenderable, fmt::format("{}//WeightedSQ//Total", module_->uniqueName()),
+                                    "Calculated F(Q)", "Calculated");
 
     // Add on reference data if present
     const Data1DImportFileFormat &referenceFileAndFormat = module->referenceFQFileAndFormat();
     if (referenceFileAndFormat.hasValidFileAndFormat())
     {
         // Add FT of reference data total G(r)
-        Renderable *refGR = totalGRGraph_->createRenderable(
-            Renderable::Data1DRenderable, fmt::format("{}//ReferenceDataFT", module_->uniqueName()), "Reference");
-        totalGRGraph_->addRenderableToGroup(refGR, "Reference");
+        totalGRGraph_
+            ->createRenderable(Renderable::Data1DRenderable, fmt::format("{}//ReferenceDataFT", module_->uniqueName()),
+                               "Reference G(r) (via FT)", "Reference")
+            ->setColour(StockColours::RedStockColour);
 
         // Add calculate total F(Q)
-        Renderable *refFQ = totalFQGraph_->createRenderable(
-            Renderable::Data1DRenderable, fmt::format("{}//ReferenceData", module_->uniqueName()), "Reference");
-        totalFQGraph_->addRenderableToGroup(refFQ, "Reference");
+        totalFQGraph_
+            ->createRenderable(Renderable::Data1DRenderable, fmt::format("{}//ReferenceData", module_->uniqueName()),
+                               "Reference F(Q)", "Reference")
+            ->setColour(StockColours::RedStockColour);
     }
 }

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -259,10 +259,15 @@ bool XRaySQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     auto &repGR = GenericListHelper<Data1D>::realise(dissolve.processingModuleData(), "RepresentativeTotalGR", uniqueName_,
                                                      GenericItem::InRestartFileFlag);
     repGR = weightedSQ.total();
-    auto qMin = weightedSQ.total().values().firstValue();
-    auto qMax = weightedSQ.total().values().lastValue();
-    double rho = nTargetConfigurations() == 0 ? 0.1 : RDFModule::summedRho(this, dissolve.processingModuleData());
-    Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * rho), qMin, 0.05, qMax, referenceWindowFunction);
+    auto rMin = weightedGR.total().xAxis().firstValue();
+    auto rMax = weightedGR.total().xAxis().lastValue();
+    auto rho = 0.1;
+    if (dissolve.processingModuleData().contains("EffectiveRho", rdfModule->uniqueName()))
+        rho = GenericListHelper<double>::value(dissolve.processingModuleData(), "EffectiveRho", rdfModule->uniqueName());
+    else
+        Messenger::warn("Couldn't locate effective atomic density for RDF module.\n");
+
+    Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * rho), rMin, 0.05, rMax, referenceWindowFunction);
     repGR.setObjectTag(fmt::format("{}//RepresentativeTotalGR", uniqueName_));
 
     // Save data if requested

--- a/tests/xray/water.txt
+++ b/tests/xray/water.txt
@@ -85,8 +85,6 @@ Layer  'Processing'
   Module  SQ  'SQ01'
     Frequency  1
     SourceRDFs  'RDF01'
-    QMin  0.0
-    QDelta 0.05
     QBroadening  GaussianC2  0.0  0.02
   EndModule
 


### PR DESCRIPTION
This PR addresses some issues identified in the GUI regarding display of certain data, arising from recent changes in workflow (#402).

Summary of major changes:
- Fixed renderable names referenced in module widgets.
- Simplified SQ widget to reflect change in data relevant to the module.
- Made data labels on some graphs more descriptive.
- Fixed some issues with Fourier transform of data, which were wrongly calculating the atomic density.
- Fixed issue with AtomTypeList / AtomTypeData, where populations would not be carried across if no isotopes were defined.
