### PR TITLE
Bugfix 17/12/20 Size Factor I/O

### DIFF
--- a/examples/benzene/input.txt
+++ b/examples/benzene/input.txt
@@ -1,8 +1,8 @@
-# Input file written by Dissolve v0.5.1 at 10:41:34 on 14-01-2020.
+# Input file written by Dissolve v0.7.0 at 10:54:15 on 17-12-2020.
 
-#------------------------------------------------------------------------------#
+#==============================================================================#
 #                                 Master Terms                                 #
-#------------------------------------------------------------------------------#
+#==============================================================================#
 
 Master
   Bond  'CA-CA'  Harmonic  3924.590     1.400
@@ -14,24 +14,24 @@ Master
   Torsion  'HA-CA-CA-HA'  Cos3     0.000    30.334     0.000
 EndMaster
 
-#------------------------------------------------------------------------------#
+#==============================================================================#
 #                                   Species                                    #
-#------------------------------------------------------------------------------#
+#==============================================================================#
 
 Species 'Benzene'
   # Atoms
-  Atom    1    C  -1.399000e+00  1.600000e-01  0.000000e+00  'CA'  -1.150000e-01
-  Atom    2    C  -5.610000e-01  1.293000e+00  0.000000e+00  'CA'  -1.150000e-01
-  Atom    3    C  8.390000e-01  1.132000e+00  0.000000e+00  'CA'  -1.150000e-01
-  Atom    4    C  1.399000e+00  -1.600000e-01  0.000000e+00  'CA'  -1.150000e-01
-  Atom    5    C  5.600000e-01  -1.293000e+00  0.000000e+00  'CA'  -1.150000e-01
-  Atom    6    C  -8.390000e-01  -1.132000e+00  0.000000e+00  'CA'  -1.150000e-01
-  Atom    7    H  1.483000e+00  2.001000e+00  0.000000e+00  'HA'  1.150000e-01
-  Atom    8    H  2.472000e+00  -2.840000e-01  0.000000e+00  'HA'  1.150000e-01
-  Atom    9    H  9.910000e-01  -2.284000e+00  0.000000e+00  'HA'  1.150000e-01
-  Atom   10    H  -1.483000e+00  -2.000000e+00  0.000000e+00  'HA'  1.150000e-01
-  Atom   11    H  -2.472000e+00  2.820000e-01  0.000000e+00  'HA'  1.150000e-01
-  Atom   12    H  -9.900000e-01  2.284000e+00  0.000000e+00  'HA'  1.150000e-01
+  Atom    1  C    -1.399000e+00  1.600000e-01  0.000000e+00  'CA'  -1.150000e-01
+  Atom    2  C    -5.610000e-01  1.293000e+00  0.000000e+00  'CA'  -1.150000e-01
+  Atom    3  C    8.390000e-01  1.132000e+00  0.000000e+00  'CA'  -1.150000e-01
+  Atom    4  C    1.399000e+00  -1.600000e-01  0.000000e+00  'CA'  -1.150000e-01
+  Atom    5  C    5.600000e-01  -1.293000e+00  0.000000e+00  'CA'  -1.150000e-01
+  Atom    6  C    -8.390000e-01  -1.132000e+00  0.000000e+00  'CA'  -1.150000e-01
+  Atom    7  H    1.483000e+00  2.001000e+00  0.000000e+00  'HA'  1.150000e-01
+  Atom    8  H    2.472000e+00  -2.840000e-01  0.000000e+00  'HA'  1.150000e-01
+  Atom    9  H    9.910000e-01  -2.284000e+00  0.000000e+00  'HA'  1.150000e-01
+  Atom   10  H    -1.483000e+00  -2.000000e+00  0.000000e+00  'HA'  1.150000e-01
+  Atom   11  H    -2.472000e+00  2.820000e-01  0.000000e+00  'HA'  1.150000e-01
+  Atom   12  H    -9.900000e-01  2.284000e+00  0.000000e+00  'HA'  1.150000e-01
 
   # Bonds
   Bond    1    2  @CA-CA
@@ -104,24 +104,24 @@ Species 'Benzene'
   EndSite
 EndSpecies
 
-#------------------------------------------------------------------------------#
+#==============================================================================#
 #                               Pair Potentials                                #
