### PR TITLE
Bugfix 13/11/20 Recognise lowercase elements

### DIFF
--- a/src/data/elements.cpp
+++ b/src/data/elements.cpp
@@ -130,7 +130,7 @@ Element &Elements::element(std::string_view symbol)
     }
     else
         for (auto n = 0; n < nElements(); n++)
-            if (cleaned == elements()[n].symbol())
+            if (DissolveSys::sameString(cleaned, elements()[n].symbol()))
                 return elements()[n];
 
     return elements()[0];


### PR DESCRIPTION
A tiny bugfix PR to address an issue where element symbols written entirely in lowercase would not be recognised as valid elements.
