### PR TITLE
Overload indexing Array3D

### DIFF
--- a/src/gui/render/renderabledata3d.cpp
+++ b/src/gui/render/renderabledata3d.cpp
@@ -520,40 +520,40 @@ void RenderableData3D::marchingCubesOriginal(const std::vector<double> &displayX
             for (k = 1; k < z.size() - 2; ++k)
             {
                 // Grab values that form vertices of cube.
-                vertex[0] = displayValues.constAt(i, j, k);
-                vertex[1] = displayValues.constAt(i + 1, j, k);
-                vertex[2] = displayValues.constAt(i + 1, j + 1, k);
-                vertex[3] = displayValues.constAt(i, j + 1, k);
-                vertex[4] = displayValues.constAt(i, j, k + 1);
-                vertex[5] = displayValues.constAt(i + 1, j, k + 1);
-                vertex[6] = displayValues.constAt(i + 1, j + 1, k + 1);
-                vertex[7] = displayValues.constAt(i, j + 1, k + 1);
+                vertex[0] = displayValues[{i, j, k}];
+                vertex[1] = displayValues[{i + 1, j, k}];
+                vertex[2] = displayValues[{i + 1, j + 1, k}];
+                vertex[3] = displayValues[{i, j + 1, k}];
+                vertex[4] = displayValues[{i, j, k + 1}];
+                vertex[5] = displayValues[{i + 1, j, k + 1}];
+                vertex[6] = displayValues[{i + 1, j + 1, k + 1}];
+                vertex[7] = displayValues[{i, j + 1, k + 1}];
 
                 // Calculate gradients at the cube vertices
-                gradient[0].x = (vertex[1] - displayValues.constAt(i - 1, j, k)) / dx;
-                gradient[0].y = (vertex[3] - displayValues.constAt(i, j - 1, k)) / dy;
-                gradient[0].z = (vertex[4] - displayValues.constAt(i, j, k - 1)) / dz;
-                gradient[1].x = (displayValues.constAt(i + 2, j, k) - vertex[0]) / dx;
-                gradient[1].y = (vertex[2] - displayValues.constAt(i + 1, j - 1, k)) / dy;
-                gradient[1].z = (vertex[5] - displayValues.constAt(i + 1, j, k - 1)) / dz;
-                gradient[2].x = (displayValues.constAt(i + 2, j + 1, k) - vertex[3]) / dx;
-                gradient[2].y = (displayValues.constAt(i + 1, j + 2, k) - vertex[1]) / dy;
-                gradient[2].z = (vertex[6] - displayValues.constAt(i + 1, j + 1, k - 1)) / dz;
-                gradient[3].x = (vertex[2] - displayValues.constAt(i - 1, j + 1, k)) / dx;
-                gradient[3].y = (displayValues.constAt(i, j + 2, k) - vertex[0]) / dy;
-                gradient[3].z = (vertex[7] - displayValues.constAt(i, j + 1, k - 1)) / dz;
-                gradient[4].x = (vertex[5] - displayValues.constAt(i - 1, j, k + 1)) / dx;
-                gradient[4].y = (vertex[7] - displayValues.constAt(i, j - 1, k + 1)) / dy;
-                gradient[4].z = (displayValues.constAt(i, j, k + 2) - vertex[0]) / dz;
-                gradient[5].x = (displayValues.constAt(i + 2, j, k + 1) - vertex[4]) / dx;
-                gradient[5].y = (vertex[6] - displayValues.constAt(i + 1, j - 1, k + 1)) / dy;
-                gradient[5].z = (displayValues.constAt(i + 1, j, k + 2) - vertex[1]) / dz;
-                gradient[6].x = (displayValues.constAt(i + 2, j + 1, k + 1) - vertex[7]) / dx;
-                gradient[6].y = (displayValues.constAt(i + 1, j + 2, k + 1) - vertex[5]) / dy;
-                gradient[6].z = (displayValues.constAt(i + 1, j + 1, k + 2) - vertex[2]) / dz;
-                gradient[7].x = (vertex[6] - displayValues.constAt(i - 1, j + 1, k + 1)) / dx;
-                gradient[7].y = (displayValues.constAt(i, j + 2, k + 1) - vertex[4]) / dy;
-                gradient[7].z = (displayValues.constAt(i, j + 1, k + 2) - vertex[3]) / dz;
+                gradient[0].x = (vertex[1] - displayValues[{i - 1, j, k}]) / dx;
+                gradient[0].y = (vertex[3] - displayValues[{i, j - 1, k}]) / dy;
+                gradient[0].z = (vertex[4] - displayValues[{i, j, k - 1}]) / dz;
+                gradient[1].x = (displayValues[{i + 2, j, k}] - vertex[0]) / dx;
+                gradient[1].y = (vertex[2] - displayValues[{i + 1, j - 1, k}]) / dy;
+                gradient[1].z = (vertex[5] - displayValues[{i + 1, j, k - 1}]) / dz;
+                gradient[2].x = (displayValues[{i + 2, j + 1, k}] - vertex[3]) / dx;
+                gradient[2].y = (displayValues[{i + 1, j + 2, k}] - vertex[1]) / dy;
+                gradient[2].z = (vertex[6] - displayValues[{i + 1, j + 1, k - 1}]) / dz;
+                gradient[3].x = (vertex[2] - displayValues[{i - 1, j + 1, k}]) / dx;
+                gradient[3].y = (displayValues[{i, j + 2, k}] - vertex[0]) / dy;
+                gradient[3].z = (vertex[7] - displayValues[{i, j + 1, k - 1}]) / dz;
+                gradient[4].x = (vertex[5] - displayValues[{i - 1, j, k + 1}]) / dx;
+                gradient[4].y = (vertex[7] - displayValues[{i, j - 1, k + 1}]) / dy;
+                gradient[4].z = (displayValues[{i, j, k + 2}] - vertex[0]) / dz;
+                gradient[5].x = (displayValues[{i + 2, j, k + 1}] - vertex[4]) / dx;
+                gradient[5].y = (vertex[6] - displayValues[{i + 1, j - 1, k + 1}]) / dy;
+                gradient[5].z = (displayValues[{i + 1, j, k + 2}] - vertex[1]) / dz;
+                gradient[6].x = (displayValues[{i + 2, j + 1, k + 1}] - vertex[7]) / dx;
+                gradient[6].y = (displayValues[{i + 1, j + 2, k + 1}] - vertex[5]) / dy;
+                gradient[6].z = (displayValues[{i + 1, j + 1, k + 2}] - vertex[2]) / dz;
+                gradient[7].x = (vertex[6] - displayValues[{i - 1, j + 1, k + 1}]) / dx;
+                gradient[7].y = (displayValues[{i, j + 2, k + 1}] - vertex[4]) / dy;
+                gradient[7].z = (displayValues[{i, j + 1, k + 2}] - vertex[3]) / dz;
 
                 // Determine cube type
                 cubeType = 0;

--- a/src/io/export/data3d.cpp
+++ b/src/io/export/data3d.cpp
@@ -66,7 +66,7 @@ bool Data3DExportFileFormat::exportBlock(LineParser &parser, const Data3D &data)
         {
             for (auto z = 0; z < values.nZ(); ++z)
             {
-                if (!parser.writeLineF("{:15.9e}\n", values.constAt(x, y, z)))
+                if (!parser.writeLineF("{:15.9e}\n", values[{x, y, z}]))
                     return false;
             }
             if (!parser.writeLineF("\n"))
@@ -93,7 +93,7 @@ bool Data3DExportFileFormat::exportCartesian(LineParser &parser, const Data3D &d
             double yVal = yAxis[y];
             for (auto z = 0; z < values.nZ(); ++z)
             {
-                if (!parser.writeLineF("{:15.9e} {:15.9e} {:15.9e} {:15.9e}\n", xVal, yVal, zAxis[z], values.constAt(x, y, z)))
+                if (!parser.writeLineF("{:15.9e} {:15.9e} {:15.9e} {:15.9e}\n", xVal, yVal, zAxis[z], values[{x, y, z}]))
                     return false;
             }
         }
@@ -134,7 +134,7 @@ bool Data3DExportFileFormat::exportPDens(LineParser &parser, const Data3D &data)
         {
             for (auto z = 0; z < values.nZ(); ++z)
             {
-                if (!parser.writeLineF("{:15.9e}\n", values.constAt(x, y, z)))
+                if (!parser.writeLineF("{:15.9e}\n", values[{x, y, z}]))
                     return false;
             }
         }

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -535,18 +535,11 @@ bool Data3D::read(LineParser &parser, CoreData &coreData)
     }
     else
     {
-        for (auto x = 0; x < x_.size(); ++x)
+        for (auto &value : values_)
         {
-            for (auto y = 0; y < y_.size(); ++y)
-            {
-                for (auto z = 0; z < z_.size(); ++z)
-                {
-                    if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-                        return false;
-		    //FIXME: Can we make this one loop?
-                    values_[{x, y, z}] = parser.argd(0);
-                }
-            }
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                return false;
+            value = parser.argd(0);
         }
     }
 
@@ -589,24 +582,18 @@ bool Data3D::write(LineParser &parser)
             for (auto y = 0; y < y_.size(); ++y)
             {
                 for (auto z = 0; z < z_.size(); ++z)
-		    //FIXME: One loop?
-		    if (!parser.writeLineF("{:e}  {:e}\n", values_[{x, y, z}], errors_[{x, y, z}]))
+                    // TODO: Turn into a single loop when we have an
+                    // iterator combinator
+                    if (!parser.writeLineF("{:e}  {:e}\n", values_[{x, y, z}], errors_[{x, y, z}]))
                         return false;
             }
         }
     }
     else
     {
-        for (auto x = 0; x < x_.size(); ++x)
-        {
-            for (auto y = 0; y < y_.size(); ++y)
-            {
-                for (auto z = 0; z < z_.size(); ++z)
-		    //FIXME: One loop
-                    if (!parser.writeLineF("{:e}\n", values_[{x, y, z}]))
-                        return false;
-            }
-        }
+        for (auto &value : values_)
+            if (!parser.writeLineF("{:e}\n", value))
+                return false;
     }
 
     return true;

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -249,7 +249,7 @@ double &Data3D::value(int xIndex, int yIndex, int zIndex)
 #endif
     ++version_;
 
