### PR TITLE
Web Update 2 - CI

### DIFF
--- a/.azure-pipelines/continuous.yml
+++ b/.azure-pipelines/continuous.yml
@@ -24,7 +24,7 @@ stages:
   - stage: 'build'
     displayName: 'Build and Package'
     jobs:
-      - job: 'linux_serialgui'
+      - job: 'linux_serialgui_appimage'
         displayName: 'Build Linux (Serial/GUI, ubuntu-18.04)'
         pool:
           vmImage: 'ubuntu-18.04'
@@ -33,19 +33,6 @@ stages:
             fetchDepth: 1
           - template: templates/set-short-hash.yml
           - template: templates/build-linux-serial-gui.yml
-      - job: 'linux_serialgui_appimage'
-        displayName: 'Build Linux (Serial/GUI, ubuntu-16.04)'
-        condition: eq(0,1)
-        pool:
-          vmImage: 'ubuntu-16.04'
-        steps:
-          - checkout: self
-            fetchDepth: 1
-          - template: templates/set-short-hash.yml
-          - template: templates/build-linux-serial-gui.yml
-            parameters:
-              ppa: 'beineri/opt-qt-5.12.0-xenial'
-              qtver: 512
           - template: templates/package-linux-serial-gui.yml
           - task: PublishBuildArtifacts@1
             inputs:
@@ -95,13 +82,13 @@ stages:
         steps:
           - checkout: self
             fetchDepth: 1
-          #- task: DownloadBuildArtifacts@0
-          #  inputs:
-          #    buildType: 'current'
-          #    specificBuildWithTriggering: true
-          #    downloadType: 'single'
-          #    artifactName: 'linux-artifacts'
-          #  displayName: 'Download Linux Artifacts'
+          - task: DownloadBuildArtifacts@0
+            inputs:
+              buildType: 'current'
+              specificBuildWithTriggering: true
+              downloadType: 'single'
+              artifactName: 'linux-artifacts'
+            displayName: 'Download Linux Artifacts'
           - task: DownloadBuildArtifacts@0
             inputs:
               buildType: 'current'
@@ -118,33 +105,31 @@ stages:
             displayName: 'Download Windows Artifacts'
           - bash: |
               VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
-              SHORTHASH=`git rev-parse --short HEAD`
               cd ./examples
-              ./package-examples -v ${VERSION}-${SHORTHASH}
+              ./package-examples -v ${VERSION}
             displayName: 'Create Example Data Archives'
           - bash: |
-              SHORTHASH=`git rev-parse --short HEAD`
               VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
               # Linux AppImages
-              #cd $(System.ArtifactsDirectory)/linux-artifacts
-              #mv -v Dissolve-${SHORTHASH}-x86_64.AppImage Dissolve-${VERSION}-${SHORTHASH}-x86_64.AppImage
-              #mv -v Dissolve-GUI-${SHORTHASH}-x86_64.AppImage Dissolve-GUI-${VERSION}-${SHORTHASH}-x86_64.AppImage
-              #cd ../
+              cd $(System.ArtifactsDirectory)/linux-artifacts
+              mv -v Dissolve-x86_64.AppImage Dissolve-${VERSION}-x86_64.AppImage
+              mv -v Dissolve-GUI-x86_64.AppImage Dissolve-GUI-${VERSION}-x86_64.AppImage
+              cd ../
               # OSX Disk Images
               cd $(System.ArtifactsDirectory)/osx-artifacts
-              mv -v Dissolve-GUI-${VERSION}.dmg Dissolve-GUI-${VERSION}-${SHORTHASH}-Catalina.dmg
+              mv -v Dissolve-GUI-${VERSION}.dmg Dissolve-GUI-${VERSION}-Catalina.dmg
               cd ../
               # Windows Installer / Zip
               cd $(System.ArtifactsDirectory)/windows-artifacts
-              mv -v Dissolve-GUI-${VERSION}-Win64.zip Dissolve-GUI-${VERSION}-${SHORTHASH}-Win64.zip
-              mv -v Dissolve-GUI-${VERSION}-Win64.exe Dissolve-GUI-${VERSION}-${SHORTHASH}-Win64.exe
+              mv -v Dissolve-GUI-${VERSION}-Win64.zip Dissolve-GUI-${VERSION}-Win64.zip
+              mv -v Dissolve-GUI-${VERSION}-Win64.exe Dissolve-GUI-${VERSION}-Win64.exe
               cd ../
             displayName: 'Rename Artifacts'
           - bash: |
               SHORTHASH=`git rev-parse --short HEAD`
               DATE=`date`
               VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
-              ./ci/scripts/update-release -r projectdissolve/dissolve -t continuous -n "Continuous Build (${SHORTHASH})" -b "Continuous release from current \`develop\` branch at ${SHORTHASH}. Built ${DATE}." -p -e -u $(System.ArtifactsDirectory)/windows-artifacts/*.exe $(System.ArtifactsDirectory)/windows-artifacts/*.zip $(System.ArtifactsDirectory)/osx-artifacts/*dmg examples/*zip examples/*.tar.gz
+              ./ci/scripts/update-release -r projectdissolve/dissolve -t continuous -n "Continuous Build (${VERSION} @ ${SHORTHASH})" -b "Continuous release from current \`develop\` branch at ${SHORTHASH}. Built ${DATE}." -p -e -u $(System.ArtifactsDirectory)/windows-artifacts/*.exe $(System.ArtifactsDirectory)/windows-artifacts/*.zip $(System.ArtifactsDirectory)/osx-artifacts/*dmg examples/*zip examples/*.tar.gz
             env:
               GITHUB_TOKEN: $(REPO_SECRET)
             displayName: 'Update Continuous Release (GitHub)'

--- a/web/content/packages.md
+++ b/web/content/packages.md
@@ -74,16 +74,16 @@ linkTitle = "Packages"
 {{< blocks/section color="secondary" >}}
 
 {{% blocks/feature icon="fab fa-linux" title="Linux" %}}
-{{< continuouslink target="GUI" urlSuffix="x86_64.AppImage" textSuffix="AppImage" >}}
+{{< continuouslink target="GUI" urlSuffix="-x86_64.AppImage" textSuffix="AppImage" >}}
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon=" fab fa-apple" title="Mac OS" %}}
-{{< continuouslink target="GUI" urlSuffix="Catalina.dmg" textSuffix="Catalina DMG" >}}
+{{< continuouslink target="GUI" urlSuffix="-Catalina.dmg" textSuffix="Catalina DMG" >}}
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fab fa-windows" title="Windows" textSuffix="Installer" %}}
-{{< continuouslink target="GUI" urlSuffix="Win64.exe" textSuffix="Installer" >}}
-{{< continuouslink target="GUI" urlSuffix="Win64.zip" textSuffix="Zip Archive" >}}
+{{< continuouslink target="GUI" urlSuffix="-Win64.exe" textSuffix="Installer" >}}
+{{< continuouslink target="GUI" urlSuffix="-Win64.zip" textSuffix="Zip Archive" >}}
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fa fa-archive" title="Example Data" %}}


### PR DESCRIPTION
This PR tidies the continuous build CI and makes it consistent with the new website.

Short hashes are no longer inserted into the continuous build artifacts, as this made linking directly to them completely impossible to do in a consistent (timed) manner from the website. Short hash versions are still injected into the code version, and so tracking of continuous versions to specific commits can still be made.
