### PR TITLE
Supply useful data from RDFModule

### DIFF
--- a/.azure-pipelines/continuous.yml
+++ b/.azure-pipelines/continuous.yml
@@ -41,6 +41,7 @@ stages:
             displayName: 'Publish Linux Artifacts'
       - job: 'osx_serialgui'
         displayName: 'Build OSX (Serial/GUI, macos-latest)'
+        timeoutInMinutes: 120
         pool:
           vmImage: 'macos-latest' 
         steps:
@@ -55,8 +56,8 @@ stages:
               ArtifactName: 'osx-artifacts'
             displayName: 'Publish OSX Artifacts'
       - job: 'windows_serialgui'
-        timeoutInMinutes: 120
         displayName: 'Build Windows (Serial/GUI, windows-latest)'
+        timeoutInMinutes: 120
         pool:
           vmImage: 'windows-latest' 
         steps:

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -58,6 +58,7 @@ stages:
             displayName: 'Publish Parallel Test Artifacts'
       - job: 'osx_serialgui'
         displayName: 'Build OSX (Serial/GUI, macos-latest)'
+        timeoutInMinutes: 120
         pool:
           vmImage: 'macos-latest' 
         steps:
@@ -72,8 +73,8 @@ stages:
               ArtifactName: 'osx-artifacts'
             displayName: 'Publish OSX Artifacts'
       - job: 'windows_serialgui'
-        timeoutInMinutes: 120
         displayName: 'Build Windows (Serial/GUI, windows-latest)'
+        timeoutInMinutes: 120
         pool:
           vmImage: 'windows-latest' 
         steps:

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -55,6 +55,7 @@ stages:
             displayName: 'Publish Parallel Test Artifacts'
       - job: 'osx_serialgui'
         displayName: 'Build OSX (Serial/GUI, macos-latest)'
+        timeoutInMinutes: 120
         pool:
           vmImage: 'macos-latest' 
         steps:
@@ -68,8 +69,8 @@ stages:
               ArtifactName: 'osx-artifacts'
             displayName: 'Publish OSX Artifacts'
       - job: 'windows_serialgui'
-        timeoutInMinutes: 120
         displayName: 'Build Windows (Serial/GUI, windows-latest)'
+        timeoutInMinutes: 120
         pool:
           vmImage: 'windows-latest' 
         steps:

--- a/.azure-pipelines/templates/package-osx-serial-gui.yml
+++ b/.azure-pipelines/templates/package-osx-serial-gui.yml
@@ -1,6 +1,6 @@
 steps:
   - script: |
-      pip3 install dmgbuild
+      pip3 install dmgbuild biplist
     displayName: 'Install Prerequisites'
   - bash: |
       set -ex

--- a/.azure-pipelines/templates/package-osx-serial-gui.yml
+++ b/.azure-pipelines/templates/package-osx-serial-gui.yml
@@ -1,6 +1,6 @@
 steps:
   - script: |
-      pip install dmgbuild
+      pip3 install dmgbuild
     displayName: 'Install Prerequisites'
   - bash: |
       set -ex

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -54,7 +54,7 @@ void NeutronWeights::clear()
 }
 
 // Add Isotopologue for Species