-    return values_.at(xIndex, yIndex, zIndex);
+    return values_[{xIndex, yIndex, zIndex}];
 }
 
 // Return value specified (const)
@@ -272,7 +272,7 @@ double Data3D::constValue(int xIndex, int yIndex, int zIndex) const
         return 0.0;
     }
 #endif
-    return values_.constAt(xIndex, yIndex, zIndex);
+    return values_[{xIndex, yIndex, zIndex}];
 }
 
 // Return values Array
@@ -355,7 +355,7 @@ double &Data3D::error(int xIndex, int yIndex, int zIndex)
 #endif
     ++version_;
 
-    return errors_.at(xIndex, yIndex, zIndex);
+    return errors_[{xIndex, yIndex, zIndex}];
 }
 
 // Return error value specified (const)
@@ -385,7 +385,7 @@ double Data3D::constError(int xIndex, int yIndex, int zIndex) const
     }
 #endif
 
-    return errors_.constAt(xIndex, yIndex, zIndex);
+    return errors_[{xIndex, yIndex, zIndex}];
 }
 
 // Return error Array
@@ -527,8 +527,8 @@ bool Data3D::read(LineParser &parser, CoreData &coreData)
                 {
                     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                         return false;
-                    values_.at(x, y, z) = parser.argd(0);
-                    errors_.at(x, y, z) = parser.argd(1);
+                    values_[{x, y, z}] = parser.argd(0);
+                    errors_[{x, y, z}] = parser.argd(1);
                 }
             }
         }
