### PR TITLE
Bugfix 07/12/20 Generic Items

### DIFF
--- a/src/genericitems/array2d_vector_double.h
+++ b/src/genericitems/array2d_vector_double.h
@@ -71,7 +71,7 @@ template <> class GenericItemContainer<Array2D<std::vector<double>>> : public Ge
             int nItems = parser.argi(0);
             data.clear();
             data.resize(nItems);
-            for (auto n : data)
+            for (auto &n : data)
             {
                 if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                     return false;

--- a/src/genericitems/array2d_vector_double.h
+++ b/src/genericitems/array2d_vector_double.h
@@ -61,14 +61,14 @@ template <> class GenericItemContainer<Array2D<std::vector<double>>> : public Ge
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
-        int nRows = parser.argi(0), nColumns = parser.argi(1);
+        auto nRows = parser.argi(0), nColumns = parser.argi(1);
         data_.initialise(nRows, nColumns, parser.argb(2));
 
         for (auto &data : data_)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
-            int nItems = parser.argi(0);
+            auto nItems = parser.argi(0);
             data.clear();
             data.resize(nItems);
             for (auto &n : data)
@@ -100,14 +100,14 @@ template <> class GenericItemContainer<Array2D<std::vector<double>>> : public Ge
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
-        int nRows = parser.argi(0), nColumns = parser.argi(1);
+        auto nRows = parser.argi(0), nColumns = parser.argi(1);
         thisData.initialise(nRows, nColumns, parser.argb(2));
 
         for (auto &data : thisData)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
-            int nItems = parser.argi(0);
+            auto nItems = parser.argi(0);
             data.createEmpty(nItems);
             for (auto m = 0; m < nItems; ++m)
             {

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -101,10 +101,13 @@ void Dissolve::registerGenericItems()
     GenericItem::addItemClass(new GenericItemContainer<std::streampos>("streampos"));
     GenericItem::addItemClass(new GenericItemContainer<std::string>("string"));
 
+    GenericItem::addItemClass(new GenericItemContainer<std::vector<double>>("std::vector<double>"));
+
     GenericItem::addItemClass(new GenericItemContainer<Vec3<int>>("Vec3<int>"));
     GenericItem::addItemClass(new GenericItemContainer<Vec3<double>>("Vec3<double>"));
 
     GenericItem::addItemClass(new GenericItemContainer<Array2D<double>>("Array2D<double>"));
+    GenericItem::addItemClass(new GenericItemContainer<Array2D<std::vector<double>>>("Array2D<std::vector<double>>"));
     GenericItem::addItemClass(new GenericItemContainer<Array2D<DummyClass>>("Array2D<DummyClass>"));
 
     GenericItem::addItemClass(new GenericItemContainer<Array<int>>("Array<int>"));

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -36,7 +36,8 @@ Array2D<std::vector<double>> &EPSRModule::potentialCoefficients(Dissolve &dissol
         for (auto &n : coefficients)
         {
             n.clear();
-            n.resize(ncoeffp, 0);
+            if (ncoeffp > 0)
+                n.resize(ncoeffp, 0);
         }
     }
 
@@ -160,6 +161,8 @@ double EPSRModule::absEnergyEP(Dissolve &dissolve)
 
     // Get coefficients array
     auto &coefficients = potentialCoefficients(dissolve, dissolve.nAtomTypes());
+    if (coefficients.empty())
+        return 0.0;
 
     double absEnergyEP = 0.0;
 

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -27,6 +27,7 @@ Array2D<std::vector<double>> &EPSRModule::potentialCoefficients(Dissolve &dissol
 {
     auto &coefficients = GenericListHelper<Array2D<std::vector<double>>>::realise(
         dissolve.processingModuleData(), "PotentialCoefficients", uniqueName_, GenericItem::InRestartFileFlag);
+
     auto arrayNCoeffP = (coefficients.nRows() && coefficients.nColumns() ? coefficients[{0, 0}].size() : 0);
     if ((coefficients.nRows() != nAtomTypes) || (coefficients.nColumns() != nAtomTypes) ||
         ((ncoeffp != -1) && (ncoeffp != arrayNCoeffP)))

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -107,8 +107,8 @@ Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int i,
     auto ncoeffp = keywords_.asInt("NCoeffP");
     const auto psigma1 = keywords_.asDouble("PSigma1");
     const auto psigma2 = keywords_.asDouble("PSigma2");
-    double rmaxpt = keywords_.asDouble("RMaxPT");
-    double rminpt = keywords_.asDouble("RMinPT");
+    auto rmaxpt = keywords_.asDouble("RMaxPT");
+    auto rminpt = keywords_.asDouble("RMinPT");
 
     // EPSR constants
     const auto mcoeff = 200;
@@ -164,15 +164,15 @@ double EPSRModule::absEnergyEP(Dissolve &dissolve)
     if (coefficients.empty())
         return 0.0;
 
-    double absEnergyEP = 0.0;
+    auto absEnergyEP = 0.0;
 
     for_each_pair(dissolve.atomTypes().begin(), dissolve.atomTypes().end(), [&](int i, auto at1, int j, auto at2) {
         auto &potCoeff = coefficients[{i, j}];
 
-        double cMin = potCoeff.empty() ? 0.0 : *std::min_element(potCoeff.begin(), potCoeff.end());
-        double cMax = potCoeff.empty() ? 0.0 : *std::max_element(potCoeff.begin(), potCoeff.end());
+        auto cMin = potCoeff.empty() ? 0.0 : *std::min_element(potCoeff.begin(), potCoeff.end());
+        auto cMax = potCoeff.empty() ? 0.0 : *std::max_element(potCoeff.begin(), potCoeff.end());
 
-        double range = cMax - cMin;
+        auto range = cMax - cMin;
         if (range > absEnergyEP)
             absEnergyEP = range;
 


### PR DESCRIPTION
This bugfix PR fixes a few issues discovered while investigating a bug where the intermolecular energy would jump when restarting a simulation. This bug existed before recent changes to the `Array` and `Array2D` classes, so it is not guaranteed that the problem has been eradicated.

Changes made:
- Register missing generic items based on `std::vector<double>`.
- Fix `Array2D<std::vector<double>>::read()` which didn't use references in the assignment loop.
- Don't assess empirical potential magnitude when there are no coefficients (caused exception).
- Formatting.