-void NeutronWeights::addIsotopologue(Species *sp, int speciesPopulation, const Isotopologue *iso,
+void NeutronWeights::addIsotopologue(const Species *sp, int speciesPopulation, const Isotopologue *iso,
                                      double isotopologueRelativePopulation)
 {
     // Does an Isotopologues definition already exist for the supplied Species?
@@ -71,7 +71,7 @@ void NeutronWeights::addIsotopologue(Species *sp, int speciesPopulation, const I
 }
 
 // Return whether an Isotopologues definition exists for the provided Species
-bool NeutronWeights::containsIsotopologues(Species *sp) const
+bool NeutronWeights::containsIsotopologues(const Species *sp) const
 {
     return std::any_of(isotopologueMixtures_.cbegin(), isotopologueMixtures_.cend(),
                        [sp](const Isotopologues &mix) { return mix.species() == sp; });

--- a/src/classes/neutronweights.h
+++ b/src/classes/neutronweights.h
@@ -32,9 +32,10 @@ class NeutronWeights : public GenericItemBase
     // Clear contents
     void clear();
     // Add Species Isotopologue to the relevant mixture
-    void addIsotopologue(Species *sp, int speciesPopulation, const Isotopologue *iso, double isotopologueRelativePopulation);
+    void addIsotopologue(const Species *sp, int speciesPopulation, const Isotopologue *iso,
+                         double isotopologueRelativePopulation);
     // Return whether an Isotopologues definition exists for the provided Species
-    bool containsIsotopologues(Species *sp) const;
+    bool containsIsotopologues(const Species *sp) const;
     // Print atomtype / weights information
     void print() const;
 

--- a/src/expression/variable.cpp
+++ b/src/expression/variable.cpp
@@ -16,7 +16,6 @@ ExpressionVariable::ExpressionVariable(ExpressionValue value, bool readOnly) : E
     readOnly_ = readOnly;
 }
 
-// Destructor (virtual)
 ExpressionVariable::~ExpressionVariable() {}
 
 // Set name of variable

--- a/src/gui/configurationviewer.hui
+++ b/src/gui/configurationviewer.hui
@@ -75,7 +75,7 @@ class ConfigurationViewer : public BaseViewer
 
     public:
     // Set target Configuration
-    void setConfiguration(Configuration *sp);
+    void setConfiguration(Configuration *cfg);
     // Return target Configuration
     Configuration *configuration() const;
 

--- a/src/gui/configurationviewer_funcs.cpp
+++ b/src/gui/configurationviewer_funcs.cpp
@@ -32,9 +32,9 @@ ConfigurationViewer::~ConfigurationViewer() {}
  */
 
 // Set target Configuration
-void ConfigurationViewer::setConfiguration(Configuration *sp)
+void ConfigurationViewer::setConfiguration(Configuration *cfg)
 {
-    configuration_ = sp;
+    configuration_ = cfg;
     configurationRenderable_ = nullptr;
 
     // Clear Renderables

--- a/src/gui/keywordwidgets/configurationreflist.h
+++ b/src/gui/keywordwidgets/configurationreflist.h
@@ -36,7 +36,7 @@ class ConfigurationRefListKeywordWidget : public KeywordDropDown, public Keyword
 
     private:
     // Selection list update function
-    void updateSelectionRow(int row, Configuration *sp, bool createItem);
+    void updateSelectionRow(int row, Configuration *cfg, bool createItem);
 
     private slots:
     // List item changed

--- a/src/gui/keywordwidgets/configurationreflist_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationreflist_funcs.cpp
@@ -37,7 +37,7 @@ ConfigurationRefListKeywordWidget::ConfigurationRefListKeywordWidget(QWidget *pa
  */
 
 // Selection list update function
-void ConfigurationRefListKeywordWidget::updateSelectionRow(int row, Configuration *sp, bool createItem)
+void ConfigurationRefListKeywordWidget::updateSelectionRow(int row, Configuration *cfg, bool createItem)
 {
     // Grab the target reference list
     RefList<Configuration> &selection = keyword_->data();
@@ -45,14 +45,14 @@ void ConfigurationRefListKeywordWidget::updateSelectionRow(int row, Configuratio
     QListWidgetItem *item;
     if (createItem)
     {
-        item = new QListWidgetItem(QString::fromStdString(std::string(sp->name())));
-        item->setData(Qt::UserRole, VariantPointer<Configuration>(sp));
+        item = new QListWidgetItem(QString::fromStdString(std::string(cfg->name())));
+        item->setData(Qt::UserRole, VariantPointer<Configuration>(cfg));
         item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
         ui_.SelectionList->insertItem(row, item);
     }
     else
         item = ui_.SelectionList->item(row);
-    item->setCheckState(selection.contains(sp) ? Qt::Checked : Qt::Unchecked);
+    item->setCheckState(selection.contains(cfg) ? Qt::Checked : Qt::Unchecked);
 }
 
 // List item changed
@@ -157,9 +157,9 @@ void ConfigurationRefListKeywordWidget::updateSummaryText()
     else
     {
         QString summaryText;
-        for (Configuration *sp : selection)
+        for (Configuration *cfg : selection)
             summaryText +=
-                QString("%1%2").arg(summaryText.isEmpty() ? "" : ", ").arg(QString::fromStdString(std::string(sp->name())));
+                QString("%1%2").arg(summaryText.isEmpty() ? "" : ", ").arg(QString::fromStdString(std::string(cfg->name())));
 
         setSummaryText(summaryText);
     }

--- a/src/keywords/configurationreflist.cpp
+++ b/src/keywords/configurationreflist.cpp
@@ -12,7 +12,6 @@ ConfigurationRefListKeyword::ConfigurationRefListKeyword(RefList<Configuration> 
     maxListSize_ = maxListSize;
 }
 
-// Destructor
 ConfigurationRefListKeyword::~ConfigurationRefListKeyword() {}
 
 /*

--- a/src/keywords/configurationreflist.cpp
+++ b/src/keywords/configurationreflist.cpp
@@ -61,7 +61,7 @@ bool ConfigurationRefListKeyword::read(LineParser &parser, int startArg, CoreDat
     return true;
 }
 
-// Write keyword data to cfgecified LineParser
+// Write keyword data to specified LineParser
 bool ConfigurationRefListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
 {
     // Loop over list of Configuration

--- a/src/keywords/configurationreflist.h
+++ b/src/keywords/configurationreflist.h
@@ -50,5 +50,5 @@ class ConfigurationRefListKeyword : public KeywordData<RefList<Configuration> &>
      */
     protected:
     // Prune any references to the supplied Configuration in the contained data
-    void removeReferencesTo(Configuration *sp);
+    void removeReferencesTo(Configuration *cfg);
 };

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -86,13 +86,8 @@ bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
                                                                 uniqueName(), GenericItem::ProtectedFlag);
         storedDataFT.setObjectTag(fmt::format("{}//ReferenceDataFT", uniqueName()));
         storedDataFT = referenceData;
-        auto rho = 0.1;
-        if (dissolve.processingModuleData().contains("EffectiveRho", rdfModule->uniqueName()))
-            rho = GenericListHelper<double>::value(dissolve.processingModuleData(), "EffectiveRho", rdfModule->uniqueName());
-        else
-            Messenger::warn("Couldn't locate effective atomic density from '{}', so Fourier transform of reference data will "
-                            "use assumed atomic density of 0.1.\n",
-                            rdfModule->uniqueName());
+        auto rho = rdfModule->effectiveDensity();
+        Messenger::print("Effective atomic density used in Fourier transform of reference data is {} atoms/Angstrom3.\n", rho);
         Fourier::sineFT(storedDataFT, 1.0 / (2.0 * PI * PI * rho), 0.0, 0.05, 30.0, referenceWindowFunction);
 
         // Save data?
@@ -228,12 +223,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     repGR = weightedSQ.total();
     auto rMin = weightedGR.total().xAxis().front();
     auto rMax = weightedGR.total().xAxis().back();
-    auto rho = 0.1;
-    if (dissolve.processingModuleData().contains("EffectiveRho", rdfModule->uniqueName()))
-        rho = GenericListHelper<double>::value(dissolve.processingModuleData(), "EffectiveRho", rdfModule->uniqueName());
-    else
-        Messenger::warn("Couldn't locate effective atomic density for RDF module.\n");
-
+    auto rho = rdfModule->effectiveDensity();
     Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * rho), rMin, 0.05, rMax, referenceWindowFunction);
     repGR.setObjectTag(fmt::format("{}//RepresentativeTotalGR", uniqueName_));
 

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -243,6 +243,27 @@ double RDFModule::effectiveDensity() const
     return rho0;
 }
 