@@ -543,7 +543,8 @@ bool Data3D::read(LineParser &parser, CoreData &coreData)
                 {
                     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                         return false;
-                    values_.at(x, y, z) = parser.argd(0);
+		    //FIXME: Can we make this one loop?
+                    values_[{x, y, z}] = parser.argd(0);
                 }
             }
         }
@@ -588,7 +589,8 @@ bool Data3D::write(LineParser &parser)
             for (auto y = 0; y < y_.size(); ++y)
             {
                 for (auto z = 0; z < z_.size(); ++z)
-                    if (!parser.writeLineF("{:e}  {:e}\n", values_.constAt(x, y, z), errors_.constAt(x, y, z)))
+		    //FIXME: One loop?
+		    if (!parser.writeLineF("{:e}  {:e}\n", values_[{x, y, z}], errors_[{x, y, z}]))
                         return false;
             }
         }
@@ -600,7 +602,8 @@ bool Data3D::write(LineParser &parser)
             for (auto y = 0; y < y_.size(); ++y)
             {
                 for (auto z = 0; z < z_.size(); ++z)
-                    if (!parser.writeLineF("{:e}\n", values_.constAt(x, y, z)))
+		    //FIXME: One loop
+                    if (!parser.writeLineF("{:e}\n", values_[{x, y, z}]))
                         return false;
             }
         }

--- a/src/math/histogram3d.cpp
+++ b/src/math/histogram3d.cpp
@@ -69,8 +69,8 @@ void Histogram3D::updateAccumulatedData()
                 if (x == 0)
                     accumulatedData_.zAxis(z) = zBinCentres_[z];
 