-#------------------------------------------------------------------------------#
+#==============================================================================#
 
 PairPotentials
   # Atom Type Parameters
   Parameters  CA  C  -1.150000e-01  LJGeometric  2.928800e-01  3.550000e+00  0.000000e+00  0.000000e+00
   Parameters  HA  H  1.150000e-01  LJGeometric  1.255200e-01  2.420000e+00  0.000000e+00  0.000000e+00
-  Range  12.000000
-  Delta  0.005000
+  Range  12.0
+  Delta  0.005
   IncludeCoulomb  True
   CoulombTruncation  Shifted
   ShortRangeTruncation  Shifted
 EndPairPotentials
 
-#------------------------------------------------------------------------------#
+#==============================================================================#
 #                                Configurations                                #
-#------------------------------------------------------------------------------#
+#==============================================================================#
 
 Configuration  'Bulk'
 
@@ -138,42 +138,42 @@ Configuration  'Bulk'
     AddSpecies
       Species  'Benzene'
       Population  '200'
+      BoxAction  AddVolume
       Density  'rho'  g/cm3
       Rotate  True
       Positioning  Random
     EndAddSpecies
   EndGenerator
 
-  Temperature  300.000000
+  Temperature  300.0
+
+  SizeFactor  10.0
 
   # Modules
   # -- None
 EndConfiguration
 
-#------------------------------------------------------------------------------#
+#==============================================================================#
 #                              Processing Layers                               #
-#------------------------------------------------------------------------------#
+#==============================================================================#
 
 Layer  'Evolve (Standard)'
   Frequency  1
 
   Module  MolShake  'MolShake01'
     Frequency  1
-
     Configuration  'Bulk'
-    RotationStepSize   1.08426e+01
-    TranslationStepSize   2.58465e-01
+    RotationStepSize   9.00000e+01
+    TranslationStepSize   3.00000e+00
   EndModule
 
   Module  MD  'MD01'
     Frequency  5
-
     Configuration  'Bulk'
   EndModule
 
   Module  Energy  'Energy01'
     Frequency  1
-
     Configuration  'Bulk'
   EndModule
 EndLayer
@@ -183,7 +183,6 @@ Layer  'Analysis'
 
   Module  CalculateAxisAngle  'CalculateAxisAngle01'
     Frequency  1
-
     Configuration  'Bulk'
     AngleRange  0.000000e+00  9.000000e+01  1.000000e+01
     SiteA  'Benzene'  'COG'
@@ -199,21 +198,18 @@ Layer  'RDF / Neutron S(Q)'
 
   Module  RDF  'RDF01'
     Frequency  1
-
     Configuration  'Bulk'
     IntraBroadening    Gaussian  1.800000e-01
   EndModule
 
   Module  SQ  'SQ01'
     Frequency  1
-
     SourceRDFs  'RDF01'
-    QBroadening  'OmegaDependentGaussian'  0.020000
+    QBroadening  'OmegaDependentGaussian'  0.02
   EndModule
 
   Module  NeutronSQ  'C6H6'
     Frequency  1
-
     SourceSQs  'SQ01'
     Reference  mint  'data/C6H6.mint01'
     EndReference
@@ -221,19 +217,17 @@ Layer  'RDF / Neutron S(Q)'
 
   Module  NeutronSQ  'C6D6'
     Frequency  1
-
     SourceSQs  'SQ01'
-    Isotopologue  'Benzene'  'Deuterated'  1.000000
+    Isotopologue  'Benzene'  'Deuterated'  1.0
     Reference  mint  'data/C6D6.mint01'
     EndReference
   EndModule
 
   Module  NeutronSQ  '5050'
     Frequency  1
-
     SourceSQs  'SQ01'
-    Isotopologue  'Benzene'  'Natural'  1.000000
-    Isotopologue  'Benzene'  'Deuterated'  1.000000
+    Isotopologue  'Benzene'  'Natural'  1.0
+    Isotopologue  'Benzene'  'Deuterated'  1.0
     Reference  mint  'data/5050.mint01'
     EndReference
   EndModule
@@ -251,9 +245,9 @@ Layer  'Refine (EPSR)'
   EndModule
 EndLayer
 
-#------------------------------------------------------------------------------#
+#==============================================================================#
 #                                  Simulation                                  #