+// Calculate and return used species populations based on target Configurations
+std::map<const Species *, double> RDFModule::speciesPopulations() const
+{
+    std::map<const Species *, double> populations;
+
+    for (auto *cfg : targetConfigurations())
+    {
+        // TODO Get weight for configuration
+        auto weight = 1.0;
+
+        ListIterator<SpeciesInfo> spInfoIterator(cfg->usedSpecies());
+        while (auto *spInfo = spInfoIterator.iterate())
+        {
+            populations.try_emplace(spInfo->species(), 0.0);
+            populations[spInfo->species()] += spInfo->population() * weight;
+        }
+    }
+
+    return populations;
+}
+
 // Calculate unweighted partials for the specified Configuration
 bool RDFModule::calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule::PartialsMethod method, const double rdfRange,
                             const double rdfBinWidth, bool &alreadyUpToDate)

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -510,10 +510,6 @@ bool RDFModule::sumUnweightedGR(ProcessPool &procPool, Module *parentModule, con
     }
     summedUnweightedGR.setFingerprint(fingerprint);
 
-    // Store the overall density of our partials
-    GenericListHelper<double>::realise(processingModuleData, "EffectiveRho", parentModule->uniqueName(),
-                                       GenericItem::InRestartFileFlag) = rho0;
-
     return true;
 }
 
@@ -585,10 +581,6 @@ bool RDFModule::sumUnweightedGR(ProcessPool &procPool, Module *parentModule, Mod
     }
     summedUnweightedGR.setFingerprint(fingerprint);
     summedUnweightedGR += 1.0;
