### PR TITLE
Bugfix 12/12/20 Unit Test Linking

### DIFF
--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -25,7 +25,37 @@ foreach(SRCFILE "${tests_SRC}")
   )
   target_link_libraries(${NAME} PUBLIC
     ${CONAN_LIBS}
+
+    ${WHOLE_ARCHIVE_FLAG}
+
     ${BASIC_LINK_LIBS}
+
+    # Module 'nogui' libs
+    analysemodulenogui
+    atomshakemodulenogui
+    benchmarkmodulenogui
+    braggmodulenogui
+    calculateanglemodulenogui
+    calculateavgmolmodulenogui
+    calculateaxisanglemodulenogui
+    calculatecnmodulenogui
+    calculatedanglemodulenogui
+    calculaterdfmodulenogui
+    calculatesdfmodulenogui
+    calibrationmodulenogui
+    datatestmodulenogui
+    energymodulenogui
+    epsrmodulenogui
+    geomoptmodulenogui
+    neutronsqmodulenogui
+    rdfmodulenogui
+    skeletonmodulenogui
+    sqmodulenogui
+    testmodulenogui
+    xraysqmodulenogui
+
+    ${NO_WHOLE_ARCHIVE_FLAG}
+
     PRIVATE
 
     antlr4-runtime


### PR DESCRIPTION
This PR addresses link errors with the unit tests, making the `target_link_libraries` the same as the CLI version of the main code.

This also highlights the verbosity of the current method for including / linking modules in the build, and which will be addressed in a future PR (issue #491).