-                accumulatedData_.value(x, y, z) = averages_.constAt(x, y, z);
-                accumulatedData_.error(x, y, z) = averages_.constAt(x, y, z).stDev();
+                accumulatedData_.value(x, y, z) = averages_[{x, y, z}];
+                accumulatedData_.error(x, y, z) = averages_[{x, y, z}].stDev();
             }
         }
     }
@@ -170,7 +170,7 @@ bool Histogram3D::bin(double x, double y, double z)
         return false;
     }
 
-    ++bins_.at(xBin, yBin, zBin);
+    ++bins_[{xBin, yBin, zBin}];
     ++nBinned_;
 
     return true;
@@ -190,7 +190,8 @@ void Histogram3D::accumulate()
         for (auto y = 0; y < nYBins_; ++y)
         {
             for (auto z = 0; z < nZBins_; ++z)
-                averages_.at(x, y, z) += double(bins_.at(x, y, z));
+	        //FIXME: std::transform?
+                averages_[{x, y, z}] += double(bins_[{x, y, z}]);
         }
     }
 
@@ -222,7 +223,8 @@ void Histogram3D::add(Histogram3D &other, int factor)
         for (auto y = 0; y < nYBins_; ++y)
         {
             for (auto z = 0; z < nZBins_; ++z)
-                bins_.at(x, y, z) += other.bins_.at(x, y, z) * factor;
+	        //FIXME: std::transform?
+                bins_[{x, y, z}] += other.bins_[{x, y, z}] * factor;
         }
     }
 }
@@ -283,7 +285,8 @@ bool Histogram3D::read(LineParser &parser, CoreData &coreData)
         for (auto y = 0; y < nYBins_; ++y)
         {
             for (auto z = 0; z < nZBins_; ++z)
-                if (!averages_.at(x, y, z).read(parser, coreData))
+	        //FIXME: one loop?
+		if (!averages_[{x, y, z}].read(parser, coreData))
                     return false;
         }
     }
@@ -306,7 +309,8 @@ bool Histogram3D::write(LineParser &parser)
         for (auto y = 0; y < nYBins_; ++y)
         {
             for (auto z = 0; z < nZBins_; ++z)
-                if (!averages_.at(x, y, z).write(parser))
+	        //FIXME: one loop
+                if (!averages_[{x, y, z}].write(parser))
                     return false;
         }
     }

--- a/src/math/transformer.cpp
+++ b/src/math/transformer.cpp
@@ -142,11 +142,12 @@ void Transformer::transformValues(Data3D &data)
             // Loop over z values
             for (auto k = 0; k < zAxis.size(); ++k)
             {
-                z_->set(values.at(i, j, k));
-                value_->set(values.at(i, j, k));
+	        //FIXME: Single loop? transform?
+                z_->set(values[{i, j, k}]);
+                value_->set(values[{i, j, k}]);
 
                 // Perform transform
-                values.at(i, j, k) = equation_.asDouble();
+                values[{i, j, k}] = equation_.asDouble();
             }
         }
     }

--- a/src/math/transformer.cpp
+++ b/src/math/transformer.cpp
@@ -142,7 +142,6 @@ void Transformer::transformValues(Data3D &data)
             // Loop over z values
             for (auto k = 0; k < zAxis.size(); ++k)
             {
-	        //FIXME: Single loop? transform?
                 z_->set(values[{i, j, k}]);
                 value_->set(values[{i, j, k}]);
 

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -136,7 +136,7 @@ bool BraggModule::calculateBraggTerms(ProcessPool &procPool, Configuration *cfg,
                         braggIndex = int(mag / qDelta);
 
                         // Point this (h,k,l) value to this Bragg reflection
-                        tempKVectors.at(h, k, l).initialise(h, k, l, braggIndex, nTypes);
+                        tempKVectors[{h, k, l}].initialise(h, k, l, braggIndex, nTypes);
 
                         // Note in the reflection that we have found another (h,k,l) that contributes to
                         // it

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -646,7 +646,7 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
             // Store fluctuation coefficients ready for addition to potential coefficients later on.
             for (auto n = 0; n < ncoeffp; ++n)
-                fluctuationCoefficients.at(i, j, n) += weight * fitCoefficients[n];
+                fluctuationCoefficients[{i, j, n}] += weight * fitCoefficients[n];
         });
 
         // Increase dataIndex