-#------------------------------------------------------------------------------#
+#==============================================================================#
 
 Simulation
   Seed  -1

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -172,17 +172,16 @@ class Configuration : public ListItem<Configuration>, public ObjectStore<Configu
     // Set requested size factor for Box
     void setRequestedSizeFactor(double factor);
     // Return requested size factor for Box
-    double requestedSizeFactor();
+    double requestedSizeFactor() const;
     // Return last size factor applied to Box / Cells
-    double appliedSizeFactor();
+    double appliedSizeFactor() const;
     // Set requested side length for individual Cell
     void setRequestedCellDivisionLength(double a);
     // Return requested side length for individual Cell
     double requestedCellDivisionLength() const;
     // Return cell array
     CellArray &cells();
-    // Return cell array
-    const CellArray &constCells() const;
+    const CellArray &cells() const;
     // Scale Box, Cells, and Molecule geometric centres according to current size factor
     void applySizeFactor(const PotentialMap &potentialMap);
 

--- a/src/classes/configuration_box.cpp
+++ b/src/classes/configuration_box.cpp
@@ -44,10 +44,10 @@ void Configuration::scaleBox(double factor)
 void Configuration::setRequestedSizeFactor(double factor) { requestedSizeFactor_ = factor; }
 
 // Return requested size factor for Box
-double Configuration::requestedSizeFactor() { return requestedSizeFactor_; }
+double Configuration::requestedSizeFactor() const { return requestedSizeFactor_; }
 
 // Return last size factor applied to Box / Cells
-double Configuration::appliedSizeFactor() { return appliedSizeFactor_; }
+double Configuration::appliedSizeFactor() const { return appliedSizeFactor_; }
 
 // Set requested side length for individual Cell
 void Configuration::setRequestedCellDivisionLength(double a) { requestedCellDivisionLength_ = a; }