-
-    // Store the overall density of our partials
-    // 	GenericListHelper<double>::realise(moduleData, "EffectiveRho", module->uniqueName(),
-    // GenericItem::InRestartFileFlag) = rho0;
 
     return true;
 }

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -474,7 +474,6 @@ bool RDFModule::sumUnweightedGR(ProcessPool &procPool, Module *parentModule, con
                                 GenericList &processingModuleData, PartialSet &summedUnweightedGR)
 {
     // Realise an AtomTypeList containing the sum of atom types over all target configurations
-    // TODO Assume weight of 1.0 per configuration now, until #398/#400 are addressed.
     auto &combinedAtomTypes = GenericListHelper<AtomTypeList>::realise(
         processingModuleData, "SummedAtomTypes", parentModule->uniqueName(), GenericItem::InRestartFileFlag);
     combinedAtomTypes.clear();
@@ -494,10 +493,8 @@ bool RDFModule::sumUnweightedGR(ProcessPool &procPool, Module *parentModule, con
     double totalWeight = 0.0;
     for (Configuration *cfg : parentModule->targetConfigurations())
     {
-        // Get weighting factor for this Configuration to contribute to the summed partials
-        auto weight = GenericListHelper<double>::value(
-            processingModuleData, fmt::format("ConfigurationWeight_{}", cfg->niceName()), parentModule->uniqueName(), 1.0);
-        Messenger::print("Weight for Configuration '{}' is {}.\n", cfg->name(), weight);
+        // TODO Assume weight of 1.0
+        auto weight = 1.0;
 
         // Add our Configuration target
         configWeights.append(cfg, weight);
@@ -546,10 +543,8 @@ bool RDFModule::sumUnweightedGR(ProcessPool &procPool, Module *parentModule, Mod
         // Loop over Configurations defined in this target
         for (Configuration *cfg : module->targetConfigurations())
         {
-            // Get weighting factor for this Configuration to contribute to the summed partials
-            auto weight = GenericListHelper<double>::value(
-                processingModuleData, fmt::format("ConfigurationWeight_{}", cfg->niceName()), module->uniqueName(), 1.0);
-            Messenger::print("Weight for Configuration '{}' is {}.\n", cfg->name(), weight);
+            // TODO Assume weight of 1.0
+            auto weight = 1.0;
 
             // Add our Configuration target
             configWeights.append(cfg, weight);

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -224,6 +224,25 @@ bool RDFModule::calculateGRCells(ProcessPool &procPool, Configuration *cfg, Part
  * Public Functions
  */
 
+// Calculate and return effective density for based on the target Configurations
+double RDFModule::effectiveDensity() const
+{
+    auto rho0 = 0.0, totalWeight = 0.0;
+    for (auto *cfg : targetConfigurations())
+    {
+        // TODO Get weight for configuration
+        auto weight = 1.0;
+
+        totalWeight += weight;
+
+        rho0 += weight / cfg->atomicDensity();
+    }
+    rho0 /= totalWeight;
+    rho0 = 1.0 / rho0;
+
+    return rho0;
+}
+
 // Calculate unweighted partials for the specified Configuration
 bool RDFModule::calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule::PartialsMethod method, const double rdfRange,
                             const double rdfBinWidth, bool &alreadyUpToDate)
@@ -427,24 +446,6 @@ bool RDFModule::calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg,
     unweightedgr.formTotal(true);
 
     return true;
-}
-
-// Return effective density for specified Module's target Configurations
-double RDFModule::summedRho(Module *module, GenericList &processingModuleData)
-{
-    double rho0 = 0.0, totalWeight = 0.0;
-    for (Configuration *cfg : module->targetConfigurations())
-    {
-        auto weight = GenericListHelper<double>::value(
-            processingModuleData, fmt::format("ConfigurationWeight_{}", cfg->niceName()), module->uniqueName(), 1.0);
-        totalWeight += weight;
-
-        rho0 += weight / cfg->atomicDensity();
-    }
-    rho0 /= totalWeight;
-    rho0 = 1.0 / rho0;
-
-    return rho0;
 }
 
 // Sum unweighted g(r) over the supplied Module's target Configurations

--- a/src/modules/rdf/rdf.h
+++ b/src/modules/rdf/rdf.h
@@ -85,6 +85,8 @@ class RDFModule : public Module
     public:
     // Calculate and return effective density for based on the target Configurations
     double effectiveDensity() const;
+    // Calculate and return used species populations based on target Configurations
+    std::map<const Species *, double> speciesPopulations() const;
     // (Re)calculate partial g(r) for the specified Configuration
     bool calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule::PartialsMethod method, const double rdfRange,
                      const double rdfBinWidth, bool &alreadyUpToDate);

--- a/src/modules/rdf/rdf.h
+++ b/src/modules/rdf/rdf.h
@@ -83,14 +83,14 @@ class RDFModule : public Module
     bool calculateGRCells(ProcessPool &procPool, Configuration *cfg, PartialSet &partialSet, const double binWidth);
 
     public:
+    // Calculate and return effective density for based on the target Configurations
+    double effectiveDensity() const;
     // (Re)calculate partial g(r) for the specified Configuration
     bool calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule::PartialsMethod method, const double rdfRange,
                      const double rdfBinWidth, bool &alreadyUpToDate);
     // Calculate smoothed/broadened partial g(r) from supplied partials
     static bool calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg, const PartialSet &originalgr,
                                       PartialSet &weightedgr, PairBroadeningFunction &intraBroadening, int smoothing);
-    // Return effective density for specified Module's target Configurations
-    static double summedRho(Module *module, GenericList &processingModuleData);
     // Sum unweighted g(r) over the supplied Module's target Configurations
     static bool sumUnweightedGR(ProcessPool &procPool, Module *parentModule, const RDFModule *rdfModule,
                                 GenericList &processingModuleData, PartialSet &summedUnweightedGR);

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -78,11 +78,8 @@ bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     const auto &unweightedgr =
         GenericListHelper<PartialSet>::value(dissolve.processingModuleData(), "UnweightedGR", rdfModule->uniqueName());
 
-    // Get effective atomic density of summed g(r)
-    if (!dissolve.processingModuleData().contains("EffectiveRho", rdfModule->uniqueName()))
-        return Messenger::error("Couldn't locate effective atomic density from module '{}'.\n", rdfModule->uniqueName());
-    const auto &rho =
-        GenericListHelper<double>::value(dissolve.processingModuleData(), "EffectiveRho", rdfModule->uniqueName());
+    // Get effective atomic density of underlying g(r)
+    const auto rho = rdfModule->effectiveDensity();
 
     // Does a PartialSet already exist for this Configuration?
     bool wasCreated;

--- a/src/modules/xraysq/functions.cpp
+++ b/src/modules/xraysq/functions.cpp
@@ -91,20 +91,12 @@ bool XRaySQModule::calculateWeightedSQ(const PartialSet &unweightedsq, PartialSe
 void XRaySQModule::calculateWeights(const RDFModule *rdfModule, XRayWeights &weights,
                                     XRayFormFactors::XRayFormFactorData formFactors) const
 {
-    // Construct weights matrix containing each Species in the Configuration in the correct proportion
-    // TODO This info would be better calculated by the RDFModule and stored there / associated to it (#400)
-    // TODO Following code should exist locally in RDFModule::sumUnweightedGR() when suitable class storage is available.
+    // Clear weights and get species populations from RDFModule
     weights.clear();
+    auto populations = rdfModule->speciesPopulations();
 
-    for (auto *cfg : rdfModule->targetConfigurations())
-    {
-        // TODO Assume weight of 1.0 per configuration now, until #398/#400 are addressed.
-        const auto CFGWEIGHT = 1.0;
-
-        ListIterator<SpeciesInfo> spInfoIterator(cfg->usedSpecies());
-        while (auto *spInfo = spInfoIterator.iterate())
-            weights.addSpecies(spInfo->species(), spInfo->population() * CFGWEIGHT);
-    }
+    for (auto speciesPop : populations)
+        weights.addSpecies(speciesPop.first, speciesPop.second);
 
     weights.finalise(formFactors);
 }


### PR DESCRIPTION
This PR address several small bugs/issues in the code, and makes an effort to tidy up a few bits along the way. Most of these issues were highlighted by recent work that simplified the interaction between the correlation modules (#402).

### Overview
All the work centres around the calculation/storage of data by the `RDFModule`, and which is referenced by other modules when doing their own calculations. In particular:

- Effective densities from multiple configurations being specified in `RDFModule`.
- Species populations over multiple configurations.

### Resolution

Storage of trivially-calculable properties in the restart file is not performed, safeguarding the accuracy of those values when Configuration contents become dynamic. Functions to calculate and return necessary data have been added to `RDFModule`.

References to ConfigurationWeights values stored in processing data have been removed, as they were defunct. Proper weighting of configurations will be addressed in a future PR once that functionality is required.

### Related Issues

Closes #451.
Closes #398.
Closes #400.