@@ -670,7 +670,7 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
             // un-smoothed coefficients are stored)
             Data1D smoothedCoefficients;
             for (auto n = 0; n < ncoeffp; ++n)
-                smoothedCoefficients.addPoint(n, fluctuationCoefficients.constAt(i, j, n));
+                smoothedCoefficients.addPoint(n, fluctuationCoefficients[{i, j, n}]);
             Filters::kolmogorovZurbenko(smoothedCoefficients, 3, 5);
 
             // Add in fluctuation coefficients

--- a/src/procedure/nodes/operateexpression.cpp
+++ b/src/procedure/nodes/operateexpression.cpp
@@ -105,8 +105,8 @@ bool OperateExpressionProcedureNode::operateData3D(ProcessPool &procPool, Config
             {
                 // Set z and  value in expression
                 z_->set(z[k]);
-		//TODO: Convert to a single loop when we have the
-		//iterator combiner
+                // TODO: Convert to a single loop when we have the
+                // iterator combiner
                 value_->set(values[{i, j, k}]);
 
                 // Evaluate and store new value

--- a/src/procedure/nodes/operateexpression.cpp
+++ b/src/procedure/nodes/operateexpression.cpp
@@ -105,10 +105,12 @@ bool OperateExpressionProcedureNode::operateData3D(ProcessPool &procPool, Config
             {
                 // Set z and  value in expression
                 z_->set(z[k]);
-                value_->set(values.at(i, j, k));
+		//TODO: Convert to a single loop when we have the
+		//iterator combiner
+                value_->set(values[{i, j, k}]);
 
                 // Evaluate and store new value
-                values.at(i, j, k) = expression_.asDouble();
+                values[{i, j, k}] = expression_.asDouble();
             }
         }
     }

--- a/src/templates/array3d.h
+++ b/src/templates/array3d.h
@@ -422,9 +422,9 @@ template <class A> class OffsetArray3D
     // Return linear array
     std::vector<A> linearArray() { return array_; }
     // Beginning iterator
-    std::vector<A> begin() { return array_.begin(); }
+    typename std::vector<A>::iterator begin() { return array_.begin(); }
     // End iterator
-    std::vector<A> end() { return array_.end(); }
+    typename std::vector<A>::iterator end() { return array_.end(); }
     // Return linear value
     A &linearValue(int index)
     {

--- a/src/templates/array3d.h
+++ b/src/templates/array3d.h
@@ -85,8 +85,9 @@ template <class A> class Array3D
             resize(nX, nY, nZ);
     }
     // Return specified element as modifiable reference
-    A &at(int x, int y, int z)
+    A &operator[](std::tuple<int, int, int> index)
     {
+        auto [x, y, z] = index;
 #ifdef CHECKS
         static A dummy;
         if ((x < 0) || (x >= nX_))
@@ -108,8 +109,9 @@ template <class A> class Array3D
         return array_[sliceOffsets_[z] + y * nX_ + x];
     }
     // Return specified element as const-reference
-    const A &constAt(int x, int y, int z) const
+    const A &operator[](std::tuple<int, int, int> index) const
     {
+        auto [x, y, z] = index;
 #ifdef CHECKS
         static A dummy;
         if ((x < 0) || (x >= nX_))
@@ -321,8 +323,9 @@ template <class A> class OffsetArray3D
         }
     }
     // Return specified element as reference
-    A &at(int x, int y, int z)
+    A &operator[](std::tuple<int, int, int> index)
     {
+        auto [x, y, z] = index;
 #ifdef CHECKS
         static A dummy;
         if ((x < xMin_) || (x > xMax_))
@@ -350,8 +353,9 @@ template <class A> class OffsetArray3D
         return array_[sliceOffsets_[z - zMin_] + (y - yMin_) * nX_ + (x - xMin_)];
     }
     // Return specified element as const reference
-    A &constAt(int x, int y, int z) const
+    const A &operator[](std::tuple<int, int, int> index) const
     {
+        auto [x, y, z] = index;
 #ifdef CHECKS
         static A dummy;
         if ((x < xMin_) || (x > xMax_))


### PR DESCRIPTION
Just as we did with Array2D, I've overloaded the [] operator to allow accessing via tuples.  I've also gone through and, where possible, moved nested loops into a loop or transform operation.

Some of these remaining loops /could/ be converted to algorithms.  However, as a matter of style, I've only used algorithms for loops which could be run in parallel.  Loops which must be performed sequentially (e.g. because they depend on the start of a parser object) have been left as loops.