@@ -58,8 +58,7 @@ double Configuration::requestedCellDivisionLength() const { return requestedCell
 // Return cell array
 CellArray &Configuration::cells() { return cells_; }
 
-// Return cell array
-const CellArray &Configuration::constCells() const { return cells_; }
+const CellArray &Configuration::cells() const { return cells_; }
 
 // Scale Box, Cells, and Molecule geometric centres according to current size factor
 void Configuration::applySizeFactor(const PotentialMap &potentialMap)

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -17,8 +17,8 @@ bool Configuration::write(LineParser &parser) const
     // Write unit cell (box) lengths and angles
     const auto lengths = box()->axisLengths();
     const auto angles = box()->axisAngles();
-    if (!parser.writeLineF("{:12e} {:12e} {:12e}  {}  {}  {}\n", lengths.x, lengths.y, lengths.z, appliedSizeFactor_, requestedSizeFactor_,
-                           DissolveSys::btoa(box()->type() == Box::NonPeriodicBoxType)))
+    if (!parser.writeLineF("{:12e} {:12e} {:12e}  {}  {}  {}\n", lengths.x, lengths.y, lengths.z, appliedSizeFactor_,
+                           requestedSizeFactor_, DissolveSys::btoa(box()->type() == Box::NonPeriodicBoxType)))
         return false;
     if (!parser.writeLineF("{:12e} {:12e} {:12e}\n", angles.x, angles.y, angles.z))
         return false;

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -17,7 +17,7 @@ bool Configuration::write(LineParser &parser) const
     // Write unit cell (box) lengths and angles
     const auto lengths = box()->axisLengths();
     const auto angles = box()->axisAngles();
-    if (!parser.writeLineF("{:12e} {:12e} {:12e}  {}  {}\n", lengths.x, lengths.y, lengths.z, requestedSizeFactor_,
+    if (!parser.writeLineF("{:12e} {:12e} {:12e}  {}  {}\n", lengths.x, lengths.y, lengths.z, appliedSizeFactor_,
                            DissolveSys::btoa(box()->type() == Box::NonPeriodicBoxType)))
         return false;
     if (!parser.writeLineF("{:12e} {:12e} {:12e}\n", angles.x, angles.y, angles.z))
@@ -75,19 +75,18 @@ bool Configuration::read(LineParser &parser, const List<Species> &availableSpeci
 
     /*
      * Read box definition
-     * Lengths, along with atomic coordinates, reflect the specified size factor (if present).
+     * Lengths, along with atomic coordinates, reflect the applied size factor.
      * Create box with unscaled lengths - they will be scaled according to the size factor at the end of the routine.
      */
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
-    auto scaledLengths = parser.arg3d(0);
-    requestedSizeFactor_ = (parser.hasArg(3) ? parser.argd(3) : 1.0);
+    appliedSizeFactor_ = parser.argd(3);
+    const auto lengths = parser.arg3d(0) / appliedSizeFactor_;
+
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
-
-    appliedSizeFactor_ = requestedSizeFactor_;
-    const auto lengths = scaledLengths / appliedSizeFactor_;
     const auto angles = parser.arg3d(0);
+
     if (!createBox(lengths, angles))
         return false;
 

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -82,13 +82,14 @@ bool Configuration::read(LineParser &parser, const List<Species> &availableSpeci
         return false;
     appliedSizeFactor_ = parser.argd(3);
     requestedSizeFactor_ = parser.argd(4);
+    auto nonPeriodic = parser.argb(5);
     const auto lengths = parser.arg3d(0) / appliedSizeFactor_;
 
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     const auto angles = parser.arg3d(0);
 
-    if (!createBox(lengths, angles))
+    if (!createBox(lengths, angles, nonPeriodic))
         return false;
 
     // Read total number of Molecules to expect

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -17,7 +17,7 @@ bool Configuration::write(LineParser &parser) const
     // Write unit cell (box) lengths and angles
     const auto lengths = box()->axisLengths();
     const auto angles = box()->axisAngles();
-    if (!parser.writeLineF("{:12e} {:12e} {:12e}  {}  {}\n", lengths.x, lengths.y, lengths.z, appliedSizeFactor_,
+    if (!parser.writeLineF("{:12e} {:12e} {:12e}  {}  {}  {}\n", lengths.x, lengths.y, lengths.z, appliedSizeFactor_, requestedSizeFactor_,
                            DissolveSys::btoa(box()->type() == Box::NonPeriodicBoxType)))
         return false;
     if (!parser.writeLineF("{:12e} {:12e} {:12e}\n", angles.x, angles.y, angles.z))
@@ -81,6 +81,7 @@ bool Configuration::read(LineParser &parser, const List<Species> &availableSpeci
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     appliedSizeFactor_ = parser.argd(3);
+    requestedSizeFactor_ = parser.argd(4);
     const auto lengths = parser.arg3d(0) / appliedSizeFactor_;
 
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -227,6 +227,8 @@ void ConfigurationTab::on_RequestedSizeFactorSpin_valueChanged(double value)
         return;
 
     configuration_->setRequestedSizeFactor(value);
+
+    dissolveWindow_->setModified();
 }
 
 /*

--- a/src/keywords/configurationreflist.cpp
+++ b/src/keywords/configurationreflist.cpp
@@ -67,7 +67,7 @@ bool ConfigurationRefListKeyword::write(LineParser &parser, std::string_view key
     // Loop over list of Configuration
     std::string configurationString;
     for (Configuration *cfg : data_)
-        configurationString += fmt::format("  '{}'", cfg->name());
+        configurationString += fmt::format("{}'{}'", configurationString.empty() ? "" : "  ", cfg->name());
 
     if (!parser.writeLineF("{}{}  {}\n", prefix, keywordName, configurationString))
         return false;

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -319,6 +319,12 @@ bool Dissolve::saveInput(std::string_view filename)
                                cfg->temperature()))
             return false;
 
+        if (!parser.writeLineF("\n"))
+            return false;
+        if (!parser.writeLineF("  {}  {}\n", ConfigurationBlock::keywords().keyword(ConfigurationBlock::SizeFactorKeyword),
+                               cfg->requestedSizeFactor()))
+            return false;
+
         // Modules
         if (!parser.writeLineF("\n  # Modules\n"))
             return false;


### PR DESCRIPTION
THis bugfix PR addresses issue #370, where the requested size factor for a configuration was not saved to the input file.

Both applied and requested size factors are now written to the restart file, while the requested size factor is written to the input file. If present, reading the restart file will override the any requested size in the input file, as should be expected.

Closes #370.
