### PR TITLE
Use ANTLR4 for expression parsing (1/2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,12 @@ else()
   set(NO_WHOLE_ARCHIVE_FLAG "-Wl,-no-whole-archive")
 endif()
 
+# Enable build of unit tests?
+if (BUILD_TESTS)
+  ENABLE_TESTING()
+  ADD_SUBDIRECTORY(unit)
+endif(BUILD_TESTS)
+
 # Build CLI target executable
 target_link_libraries( ${target_name}
 
@@ -340,7 +346,6 @@ target_link_libraries( ${target_name}
   antlr4-runtime
 
   ${EXTRA_LINK_LIBS}
-
 
   INTERFACE
 

--- a/src/base/sysfunc.cpp
+++ b/src/base/sysfunc.cpp
@@ -272,6 +272,21 @@ bool DissolveSys::isNumber(std::string_view text, bool &isFloatingPoint)
     return true;
 }
 
+// Replace all occurrences of search string with replace string
+std::string DissolveSys::replace(const std::string_view source, const std::string_view search, const std::string_view replace)
+{
+    std::string result{source};
+
+    size_t pos = result.find(search);
+    while (pos != std::string::npos)
+    {
+        result.replace(pos, search.size(), replace);
+        pos = result.find(search, pos + replace.size());
+    }
+
+    return result;
+}
+
 /*
  * Files
  */

--- a/src/base/sysfunc.h
+++ b/src/base/sysfunc.h
@@ -54,6 +54,8 @@ class DissolveSys
     static bool isNumber(std::string_view text);
     // Return whether the supplied string is a number, and also whether it is floating-point
     static bool isNumber(std::string_view text, bool &isFloatingPoint);
+    // Replace all occurrences of search string with replace string
+    static std::string replace(const std::string_view source, const std::string_view search, const std::string_view replace);
 
     /*
      * Files

--- a/src/expression/CMakeLists.txt
+++ b/src/expression/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Expression ANTLR Lexer/Parser
+antlr_target(ExpressionGrammarLexer ExpressionLexer.g4 LEXER)
+#              PACKAGE ExpressionGrammar)
+antlr_target(ExpressionGrammarParser ExpressionParser.g4 PARSER
+#              PACKAGE ExpressionGrammar
+             DEPENDS_ANTLR ExpressionGrammarLexer
+             COMPILE_FLAGS -no-listener -visitor -lib ${ANTLR_ExpressionGrammarLexer_OUTPUT_DIR})
+
+# Append path to ANTLR parser output, and set cache variable
+list(APPEND ANTLR_OUTPUT_DIRS ${ANTLR_ExpressionGrammarLexer_OUTPUT_DIR})
+list(APPEND ANTLR_OUTPUT_DIRS ${ANTLR_ExpressionGrammarParser_OUTPUT_DIR})
+set(ANTLR_OUTPUT_DIRS ${ANTLR_OUTPUT_DIRS} CACHE INTERNAL "")
+
+# Old Bison target
 bison_target(ExpressionGenerator generator_grammar.yy ${CMAKE_CURRENT_BINARY_DIR}/generator_grammar.cc COMPILE_FLAGS -y )
 
 add_library(expression
@@ -10,6 +24,8 @@ add_library(expression
   value.cpp
   variable.cpp
   variablevalue.cpp
+  ExpressionErrorListeners.cpp
+  ExpressionVisitor.cpp
 
   expression.h
   function.h
@@ -19,9 +35,45 @@ add_library(expression
   value.h
   variable.h
   variablevalue.h
+  ExpressionErrorListeners.h
+  ExpressionVisitor.h
+
+  ${ANTLR_ExpressionGrammarLexer_CXX_OUTPUTS}
+  ${ANTLR_ExpressionGrammarParser_CXX_OUTPUTS}
+
+  ExpressionErrorListeners.cpp
+  ExpressionVisitor.cpp
+  binary.cpp
+  expressionNEW.cpp
+  functionNEW.cpp
+  nodeNEW.cpp
+  number.cpp
+  reference.cpp
+  root.cpp
+  unary.cpp
+
+  ExpressionErrorListeners.h
+  ExpressionVisitor.h
+  binary.h
+  expressionNEW.h
+  functionNEW.h
+  nodeNEW.h
+  number.h
+  reference.h
+  root.h
+  unary.h
 )
 
 target_include_directories(expression PRIVATE
   ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_BINARY_DIR}/src
+  ${ANTLRRUNTIME_INCLUDE_DIRS}
+  ${ANTLR_ExpressionGrammarLexer_OUTPUT_DIR}
+  ${ANTLR_ExpressionGrammarParser_OUTPUT_DIR}
 )
+
+
+
+
+
+

--- a/src/expression/ExpressionErrorListeners.cpp
+++ b/src/expression/ExpressionErrorListeners.cpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/ExpressionErrorListeners.h"
+#include "base/messenger.h"
+#include "expression/expressionNEW.h"
+
+/*
+ * Expression Lexer Error Listener
+ */
+
+ExpressionLexerErrorListener::ExpressionLexerErrorListener(const ExpressionNEW &expr) : expression_(expr) {}
+
+void ExpressionLexerErrorListener::syntaxError(antlr4::Recognizer *recognizer, antlr4::Token *token, size_t line,
+                                               size_t charPositionInLine, const std::string &message, std::exception_ptr ep)
+{
+    Messenger::print("\nError in Expression definition '{}'\n", expression_.expressionString());
+    std::string marker(32 + charPositionInLine, ' ');
+    marker += '^';
+    Messenger::print("{}\n", marker);
+
+    // The actual error message can contain braces, so escape those to avoid breaking fmt
+    auto escaped = DissolveSys::replace(DissolveSys::replace(message, "{", "{{"), "}", "}}");
+
+    throw ExpressionExceptions::ExpressionSyntaxException(fmt::format("Syntax Error: {}", escaped));
+}
+
+/*
+ * Expression Parser Error Listener
+ */
+
+ExpressionParserErrorListener::ExpressionParserErrorListener(const ExpressionNEW &expr) : expression_(expr) {}
+
+void ExpressionParserErrorListener::syntaxError(antlr4::Recognizer *recognizer, antlr4::Token *token, size_t line,
+                                                size_t charPositionInLine, const std::string &message, std::exception_ptr ep)
+{
+    Messenger::print("\nError in Expression definition '{}'\n", expression_.expressionString());
+    std::string marker(32 + charPositionInLine, ' ');
+    marker += '^';
+    Messenger::print("{}\n", marker);
+
+    // The actual error message can contain braces, so escape those to avoid breaking fmt
+    auto escaped = DissolveSys::replace(DissolveSys::replace(message, "{", "{{"), "}", "}}");
+
+    throw ExpressionExceptions::ExpressionSyntaxException(fmt::format("Syntax Error: {}", escaped));
+}

--- a/src/expression/ExpressionErrorListeners.h
+++ b/src/expression/ExpressionErrorListeners.h
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include <antlr4-runtime.h>
+#include <exception>
+
+// Forward Declarations
+class ExpressionNEW;
+
+namespace ExpressionExceptions
+{
+// Expression Syntax Exception
+class ExpressionSyntaxException : public std::exception
+{
+    public:
+    ExpressionSyntaxException(std::string_view message = "Undefined Expression Syntax Exception") : message_{message} {}
+
+    private:
+    // Error message
+    std::string message_;
+
+    public:
+    virtual const char *what() const throw() { return message_.c_str(); }
+};
+
+// Expression Internal Error Exception
+class ExpressionInternalErrorException : public std::exception
+{
+    public:
+    ExpressionInternalErrorException(std::string_view message = "Expression internal error.") : message_{message} {}
+
+    private:
+    // Error message
+    std::string message_;
+
+    public:
+    virtual const char *what() const throw() { return message_.c_str(); }
+};
+} // namespace ExpressionExceptions
+
+// Expression Lexer Error Listener
+class ExpressionLexerErrorListener : public antlr4::BaseErrorListener
+{
+    public:
+    ExpressionLexerErrorListener(const ExpressionNEW &expr);
+
+    private:
+    // Expression being constructed
+    const ExpressionNEW &expression_;
+
+    /*
+     * BaseErrorListener Overrides
+     */
+    public:
+    void syntaxError(antlr4::Recognizer *recognizer, antlr4::Token *, size_t line, size_t charPositionInLine,
+                     const std::string &, std::exception_ptr ep);
+};
+
+// Expression Parser Error Listener
+class ExpressionParserErrorListener : public antlr4::BaseErrorListener
+{
+    public:
+    ExpressionParserErrorListener(const ExpressionNEW &expr);
+
+    private:
+    // Expression being constructed
+    const ExpressionNEW &expression_;
+
+    /*
+     * BaseErrorListener Overrides
+     */
+    public:
+    void syntaxError(antlr4::Recognizer *recognizer, antlr4::Token *, size_t line, size_t charPositionInLine,
+                     const std::string &, std::exception_ptr ep);
+};

--- a/src/expression/ExpressionLexer.g4
+++ b/src/expression/ExpressionLexer.g4
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+lexer grammar ExpressionLexer;
+
+// Lexer file header
+@lexer::header {/* Expression ANTLR Lexer */}
+
+// Add custom includes after standard ANTLR includes in both *.h and *.cpp files
+@lexer::postinclude { }
+
+// Directly precedes the lexer class declaration in the h file (e.g. for additional types etc.).
+@lexer::context {/* lexer context section */}
+
+// Appears in the private part of the lexer in the h file.
+@lexer::declarations {
+bool isVariable(std::string symbol) { return false; /* Elements::element(symbol.c_str()).Z() != 0; */ }
+}
+
+// Appears in line with the other class member definitions in the cpp file.
+@lexer::definitions {/* lexer definitions section */}
+
+/*
+ * Lexer Rules
+ */
+
+// Fragments
+fragment DIGIT: [0-9];
+fragment LETTER: [a-zA-Z];
+fragment EXPONENT: ('e'|'E') ('+'|'-')? ('0'..'9')+;
+ 
+// Comparison Operators
+ComparisonOperator: '<=' | '>=' | '<' | '>' | '=' | '!=';
+
+// Punctuation
+OpenParenthesis: '(';
+CloseParenthesis: ')';
+Comma: ',';
+
+// Whitespace
+WS : [ ]+ -> skip;
+
+// Numerical Tokens
+Integer: DIGIT+ EXPONENT?;
+Double: DIGIT* '.' DIGIT+ EXPONENT?;
+
+// Operators
+Multiply: '*';
+Divide: '/';
+Add: '+';
+Subtract: '-';
+Power: '^';
+
+// Named Token
+Name: LETTER+;
+// Variable: LETTER+ { isVariable(getText()) }?;

--- a/src/expression/ExpressionParser.g4
+++ b/src/expression/ExpressionParser.g4
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+parser grammar ExpressionParser;
+
+options {
+	tokenVocab = ExpressionLexer;
+}
+
+// Parser file header
+@parser::header {/* Expression ANTLR Parser */}
+
+// Add custom includes after standard ANTLR includes in both *.h and *.cpp files
+@parser::postinclude { }
+
+// Appears in the private part of the parser in the h file.
+@parser::members { /* public parser declarations/members section */ }
+
+// Appears in the public part of the parser in the h file.
+@parser::declarations {/* private parser declarations section */}
+
+// Appears in line with the other class member definitions in the cpp file.
+@parser::definitions {/* parser definitions section */}
+
+/*
+ * Expression Grammar
+ */
+
+// Compound expression
+expression: expr EOF;
+
+// Expressions
+expr: OpenParenthesis expr CloseParenthesis                     #parentheses
+| Subtract expr                                                 #unaryMinus
+| expr Power expr                                               #power
+| expr op=(Multiply | Divide) expr                              #multiplyDivide
+| expr op=(Add | Subtract) expr                                 #addSubtract
+| Name OpenParenthesis (expr (Comma expr)*)? CloseParenthesis   #function
+| Name                                                          #variable
+| value                                                         #number
+;
+
+// Numerical value
+value: Integer
+| Double;

--- a/src/expression/ExpressionVisitor.cpp
+++ b/src/expression/ExpressionVisitor.cpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/ExpressionVisitor.h"
+#include "data/ff.h"
+#include "expression/ExpressionErrorListeners.h"
+#include "expression/binary.h"
+#include "expression/functionNEW.h"
+#include "expression/number.h"
+#include "expression/reference.h"
+#include "expression/unary.h"
+#include "expression/variable.h"
+#include "templates/optionalref.h"
+
+/*
+ * Creation Entry Point
+ */
+
+// Return the topmost context in the stack
+std::shared_ptr<ExpressionNodeNEW> ExpressionVisitor::currentContext() const
+{
+    assert(contextStack_.size() != 0);
+
+    return contextStack_.back();
+}
+
+// Construct description within supplied object, from given tree
+void ExpressionVisitor::create(ExpressionNEW &expr, ExpressionParser::ExpressionContext *tree,
+                               RefList<ExpressionVariable> externalVariables)
+{
+    expression_ = &expr;
+    externalVariables_ = externalVariables;
+
+    // Add the definition's root node as the topmost context in the stack
+    contextStack_.push_back(expression_->rootNode());
+
+    // Traverse the AST
+    visitChildren(tree);
+}
+
+/*
+ * Visitor Overrides
+ */
+
+antlrcpp::Any ExpressionVisitor::visitParentheses(ExpressionParser::ParenthesesContext *ctx)
+{
+    auto node = std::make_shared<ExpressionRootNode>();
+
+    currentContext()->addChild(node);
+
+    contextStack_.push_back(node);
+
+    auto result = visitChildren(ctx);
+
+    contextStack_.pop_back();
+
+    return result;
+}
+
+antlrcpp::Any ExpressionVisitor::visitUnaryMinus(ExpressionParser::UnaryMinusContext *ctx)
+{
+    auto node = std::make_shared<ExpressionUnaryOperatorNode>(ExpressionUnaryOperatorNode::OperatorNegate);
+
+    currentContext()->addChild(node);
+
+    contextStack_.push_back(node);
+
+    auto result = visitChildren(ctx);
+
+    contextStack_.pop_back();
+
+    return result;
+}
+
+antlrcpp::Any ExpressionVisitor::visitPower(ExpressionParser::PowerContext *ctx)
+{
+    auto node = std::make_shared<ExpressionBinaryOperatorNode>(ExpressionBinaryOperatorNode::OperatorPow);
+
+    currentContext()->addChild(node);
+
+    contextStack_.push_back(node);
+
+    auto result = visitChildren(ctx);
+
+    contextStack_.pop_back();
+
+    return result;
+}
+
+antlrcpp::Any ExpressionVisitor::visitMultiplyDivide(ExpressionParser::MultiplyDivideContext *ctx)
+{
+    auto node = std::make_shared<ExpressionBinaryOperatorNode>(ctx->Multiply() ? ExpressionBinaryOperatorNode::OperatorMultiply
+                                                                               : ExpressionBinaryOperatorNode::OperatorDivide);
+
+    currentContext()->addChild(node);
+
+    contextStack_.push_back(node);
+
+    auto result = visitChildren(ctx);
+
+    contextStack_.pop_back();
+
+    return result;
+}
+
+antlrcpp::Any ExpressionVisitor::visitAddSubtract(ExpressionParser::AddSubtractContext *ctx)
+{
+    auto node = std::make_shared<ExpressionBinaryOperatorNode>(ctx->Add() ? ExpressionBinaryOperatorNode::OperatorAdd
+                                                                          : ExpressionBinaryOperatorNode::OperatorSubtract);
+
+    currentContext()->addChild(node);
+
+    contextStack_.push_back(node);
+
+    auto result = visitChildren(ctx);
+
+    contextStack_.pop_back();
+
+    return result;
+}
+
+antlrcpp::Any ExpressionVisitor::visitFunction(ExpressionParser::FunctionContext *ctx)
+{
+    // Check that the function name is valid
+    if (!ExpressionFunctionNode::internalFunctions().isValid(ctx->Name()->getText()))
+        throw(ExpressionExceptions::ExpressionSyntaxException(
+            fmt::format("'{}' is not a valid internal function.", ctx->Name()->getText())));
+    ExpressionFunctionNode::InternalFunction func =
+        ExpressionFunctionNode::internalFunctions().enumeration(ctx->Name()->getText());
+
+    auto node = std::make_shared<ExpressionFunctionNode>(func);
+
+    currentContext()->addChild(node);
+
+    contextStack_.push_back(node);
+
+    auto result = visitChildren(ctx);
+
+    contextStack_.pop_back();
+
+    // Check number of args that were given...
+    const auto nArgs = ExpressionFunctionNode::internalFunctions().minArgs(func);
+    if (node->nChildren() != nArgs)
+        throw(ExpressionExceptions::ExpressionSyntaxException(
+            fmt::format("Internal function '{}' expects exactly {} {} but {} {} given.", ctx->Name()->getText(), nArgs,
+                        nArgs == 1 ? "argument" : "arguments", node->nChildren(), node->nChildren() == 1 ? "was" : "were")));
+
+    return result;
+}
+
+antlrcpp::Any ExpressionVisitor::visitVariable(ExpressionParser::VariableContext *ctx)
+{
+    // Does the named variable exist?
+    auto it = std::find_if(externalVariables_.begin(), externalVariables_.end(),
+                           [ctx](auto var) { return DissolveSys::sameString(var->name(), ctx->Name()->getText()); });
+    if (it == externalVariables_.end())
+        throw(ExpressionExceptions::ExpressionSyntaxException(
+            fmt::format("Variable '{}' does not exist in this context.", ctx->Name()->getText())));
+
+    auto node = std::make_shared<ExpressionReferenceNode>(it.item());
+
+    currentContext()->addChild(node);
+
+    return visitChildren(ctx);
+}
+
+antlrcpp::Any ExpressionVisitor::visitValue(ExpressionParser::ValueContext *ctx)
+{
+    if (ctx->Integer())
+        currentContext()->addChild(std::make_shared<ExpressionNumberNode>(std::stoi(ctx->Integer()->getText())));
+    else if (ctx->Double())
+        currentContext()->addChild(std::make_shared<ExpressionNumberNode>(std::stod(ctx->Double()->getText())));
+
+    return visitChildren(ctx);
+}
+
+/*
+antlrcpp::Any ExpressionVisitor::visitFlag(ExpressionParser::FlagContext *context)
+{
+    if (currentExpressionContext()->isValidFlag(context->Keyword()->getText().c_str()))
+    {
+        if (!currentExpressionContext()->setFlag(context->Keyword()->getText().c_str(), true))
+            throw(ExpressionExceptions::ExpressionSyntaxException(
+                fmt::format("Failed to set flag '{}' for the current context ({}).", context->Keyword()->getText().c_str(),
+                            ExpressionNode::nodeTypes().keyword(currentExpressionContext()->nodeType()))));
+    }
+    else
+        throw(ExpressionExceptions::ExpressionSyntaxException(
+            fmt::format("'{}' is not a valid flag for the current context ({}).", context->Keyword()->getText().c_str(),
+                        ExpressionNode::nodeTypes().keyword(currentExpressionContext()->nodeType()))));
+
+    return visitChildren(context);
+}*/

--- a/src/expression/ExpressionVisitor.h
+++ b/src/expression/ExpressionVisitor.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include "ExpressionParserBaseVisitor.h"
+#include "expression/expressionNEW.h"
+#include <antlr4-runtime.h>
+
+// Expression Visitor for ANTLR
+class ExpressionVisitor : ExpressionParserBaseVisitor
+{
+    /*
+     * Creation Entry-Point
+     */
+    private:
+    // Target ExpressionDefinition
+    ExpressionNEW *expression_;
+    // External variables available to this expression
+    RefList<ExpressionVariable> externalVariables_;
+    // Context stack
+    std::vector<std::shared_ptr<ExpressionNodeNEW>> contextStack_;
+
+    private:
+    // Return the topmost context in the stack
+    std::shared_ptr<ExpressionNodeNEW> currentContext() const;
+
+    public:
+    // Construct description within supplied object, from given tree
+    void create(ExpressionNEW &expr, ExpressionParser::ExpressionContext *tree, RefList<ExpressionVariable> externalVariables);
+
+    /*
+     * Visitor Overrides
+     */
+    private:
+    // Nodes
+    antlrcpp::Any visitParentheses(ExpressionParser::ParenthesesContext *ctx) override;
+    antlrcpp::Any visitUnaryMinus(ExpressionParser::UnaryMinusContext *ctx) override;
+    antlrcpp::Any visitPower(ExpressionParser::PowerContext *ctx) override;
+    antlrcpp::Any visitMultiplyDivide(ExpressionParser::MultiplyDivideContext *ctx) override;
+    antlrcpp::Any visitAddSubtract(ExpressionParser::AddSubtractContext *ctx) override;
+    antlrcpp::Any visitFunction(ExpressionParser::FunctionContext *ctx) override;
+    antlrcpp::Any visitVariable(ExpressionParser::VariableContext *ctx) override;
+    antlrcpp::Any visitValue(ExpressionParser::ValueContext *ctx) override;
+};

--- a/src/expression/binary.cpp
+++ b/src/expression/binary.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/binary.h"
+
+ExpressionBinaryOperatorNode::ExpressionBinaryOperatorNode(BinaryOperator op) : ExpressionNodeNEW(), operator_(op) {}
+
+/*
+ * Evaluation
+ */
+
+// Evaluate node
+std::optional<ExpressionValue> ExpressionBinaryOperatorNode::evaluate() const
+{
+    // Must be two child nodes
+    if (children_.size() != 2)
+        return std::nullopt;
+
+    // Evaluate LHS and RHS nodes
+    auto optl = children_[0]->evaluate();
+    if (!optl)
+        return std::nullopt;
+    auto optr = children_[1]->evaluate();
+    if (!optr)
+        return std::nullopt;
+
+    // Perform the operation
+    ExpressionValue result;
+    auto lhs = (*optl), rhs = (*optr);
+    switch (operator_)
+    {
+        case (OperatorAdd):
+            if (ExpressionValue::bothIntegers(lhs, rhs))
+                result = lhs.asInteger() + rhs.asInteger();
+            else
+                result = lhs.asDouble() + rhs.asDouble();
+            break;
+        case (OperatorDivide):
+            if (ExpressionValue::bothIntegers(lhs, rhs))
+                result = lhs.asInteger() / rhs.asInteger();
+            else
+                result = lhs.asDouble() / rhs.asDouble();
+            break;
+        case (OperatorSubtract):
+            if (ExpressionValue::bothIntegers(lhs, rhs))
+                result = lhs.asInteger() - rhs.asInteger();
+            else
+                result = lhs.asDouble() - rhs.asDouble();
+            break;
+        case (OperatorPow):
+            result = pow(lhs.asDouble(), rhs.asDouble());
+            break;
+        case (OperatorMultiply):
+            if (ExpressionValue::bothIntegers(lhs, rhs))
+                result = lhs.asInteger() * rhs.asInteger();
+            else
+                result = lhs.asDouble() * rhs.asDouble();
+            break;
+    }
+
+    return result;
+}

--- a/src/expression/binary.h
+++ b/src/expression/binary.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include "expression/nodeNEW.h"
+
+// Expression Binary Operator Node
+class ExpressionBinaryOperatorNode : public ExpressionNodeNEW
+{
+    public:
+    // Binary Operators Enum
+    enum BinaryOperator
+    {
+        OperatorAdd,
+        OperatorDivide,
+        OperatorMultiply,
+        OperatorPow,
+        OperatorSubtract
+    };
+    ExpressionBinaryOperatorNode(BinaryOperator op);
+    ~ExpressionBinaryOperatorNode() = default;
+
+    /*
+     * Data
+     */
+    private:
+    // Operator type
+    BinaryOperator operator_;
+
+    /*
+     * Evaluation
+     */
+    public:
+    // Evaluate node
+    virtual std::optional<ExpressionValue> evaluate() const;
+};

--- a/src/expression/expressionNEW.cpp
+++ b/src/expression/expressionNEW.cpp
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/expressionNEW.h"
+#include "ExpressionLexer.h"
+#include "ExpressionParser.h"
+#include "base/messenger.h"
+#include "base/sysfunc.h"
+#include "expression/ExpressionErrorListeners.h"
+#include "expression/ExpressionVisitor.h"
+#include "expression/root.h"
+#include <algorithm>
+#include <stdarg.h>
+#include <string.h>
+
+ExpressionNEW::ExpressionNEW(std::string_view expressionText)
+{
+    if (!expressionText.empty())
+        create(expressionText);
+}
+
+ExpressionNEW::~ExpressionNEW() { clear(); }
+
+ExpressionNEW::ExpressionNEW(const ExpressionNEW &source) { (*this) = source; }
+
+void ExpressionNEW::operator=(const ExpressionNEW &source)
+{
+    throw(std::runtime_error("TODO Expression::operator= not implemented"));
+    // Reset our structure, and regenerate from the expression string
+    //     clear();
+
+    //     expressionString_ = source.expressionString_;
+
+    //     ExpressionNEWGenerator::generate(*this, source.externalVariables_);
+}
+
+/*
+ * Data
+ */
+
+// Clear data
+void ExpressionNEW::clear()
+{
+    expressionString_ = "";
+
+    if (rootNode_)
+        rootNode_->clear();
+
+    rootNode_ = nullptr;
+}
+
+// Return whether current expression is valid
+bool ExpressionNEW::isValid() const { return rootNode_ != nullptr; }
+
+// Create expression from supplied string, with optional external variables
+bool ExpressionNEW::create(std::string_view expressionString, RefList<ExpressionVariable> externalVariables)
+{
+    clear();
+
+    expressionString_ = expressionString;
+    rootNode_ = std::make_shared<ExpressionRootNode>();
+
+    // Create string stream and set up ANTLR input strem
+    std::stringstream stream;
+    stream << expressionString_;
+    antlr4::ANTLRInputStream input(stream);
+
+    // Create ANTLR lexer and set-up error listener
+    ExpressionLexer lexer(&input);
+    ExpressionLexerErrorListener lexerErrorListener(*this);
+    lexer.removeErrorListeners();
+    lexer.addErrorListener(&lexerErrorListener);
+
+    // Generate tokens from input stream
+    antlr4::CommonTokenStream tokens(&lexer);
+
+    // Create ANTLR parser and set-up error listenres
+    ExpressionParser parser(&tokens);
+    ExpressionParserErrorListener parserErrorListener(*this);
+    parser.removeErrorListeners();
+    parser.removeParseListeners();
+    parser.addErrorListener(&lexerErrorListener);
+    parser.addErrorListener(&parserErrorListener);
+
+    // Generate the AST
+    ExpressionParser::ExpressionContext *tree = nullptr;
+    try
+    {
+        tree = parser.expression();
+    }
+    catch (ExpressionExceptions::ExpressionSyntaxException &ex)
+    {
+        return Messenger::error(ex.what());
+    };
+
+    // Visit the nodes in the AST
+    ExpressionVisitor visitor;
+    try
+    {
+        visitor.create(*this, tree, externalVariables);
+    }
+    catch (ExpressionExceptions::ExpressionSyntaxException &ex)
+    {
+        return Messenger::error(ex.what());
+    }
+
+    return true;
+}
+
+// Return original generating string
+std::string_view ExpressionNEW::expressionString() const { return expressionString_; }
+
+// Return root node for the expression
+std::shared_ptr<ExpressionRootNode> ExpressionNEW::rootNode() { return rootNode_; }
+
+/*
+ * Execution
+ */
+
+// Execute expression
+std::optional<ExpressionValue> ExpressionNEW::evaluate()
+{
+    if (rootNode_)
+        return rootNode_->evaluate();
+
+    return std::nullopt;
+}
+
+// Execute and return as integer
+int ExpressionNEW::asInteger()
+{
+    auto result = evaluate();
+    if (!result)
+        throw(std::runtime_error(fmt::format("Failed to evaluate expression '{}'.", expressionString_)));
+
+    return (*result).asInteger();
+}
+
+// Execute and return as double
+double ExpressionNEW::asDouble()
+{
+    auto result = evaluate();
+    if (!result)
+        throw(std::runtime_error(fmt::format("Failed to evaluate expression '{}'.", expressionString_)));
+
+    return (*result).asDouble();
+}

--- a/src/expression/expressionNEW.h
+++ b/src/expression/expressionNEW.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include "expression/functions.h"
+#include "expression/root.h"
+#include "templates/reflist.h"
+
+// Forward Declarations
+class ExpressionVariable;
+
+// Mathematical Expression
+class ExpressionNEW
+{
+    public:
+    ExpressionNEW(std::string_view expressionText = "");
+    ~ExpressionNEW();
+    ExpressionNEW(const ExpressionNEW &source);
+    void operator=(const ExpressionNEW &source);
+
+    /*
+     * Data
+     */
+    private:
+    // Original generating string
+    std::string expressionString_;
+    // Root node for the expression
+    std::shared_ptr<ExpressionRootNode> rootNode_;
+
+    public:
+    // Clear data
+    void clear();
+    // Return whether current expression is valid (contains at least one node)
+    bool isValid() const;
+    // Create expression from supplied string, with optional external variables
+    bool create(std::string_view expressionString,
+                RefList<ExpressionVariable> externalVariables = RefList<ExpressionVariable>());
+    // Return original generating string
+    std::string_view expressionString() const;
+    // Return root node for the expression
+    std::shared_ptr<ExpressionRootNode> rootNode();
+
+    /*
+     * Execution
+     */
+    public:
+    // Evaluate the expression
+    std::optional<ExpressionValue> evaluate();
+    // Execute and return as integer
+    int asInteger();
+    // Execute and return as double
+    double asDouble();
+};

--- a/src/expression/functionNEW.cpp
+++ b/src/expression/functionNEW.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/functionNEW.h"
+#include "math/constants.h"
+
+// Return enum options for NodeTypes
+EnumOptions<ExpressionFunctionNode::InternalFunction> ExpressionFunctionNode::internalFunctions()
+{
+    static EnumOptionsList InternalFunctions =
+        EnumOptionsList() << EnumOption(AbsFunction, "abs", 1, 1) << EnumOption(ACosFunction, "acos", 1, 1)
+                          << EnumOption(ASinFunction, "asin", 1, 1) << EnumOption(ATanFunction, "atan", 1, 1)
+                          << EnumOption(CosFunction, "cos", 1, 1) << EnumOption(ExpFunction, "exp", 1, 1)
+                          << EnumOption(LnFunction, "ln", 1, 1) << EnumOption(LogFunction, "log", 1, 1)
+                          << EnumOption(SinFunction, "sin", 1, 1) << EnumOption(SqrtFunction, "sqrt", 1, 1)
+                          << EnumOption(TanFunction, "tan", 1, 1);
+
+    static EnumOptions<ExpressionFunctionNode::InternalFunction> options("InternalFunction", InternalFunctions);
+
+    return options;
+}
+
+ExpressionFunctionNode::ExpressionFunctionNode(InternalFunction func) : ExpressionNodeNEW(), function_(func) {}
+
+/*
+ * Evaluation
+ */
+
+// Evaluate node
+std::optional<ExpressionValue> ExpressionFunctionNode::evaluate() const
+{
+    // Number of required child nodes depends on the function
+    const auto nArgs = internalFunctions().minArgs(function_);
+    if (children_.size() != nArgs)
+        return std::nullopt;
+
+    // Evaluate the arguments
+    std::vector<ExpressionValue> args;
+    for (auto n = 0; n < nArgs; ++n)
+    {
+        auto optArg = children_[n]->evaluate();
+        if (!optArg)
+            return std::nullopt;
+        args.emplace_back(*optArg);
+    }
+
+    // Evaluate the function
+    ExpressionValue result;
+    switch (function_)
+    {
+        case (AbsFunction):
+            if (args[0].isInteger())
+                result = abs(args[0].asInteger());
+            else
+                result = fabs(args[0].asDouble());
+            break;
+        case (ACosFunction):
+            result = acos(args[0].asDouble()) * DEGRAD;
+            break;
+        case (ASinFunction):
+            result = asin(args[0].asDouble()) * DEGRAD;
+            break;
+        case (ATanFunction):
+            result = atan(args[0].asDouble()) * DEGRAD;
+            break;
+        case (CosFunction):
+            result = cos(args[0].asDouble() / DEGRAD);
+            break;
+        case (ExpFunction):
+            result = exp(args[0].asDouble());
+            break;
+        case (LnFunction):
+            result = log(args[0].asDouble());
+            break;
+        case (LogFunction):
+            result = log10(args[0].asDouble());
+            break;
+        case (SinFunction):
+            result = sin(args[0].asDouble() / DEGRAD);
+            break;
+        case (SqrtFunction):
+            result = sqrt(args[0].asDouble());
+            break;
+        case (TanFunction):
+            result = tan(args[0].asDouble() / DEGRAD);
+            break;
+    }
+
+    return result;
+}

--- a/src/expression/functionNEW.h
+++ b/src/expression/functionNEW.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include "expression/nodeNEW.h"
+
+// Expression Function Node
+class ExpressionFunctionNode : public ExpressionNodeNEW
+{
+    public:
+    // Internal Functions enum
+    enum InternalFunction
+    {
+        AbsFunction,
+        ACosFunction,
+        ASinFunction,
+        ATanFunction,
+        CosFunction,
+        ExpFunction,
+        LnFunction,
+        LogFunction,
+        SinFunction,
+        SqrtFunction,
+        TanFunction
+    };
+    // Return enum options for NodeTypes
+    static EnumOptions<ExpressionFunctionNode::InternalFunction> internalFunctions();
+    ExpressionFunctionNode(InternalFunction func);
+    ~ExpressionFunctionNode() = default;
+
+    /*
+     * Data
+     */
+    private:
+    // Function that the node performs
+    InternalFunction function_;
+
+    /*
+     * Evaluation
+     */
+    public:
+    // Evaluate node
+    virtual std::optional<ExpressionValue> evaluate() const;
+};

--- a/src/expression/nodeNEW.cpp
+++ b/src/expression/nodeNEW.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/nodeNEW.h"
+#include "base/messenger.h"
+#include "base/sysfunc.h"
+
+ExpressionNodeNEW::~ExpressionNodeNEW() { clear(); }
+
+/*
+ * Nodes
+ */
+
+// Clear all nodes
+void ExpressionNodeNEW::clear() { children_.clear(); }
+
+// Add child node
+void ExpressionNodeNEW::addChild(std::shared_ptr<ExpressionNodeNEW> node) { children_.emplace_back(node); }
+
+// Return number of children
+int ExpressionNodeNEW::nChildren() const { return children_.size(); }

--- a/src/expression/nodeNEW.h
+++ b/src/expression/nodeNEW.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/enumoptions.h"
+#include "expression/value.h"
+#include <memory>
+#include <vector>
+
+// Forward Declarations
+class ExpressionNEW;
+
+// NETA Node
+class ExpressionNodeNEW
+{
+    public:
+    ExpressionNodeNEW() = default;
+    virtual ~ExpressionNodeNEW();
+
+    /*
+     * Nodes
+     */
+    protected:
+    // Child nodes
+    std::vector<std::shared_ptr<ExpressionNodeNEW>> children_;
+
+    public:
+    // Clear all nodes
+    void clear();
+    // Add child node
+    void addChild(std::shared_ptr<ExpressionNodeNEW> node);
+    // Return number of children
+    int nChildren() const;
+
+    /*
+     * Evaluation
+     */
+    public:
+    // Evaluate node
+    virtual std::optional<ExpressionValue> evaluate() const = 0;
+};

--- a/src/expression/number.cpp
+++ b/src/expression/number.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/number.h"
+
+ExpressionNumberNode::ExpressionNumberNode(int i) : ExpressionNodeNEW() { value_ = i; }
+
+ExpressionNumberNode::ExpressionNumberNode(double d) : ExpressionNodeNEW() { value_ = d; }
+
+/*
+ * Evaluation
+ */
+
+// Evaluate node
+std::optional<ExpressionValue> ExpressionNumberNode::evaluate() const
+{
+    // Must be zero children
+    if (children_.size() != 0)
+        return std::nullopt;
+
+    return value_;
+}

--- a/src/expression/number.h
+++ b/src/expression/number.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include "expression/nodeNEW.h"
+#include "expression/value.h"
+
+// Expression Number Node
+class ExpressionNumberNode : public ExpressionNodeNEW
+{
+    public:
+    ExpressionNumberNode(int i);
+    ExpressionNumberNode(double d);
+    ~ExpressionNumberNode() = default;
+
+    /*
+     * Data
+     */
+    private:
+    // Numerical value of the node
+    ExpressionValue value_;
+
+    /*
+     * Evaluation
+     */
+    public:
+    // Evaluate node
+    virtual std::optional<ExpressionValue> evaluate() const;
+};

--- a/src/expression/reference.cpp
+++ b/src/expression/reference.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/reference.h"
+#include "expression/variable.h"
+
+ExpressionReferenceNode::ExpressionReferenceNode(ExpressionVariable *variable) : ExpressionNodeNEW(), variable_(variable) {}
+
+/*
+ * Evaluation
+ */
+
+// Evaluate node
+std::optional<ExpressionValue> ExpressionReferenceNode::evaluate() const
+{
+    // Must have a valid pointer
+    if (!variable_)
+        return std::nullopt;
+
+    return (variable_->value());
+}

--- a/src/expression/reference.h
+++ b/src/expression/reference.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include "expression/nodeNEW.h"
+
+// Forward Declarations
+class ExpressionVariable;
+
+// Expression Variable Reference Node
+class ExpressionReferenceNode : public ExpressionNodeNEW
+{
+    public:
+    ExpressionReferenceNode(ExpressionVariable *variable);
+    ~ExpressionReferenceNode() = default;
+
+    /*
+     * Data
+     */
+    private:
+    // Target variable
+    ExpressionVariable *variable_;
+
+    /*
+     * Evaluation
+     */
+    public:
+    // Evaluate node
+    virtual std::optional<ExpressionValue> evaluate() const;
+};

--- a/src/expression/root.cpp
+++ b/src/expression/root.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/root.h"
+
+ExpressionRootNode::ExpressionRootNode() : ExpressionNodeNEW() {}
+
+/*
+ * Evaluation
+ */
+
+// Evaluate node
+std::optional<ExpressionValue> ExpressionRootNode::evaluate() const
+{
+    // Must be only a single child node
+    if (children_.size() != 1)
+        return std::nullopt;
+
+    return children_[0]->evaluate();
+}

--- a/src/expression/root.h
+++ b/src/expression/root.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include "expression/nodeNEW.h"
+
+// Expression Root Node
+class ExpressionRootNode : public ExpressionNodeNEW
+{
+    public:
+    ExpressionRootNode();
+    ~ExpressionRootNode() = default;
+
+    /*
+     * Evaluation
+     */
+    public:
+    // Evaluate node
+    virtual std::optional<ExpressionValue> evaluate() const;
+};

--- a/src/expression/unary.cpp
+++ b/src/expression/unary.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/unary.h"
+
+ExpressionUnaryOperatorNode::ExpressionUnaryOperatorNode(UnaryOperator op) : ExpressionNodeNEW(), operator_(op) {}
+
+/*
+ * Evaluation
+ */
+
+// Evaluate node
+std::optional<ExpressionValue> ExpressionUnaryOperatorNode::evaluate() const
+{
+    // Must be a single child node
+    if (children_.size() != 1)
+        return std::nullopt;
+
+    // Evaluate LHS node
+    auto optl = children_[0]->evaluate();
+    if (!optl)
+        return std::nullopt;
+
+    // Perform the operation
+    ExpressionValue result;
+    auto rhs = (*optl);
+    switch (operator_)
+    {
+        case (OperatorNegate):
+            if (rhs.isInteger())
+                result = -rhs.asInteger();
+            else
+                result = -rhs.asDouble();
+            break;
+    }
+
+    return result;
+}

--- a/src/expression/unary.h
+++ b/src/expression/unary.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#pragma once
+
+#include "expression/nodeNEW.h"
+
+// Expression Unary Operator Node
+class ExpressionUnaryOperatorNode : public ExpressionNodeNEW
+{
+    public:
+    // Unary Operators Enum
+    enum UnaryOperator
+    {
+        OperatorNegate
+    };
+    ExpressionUnaryOperatorNode(UnaryOperator op);
+    ~ExpressionUnaryOperatorNode() = default;
+
+    /*
+     * Data
+     */
+    private:
+    // Operator type
+    UnaryOperator operator_;
+
+    /*
+     * Evaluation
+     */
+    public:
+    // Evaluate node
+    virtual std::optional<ExpressionValue> evaluate() const;
+};

--- a/src/expression/value.cpp
+++ b/src/expression/value.cpp
@@ -30,7 +30,13 @@ ExpressionValue::ExpressionValue(double value)
 
 ExpressionValue::~ExpressionValue() {}
 
-ExpressionValue::ExpressionValue(const ExpressionValue &source) { (*this) = source; }
+ExpressionValue::ExpressionValue(const ExpressionValue &source)
+{
+    valueI_ = source.valueI_;
+    valueD_ = source.valueD_;
+    type_ = source.type_;
+    typeFixed_ = source.typeFixed_;
+}
 
 void ExpressionValue::operator=(const ExpressionValue &source)
 {

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -1,0 +1,38 @@
+# CMakeLists.txt for Unit Tests
+# All tests must be single source file.
+
+# Get list of sources, from which we can construct the exe / test list.
+file(GLOB_RECURSE tests_SRC "*.cpp")
+
+# Add executables and tests
+foreach(SRCFILE "${tests_SRC}")
+  # Strip path and extension from source file to get test name
+  get_filename_component(NAME ${SRCFILE} NAME_WE)
+
+  # Register executable target
+  ADD_EXECUTABLE(${NAME} ${SRCFILE})
+
+  # Configure target
+  target_include_directories(${NAME} PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_BINARY_DIR}/src
+    ${ANTLR4_INCLUDE_DIRS}
+    ${ANTLR_OUTPUT_DIRS}
+  )
+  target_link_libraries(${NAME} PUBLIC
+    ${BASIC_LINK_LIBS}
+    PRIVATE
+
+    antlr4-runtime
+
+    ${EXTRA_LINK_LIBS}
+
+    INTERFACE
+
+    CONAN_PKG::fmt
+    CONAN_PKG::CLI11
+  )
+
+  # Register the test
+  ADD_TEST(${NAME} ${NAME})
+endforeach(SRCFILE)

--- a/unit/test_expression.cpp
+++ b/unit/test_expression.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Team Dissolve and contributors
+
+#include "expression/expressionNEW.h"
+#include "expression/reference.h"
+#include "expression/variable.h"
+#include <fmt/format.h>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+int main(int args, char **argv)
+{
+    // Test ANTLR-based Expression parser
+
+    // Set up test data:  <"name", "expression", "expectedValue", "shouldFail">
+    RefList<ExpressionVariable> variables;
+    ExpressionVariable a(1.0);
+    a.setName("a");
+    ExpressionVariable bee(100.0);
+    bee.setName("bee");
+    variables.append(&a);
+    variables.append(&bee);
+    std::vector<std::tuple<std::string_view, std::string_view, ExpressionValue, bool>> tests = {
+        {"Basic integer math 1", "1-(3*2)", 1 - (3 * 2), false},
+        {"Basic integer math 2", "1-3*2", 1 - 3 * 2, false},
+        {"Basic integer math 3", "242/15", 242 / 15, false},
+        {"Basic floating point math", "1.0+24*3.4", 1.0 + 24 * 3.4, false},
+        {"Parentheses", "(9.231-4*89.4)/76.92+7", (9.231 - 4 * 89.4) / 76.92 + 7, false},
+        {"Unary minus", "-(6.5+7)", -(6.5 + 7), false},
+        {"Power", "-3.0^3", pow(-3.0, 3), false},
+        {"Bad operators 1", "2++7", 0, true},
+        {"Bad operators 2", "2+7*", 0, true},
+        {"Legit odd operators 1", "2+-7", 2 + -7, false},
+        {"Legit odd operators 2", "2--7", 2 - (-7), false},
+        {"Functions 1", "cos(45)", cos(45), false},
+        {"Functions 2", "exp(cos(45))", exp(cos(45)), false},
+        {"Functions 3", "sqrt(sin(78.9)*cos(45))", sqrt(sin(78.9) * cos(45)), false},
+        {"Bad function args 1", "atan()", 0, true},
+        {"Bad function args 2", "ln(0.0, 1.0)", 0, true},
+        {"Variables 1", "a/5", a.value().asDouble() / 5, false},
+        {"Variables 2", "a + sqrt(bee)", a.value().asDouble() + sqrt(bee.value().asDouble()), false},
+        {"Bad name", "1.8*wasp", 0, true}};
+
+    const auto threshold = 1.0e-10;
+
+    for (auto test : tests)
+    {
+        auto title = std::get<0>(test);
+        auto expr = std::get<1>(test);
+        auto expectedResult = std::get<2>(test);
+        auto shouldFail = std::get<3>(test);
+
+        fmt::print("Evaluating: {}\n", title);
+        ExpressionNEW expression;
+        auto generationResult = expression.create(expr, variables);
+        if (shouldFail)
+        {
+            if (generationResult)
+                throw(std::runtime_error(fmt::format("Expression '{}' parsed correctly when it shouldn't have.", expr)));
+            else
+                continue;
+        }
+        else if (!generationResult)
+            throw(std::runtime_error(fmt::format("Expression '{}' did not parse correctly.", expr)));
+
+        // Evaluate the expression
+        auto optResult = expression.evaluate();
+        if (!optResult)
+            throw(std::runtime_error(fmt::format("Expression '{}' failed to evaluate.", expr)));
+
+        auto result = (*optResult);
+
+        // Check result type
+        if (expectedResult.type() != result.type())
+            throw(std::runtime_error(
+                fmt::format("Expression '{}' failed - actual result is not of equivalent type to expected result.", expr)));
+
+        // Compare result values
+        if (expectedResult.isInteger() && (expectedResult.asInteger() != result.asInteger()))
+            throw(std::runtime_error(
+                fmt::format("Expression '{}' failed - actual result '{}' does not match expected result '{}'.", expr,
+                            result.asInteger(), expectedResult.asInteger())));
+        else if (fabs(result.asDouble() - expectedResult.asDouble()) > threshold)
+            throw(std::runtime_error(fmt::format(
+                "Expression '{}' failed - actual result '{}' does not match expected result '{}' (is beyond threshold).", expr,
+                result.asDouble(), expectedResult.asDouble())));
+    }
+
+    // Success
+    exit(0);
+}

--- a/web/content/docs/developers/compilation.md
+++ b/web/content/docs/developers/compilation.md
@@ -172,6 +172,14 @@ Example: `-DBUILD_ANTLR_ZIPFILE:path=/path/to/antlr4-cpp-runtime-4.8-source.zip`
 
 Default: `not set`
 
+#### `BUILD_TESTS`
+
+In addition to the main build, also build unit tests.
+
+Example: `-DBUILD_TESTS:bool=true`
+
+Default: `false`
+
 #### `GUI`
 
 Requests that the GUI version of Dissolve be built. This option is mutually exclusive with `-DPARALLEL:bool=true`. Qt5 libraries and development tools must be present in the path, as well as [`FTGL`](http://ftgl.sourceforge.net/docs/html/).


### PR DESCRIPTION
This PR adds an ANTLR4-based expression parser to replace the existing Bison implementation. As a by-product, a basic unit-testing framework has also been put in place.

The ANTLR4 implementation exists alongside the old Bison grammar in this PR, with no attempt made to incorporate it into the rest of the codebase. This work is performed in a separate PR to follow once this has been approved and merged.
