### PR TITLE
Use const overloads

### DIFF
--- a/src/base/processgroup.cpp
+++ b/src/base/processgroup.cpp
@@ -18,16 +18,16 @@ void ProcessGroup::addProcess(int poolRank, int worldRank)
 }
 
 // Return total number of processes in group
-int ProcessGroup::nProcesses() { return poolRanks_.nItems(); }
+int ProcessGroup::nProcesses() const { return poolRanks_.nItems(); }
 
 // Return world ranks of group processes
 Array<int> &ProcessGroup::worldRanks() { return worldRanks_; }
 
 // Return nth world rank of group processes
-int ProcessGroup::worldRank(int n) const { return worldRanks_.constAt(n); }
+int ProcessGroup::worldRank(int n) const { return worldRanks_.at(n); }
 
 // Return pool ranks of group processes
-Array<int> &ProcessGroup::poolRanks() { return poolRanks_; }
+const Array<int> &ProcessGroup::poolRanks() const { return poolRanks_; }
 
 // Return nth pool rank of group processes
-int ProcessGroup::poolRank(int n) const { return poolRanks_.constAt(n); }
+int ProcessGroup::poolRank(int n) const { return poolRanks_.at(n); }

--- a/src/base/processgroup.h
+++ b/src/base/processgroup.h
@@ -35,13 +35,13 @@ class ProcessGroup : public ListItem<ProcessGroup>
     // Add process to group
     void addProcess(int poolRank, int worldRank);
     // Return total number of processes in group
-    int nProcesses();
+    int nProcesses() const;
     // Return world ranks of group processes
     Array<int> &worldRanks();
     // Return nth world rank of group processes
     int worldRank(int n) const;
     // Return pool ranks of group processes
-    Array<int> &poolRanks();
+    const Array<int> &poolRanks() const;
     // Return nth pool rank of group processes
     int poolRank(int n) const;
 };

--- a/src/base/processpool.cpp
+++ b/src/base/processpool.cpp
@@ -164,9 +164,9 @@ bool ProcessPool::isMaster(ProcessPool::CommunicatorType commType) const
     if (commType == ProcessPool::PoolProcessesCommunicator)
         return (poolRank_ == 0);
     else if (commType == ProcessPool::GroupProcessesCommunicator)
-        return (groupLeaders_.constAt(groupIndex_) == poolRank_);
+        return (groupLeaders_.at(groupIndex_) == poolRank_);
     else if (commType == ProcessPool::GroupLeadersCommunicator)
-        return (groupLeaders_.constAt(0) == poolRank_);
+        return (groupLeaders_.at(0) == poolRank_);
 
     return false;
 }
@@ -177,9 +177,9 @@ bool ProcessPool::isSlave(ProcessPool::CommunicatorType commType) const
     if (commType == ProcessPool::PoolProcessesCommunicator)
         return (poolRank_ != 0);
     else if (commType == ProcessPool::GroupProcessesCommunicator)
-        return (groupLeaders_.constAt(groupIndex_) != poolRank_);
+        return (groupLeaders_.at(groupIndex_) != poolRank_);
     else if (commType == ProcessPool::GroupLeadersCommunicator)
-        return (groupLeaders_.constAt(0) != poolRank_);
+        return (groupLeaders_.at(0) != poolRank_);
 
     return true;
 }
@@ -191,7 +191,7 @@ bool ProcessPool::isMe(int poolIndex) const { return (poolRank_ == poolIndex); }
 bool ProcessPool::involvesMe() const
 {
     for (auto n = 0; n < worldRanks_.nItems(); ++n)
-        if (worldRanks_.constAt(n) == worldRank_)
+        if (worldRanks_.at(n) == worldRank_)
             return true;
     return false;
 }
@@ -287,7 +287,7 @@ std::string_view ProcessPool::name() const { return name_; }
 int ProcessPool::nProcesses() const { return worldRanks_.nItems(); }
 
 // Return root (first) world rank of this pool
-int ProcessPool::rootWorldRank() const { return worldRanks_.constAt(0); }
+int ProcessPool::rootWorldRank() const { return worldRanks_.at(0); }
 
 // Assign processes to groups
 bool ProcessPool::assignProcessesToGroups()
@@ -497,11 +497,11 @@ int ProcessPool::nProcessesInGroup(int groupId) const
         return 0;
     }
 #endif
-    return processGroups_.constAt(groupId).nProcesses();
+    return processGroups_.at(groupId).nProcesses();
 }
 
 // Return array of pool ranks in specified group
-int *ProcessPool::poolRanksInGroup(int groupId) const
+const Array<int> &ProcessPool::poolRanksInGroup(int groupId) const
 {
 #ifdef CHECKS
     if ((groupId < 0) || (groupId >= processGroups_.nItems()))
@@ -512,7 +512,7 @@ int *ProcessPool::poolRanksInGroup(int groupId) const
         return 0;
     }
 #endif
-    return processGroups_.constAt(groupId).poolRanks().array();
+    return processGroups_.at(groupId).poolRanks();
 }
 
 // Return whether group data is modifiable
@@ -2395,9 +2395,9 @@ bool ProcessPool::equality(const Array<int> &array, ProcessPool::CommunicatorTyp
 
     // Keep it simple (and slow) and check/send one value at a time
     for (auto n = 0; n < array.nItems(); ++n)
-        if (!equality(array.constAt(n), commType))
+        if (!equality(array.at(n), commType))
             return Messenger::error("Array<int> value {} is not equivalent (process {} has {:e}).\n", n, poolRank_,
-                                    array.constAt(n));
+                                    array.at(n));
 #endif
     return true;
 }
@@ -2412,9 +2412,9 @@ bool ProcessPool::equality(const Array<double> &array, ProcessPool::Communicator
 
     // Keep it simple (and slow) and check/send one value at a time
     for (auto n = 0; n < array.nItems(); ++n)
-        if (!equality(array.constAt(n), commType))
+        if (!equality(array.at(n), commType))
             return Messenger::error("Array<double> value {} is not equivalent (process {} has {:e}).\n", n, poolRank_,
-                                    array.constAt(n));
+                                    array.at(n));
 #endif
     return true;
 }

--- a/src/base/processpool.h
+++ b/src/base/processpool.h
@@ -171,7 +171,7 @@ class ProcessPool
     // Return number of processes in specified group
     int nProcessesInGroup(int groupId) const;
     // Return array of pool ranks in the specified group
-    int *poolRanksInGroup(int groupId) const;
+    const Array<int> &poolRanksInGroup(int groupId) const;
     // Return whether group data is modifiable
     bool groupsModifiable() const;
     // Prevent group data from being modified

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -140,7 +140,6 @@ class Configuration : public ListItem<Configuration>, public ObjectStore<Configu
     int nAtoms() const;
     // Return Atom array
     std::vector<std::shared_ptr<Atom>> &atoms();
-    // Return Atom array (const)
     const std::vector<std::shared_ptr<Atom>> &atoms() const;
     // Return nth Atom
     std::shared_ptr<Atom> atom(int n);

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -170,7 +170,6 @@ int Configuration::nAtoms() const { return atoms_.size(); }
 // Return Atom array
 std::vector<std::shared_ptr<Atom>> &Configuration::atoms() { return atoms_; }
 
-// Return Atom array (const)
 const std::vector<std::shared_ptr<Atom>> &Configuration::atoms() const { return atoms_; }
 
 // Return nth atom

--- a/src/classes/coordinateset.cpp
+++ b/src/classes/coordinateset.cpp
@@ -22,7 +22,7 @@ int CoordinateSet::size() const { return coordinates_.nItems(); }
 void CoordinateSet::set(int index, Vec3<double> r) { coordinates_.at(index) = r; }
 
 // Return specified coordinates
-Vec3<double> CoordinateSet::r(int index) const { return coordinates_.constAt(index); }
+Vec3<double> CoordinateSet::r(int index) const { return coordinates_.at(index); }
 
 // Return coordinates array
 Array<Vec3<double>> &CoordinateSet::coordinates() { return coordinates_; }

--- a/src/classes/distributor.cpp
+++ b/src/classes/distributor.cpp
@@ -107,7 +107,7 @@ bool Distributor::addHardLocks(Array<Cell *> cells)
     // Loop over Cells to hard-lock
     for (auto n = 0; n < cells.nItems(); ++n)
     {
-        cellId = cells.constAt(n)->index();
+        cellId = cells.at(n)->index();
 
         // Add a hard lock to the Cell - set the lock counter to -1.
         // We can't hard-lock a cell if it is currently being modified ( == HardLocked ) or is soft-locked ( > 0 )
@@ -129,7 +129,7 @@ bool Distributor::addHardLocks(Array<Cell *> cells)
     // Must now soft-lock all the surrounding Cells
     for (auto n = 0; n < softCells.nItems(); ++n)
     {
-        cellId = softCells.constAt(n)->index();
+        cellId = softCells.at(n)->index();
         if (!addSoftLock(cellId))
             return false;
     }
@@ -150,7 +150,7 @@ bool Distributor::removeHardLocks(Array<Cell *> cells)
     // Loop over Cells to hard-unlock
     for (auto n = 0; n < cells.nItems(); ++n)
     {
-        cellId = cells.constAt(n)->index();
+        cellId = cells.at(n)->index();
 
         // Remove a hard lock from the Cell - set lock counter to zero
         // We can't hard-unlock a cell unless it is currently hard-locked (obviously!)
@@ -172,7 +172,7 @@ bool Distributor::removeHardLocks(Array<Cell *> cells)
     // Must now soft-unlock all the surrounding Cells
     for (auto n = 0; n < softCells.nItems(); ++n)
     {
-        cellId = softCells.constAt(n)->index();
+        cellId = softCells.at(n)->index();
         if (!removeSoftLock(cellId))
             return false;
     }
@@ -181,12 +181,12 @@ bool Distributor::removeHardLocks(Array<Cell *> cells)
 }
 
 // Return lock count
-int Distributor::lockCount(int cellIndex) const { return cellLocks_.constAt(cellIndex); }
+int Distributor::lockCount(int cellIndex) const { return cellLocks_.at(cellIndex); }
 
 // Check hard lock possibility
 bool Distributor::canHardLock(int cellIndex) const
 {
-    if (cellLocks_.constAt(cellIndex) != NoLocks)
+    if (cellLocks_.at(cellIndex) != NoLocks)
         return false;
 
     Cell *cell = cellArray_.cell(cellIndex);
@@ -198,7 +198,7 @@ bool Distributor::canHardLock(int cellIndex) const
     for (auto n = 0; n < cell->nCellNeighbours(); ++n)
     {
         id = cell->cellNeighbour(n)->index();
-        if (cellLocks_.constAt(id) == HardLocked)
+        if (cellLocks_.at(id) == HardLocked)
             return false;
     }
 
@@ -206,7 +206,7 @@ bool Distributor::canHardLock(int cellIndex) const
     for (auto n = 0; n < cell->nMimCellNeighbours(); ++n)
     {
         id = cell->mimCellNeighbour(n)->index();
-        if (cellLocks_.constAt(id) == HardLocked)
+        if (cellLocks_.at(id) == HardLocked)
             return false;
     }
 
@@ -466,7 +466,7 @@ bool Distributor::finishedWithObject()
         // Mark hard-locked Cells as being modified
         for (auto n = 0; n < lastHardLockedCells_[processOrGroup].nItems(); ++n)
         {
-            auto cellIndex = lastHardLockedCells_[processOrGroup].constAt(n)->index();
+            auto cellIndex = lastHardLockedCells_[processOrGroup].at(n)->index();
 
             // If the current process/group was the last to modify it, that's OK.
             if (cellContentsModifiedBy_[cellIndex] == processOrGroup)

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -717,7 +717,7 @@ double EnergyKernel::energy(const SpeciesTorsion &torsion)
                                                 torsion.l()->r() - torsion.k()->r()));
 }
 
-// Return SpeciesImproper energy
+// Return SpeciesImproper energy at Atoms specified
 double EnergyKernel::energy(const SpeciesImproper &imp, const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j,
                             const std::shared_ptr<Atom> k, const std::shared_ptr<Atom> l)
 {
@@ -738,6 +738,13 @@ double EnergyKernel::energy(const SpeciesImproper &imp, const std::shared_ptr<At
         veckl = l->r() - k->r();
 
     return imp.energy(Box::torsionInDegrees(vecji, vecjk, veckl));
+}
+
+// Return SpeciesImproper energy
+double EnergyKernel::energy(const SpeciesImproper &imp)
+{
+    return imp.energy(
+        Box::torsionInDegrees(imp.i()->r() - imp.j()->r(), imp.k()->r() - imp.j()->r(), imp.l()->r() - imp.k()->r()));
 }
 
 // Return intramolecular energy for the supplied Atom

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -807,26 +807,26 @@ double EnergyKernel::intramolecularEnergy(std::shared_ptr<const Molecule> mol)
     auto intraEnergy = 0.0;
 
     // Loop over Bonds
-    intraEnergy = std::accumulate(mol->species()->constBonds().begin(), mol->species()->constBonds().end(), intraEnergy,
+    intraEnergy = std::accumulate(mol->species()->bonds().begin(), mol->species()->bonds().end(), intraEnergy,
                                   [mol, this](const auto acc, const auto &bond) {
                                       return acc + energy(bond, mol->atom(bond.indexI()), mol->atom(bond.indexJ()));
                                   });
     // Loop over Angles
-    intraEnergy = std::accumulate(mol->species()->constAngles().begin(), mol->species()->constAngles().end(), intraEnergy,
+    intraEnergy = std::accumulate(mol->species()->angles().begin(), mol->species()->angles().end(), intraEnergy,
                                   [mol, this](const auto acc, const auto &angle) {
                                       return acc + energy(angle, mol->atom(angle.indexI()), mol->atom(angle.indexJ()),
                                                           mol->atom(angle.indexK()));
                                   });
 
     // Loop over Torsions
-    intraEnergy = std::accumulate(mol->species()->constTorsions().begin(), mol->species()->constTorsions().end(), intraEnergy,
+    intraEnergy = std::accumulate(mol->species()->torsions().begin(), mol->species()->torsions().end(), intraEnergy,
                                   [mol, this](const auto acc, const auto &torsion) {
                                       return acc + energy(torsion, mol->atom(torsion.indexI()), mol->atom(torsion.indexJ()),
                                                           mol->atom(torsion.indexK()), mol->atom(torsion.indexL()));
                                   });
 
     // Loop over Impropers
-    intraEnergy = std::accumulate(mol->species()->constImpropers().begin(), mol->species()->constImpropers().end(), intraEnergy,
+    intraEnergy = std::accumulate(mol->species()->impropers().begin(), mol->species()->impropers().end(), intraEnergy,
                                   [mol, this](const auto acc, const auto &improper) {
                                       return acc + energy(improper, mol->atom(improper.indexI()), mol->atom(improper.indexJ()),
                                                           mol->atom(improper.indexK()), mol->atom(improper.indexL()));

--- a/src/classes/energykernel.h
+++ b/src/classes/energykernel.h
@@ -97,9 +97,11 @@ class EnergyKernel
                   const std::shared_ptr<Atom> k, const std::shared_ptr<Atom> l);
     // Return SpeciesTorsion energy
     static double energy(const SpeciesTorsion &t);
-    // Return SpeciesImproper energy
+    // Return SpeciesImproper energy at Atoms specified
     double energy(const SpeciesImproper &imp, const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j,
                   const std::shared_ptr<Atom> k, const std::shared_ptr<Atom> l);
+    // Return SpeciesImproper energy
+    static double energy(const SpeciesImproper &imp);
     // Return intramolecular energy for the supplied Atom
     double intramolecularEnergy(std::shared_ptr<const Molecule> mol, const std::shared_ptr<Atom> i);
     // Return intramolecular energy for the supplied Molecule

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -140,8 +140,7 @@ bool Isotopologues::contains(const Isotopologue *iso) const
 // Return Isotopologue/weight mix
 std::vector<IsotopologueWeight> &Isotopologues::mix() { return mix_; }
 
-// Return Isotopologue/weight mix (const)
-const std::vector<IsotopologueWeight> &Isotopologues::constMix() const { return mix_; }
+const std::vector<IsotopologueWeight> &Isotopologues::mix() const { return mix_; }
 
 // Return number of Isotopologues in list
 int Isotopologues::nIsotopologues() const { return mix_.size(); }

--- a/src/classes/isotopologues.h
+++ b/src/classes/isotopologues.h
@@ -54,8 +54,7 @@ class Isotopologues : public GenericItemBase
     bool contains(const Isotopologue *iso) const;
     // Return Isotopologue/weight mix
     std::vector<IsotopologueWeight> &mix();
-    // Return Isotopologue/weight mix (const)
-    const std::vector<IsotopologueWeight> &constMix() const;
+    const std::vector<IsotopologueWeight> &mix() const;
     // Return number of Isotopologues in mix
     int nIsotopologues() const;
     // Return total relative population

--- a/src/classes/isotopologueset.cpp
+++ b/src/classes/isotopologueset.cpp
@@ -95,8 +95,7 @@ int IsotopologueSet::nIsotopologues() const { return isotopologues_.size(); }
 // Return vector of all Isotopologues
 std::vector<Isotopologues> &IsotopologueSet::isotopologues() { return isotopologues_; }
 
-// Return vector of all Isotopologues (const)
-const std::vector<Isotopologues> &IsotopologueSet::constIsotopologues() const { return isotopologues_; }
+const std::vector<Isotopologues> &IsotopologueSet::isotopologues() const { return isotopologues_; }
 
 /*
  * GenericItemBase Implementations

--- a/src/classes/isotopologueset.h
+++ b/src/classes/isotopologueset.h
@@ -46,8 +46,7 @@ class IsotopologueSet : public GenericItemBase
     int nIsotopologues() const;
     // Return vector of all Isotopologues
     std::vector<Isotopologues> &isotopologues();
-    // Return vector of all Isotopologues (const)
-    const std::vector<Isotopologues> &constIsotopologues() const;
+    const std::vector<Isotopologues> &isotopologues() const;
 
     /*
      * GenericItemBase Implementations

--- a/src/classes/moleculedistributor.cpp
+++ b/src/classes/moleculedistributor.cpp
@@ -31,7 +31,7 @@ Array<Cell *> MoleculeDistributor::cellsToBeModifiedForObject(int objectId)
 
         // Is it already in the list?
         for (n = 0; n < cells.nItems(); ++n)
-            if (cells.constAt(n) == cell)
+            if (cells.at(n) == cell)
                 break;
         if (n == cells.nItems())
             cells.add(cell);

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -84,9 +84,9 @@ void NeutronWeights::print() const
     Messenger::print("  ------------------------------------------------------\n");
     for (auto &topes : isotopologueMixtures_)
     {
-        for (auto it = topes.constMix().begin(); it != topes.constMix().end(); ++it)
+        for (auto it = topes.mix().begin(); it != topes.mix().end(); ++it)
         {
-            if (it == topes.constMix().begin())
+            if (it == topes.mix().begin())
                 Messenger::print("  {:<15}  {:<15}  {:<10d}  {}\n", topes.species()->name(), it->isotopologue()->name(),
                                  topes.speciesPopulation(), it->weight());
             else

--- a/src/classes/pairpotential.cpp
+++ b/src/classes/pairpotential.cpp
@@ -426,21 +426,20 @@ void PairPotential::calculateDUFull()
         if ((n == 1) || (n == (nPoints_ - 2)))
         {
             // Three-point
-            dUFull_.value(n) = -(uFull_.constValue(n - 1) - uFull_.constValue(n + 1)) / (2 * delta_);
+            dUFull_.value(n) = -(uFull_.value(n - 1) - uFull_.value(n + 1)) / (2 * delta_);
         }
         else
         {
             // Five-point stencil
-            fprime = -uFull_.constValue(n + 2) + 8 * uFull_.constValue(n + 1) - 8 * uFull_.constValue(n - 1) +
-                     uFull_.constValue(n - 2);
+            fprime = -uFull_.value(n + 2) + 8 * uFull_.value(n + 1) - 8 * uFull_.value(n - 1) + uFull_.value(n - 2);
             fprime /= 12 * delta_;
             dUFull_.value(n) = fprime;
         }
     }
 
     // Set first and last points
-    dUFull_.value(0) = 10.0 * dUFull_.constValue(1);
-    dUFull_.value(nPoints_ - 1) = dUFull_.constValue(nPoints_ - 2);
+    dUFull_.value(0) = 10.0 * dUFull_.value(1);
+    dUFull_.value(nPoints_ - 1) = dUFull_.value(nPoints_ - 2);
 
     // Update interpolation
     dUFullInterpolation_.interpolate(Interpolator::ThreePointInterpolation);
@@ -516,7 +515,7 @@ void PairPotential::calculateUOriginal(bool recalculateUFull)
     }
 
     // Since the first point (at zero) risks being a nan, set it to ten times the second point instead
-    uOriginal_.value(0) = 10.0 * uOriginal_.constValue(1);
+    uOriginal_.value(0) = 10.0 * uOriginal_.value(1);
 
     // Update full potential (if not the first generation of the potential)
     if (recalculateUFull)

--- a/src/classes/partialset.cpp
+++ b/src/classes/partialset.cpp
@@ -277,8 +277,8 @@ bool PartialSet::save() const
         auto &unbound = unboundPartials_[{typeI, typeJ}];
         parser.writeLineF("# {:<14}  {:<16}  {:<16}  {:<16}\n", abscissaUnits_, "Full", "Bound", "Unbound");
         for (auto n = 0; n < full.nValues(); ++n)
-            parser.writeLineF("{:16.9e}  {:16.9e}  {:16.9e}  {:16.9e}\n", full.constXAxis(n), full.constValue(n),
-                              bound.constValue(n), unbound.constValue(n));
+            parser.writeLineF("{:16.9e}  {:16.9e}  {:16.9e}  {:16.9e}\n", full.xAxis(n), full.value(n), bound.value(n),
+                              unbound.value(n));
         parser.closeFiles();
 
         return EarlyReturn<bool>::Continue;

--- a/src/classes/regionaldistributor.cpp
+++ b/src/classes/regionaldistributor.cpp
@@ -230,11 +230,11 @@ ProcessPool::DivisionStrategy RegionalDistributor::currentStrategy() { return cu
 // Return whether the specified processOrGroup can lock the given Cell index
 bool RegionalDistributor::canLockCellForEditing(int processOrGroup, int cellIndex)
 {
-    CellStatusFlag status = cellStatusFlags_.constAt(cellIndex);
+    CellStatusFlag status = cellStatusFlags_.at(cellIndex);
 
     if (DND)
         Messenger::print("  0-- Checking ability to lock Cell index {} for process/group {}: current status = {}\n", cellIndex,
-                         processOrGroup, cellStatusFlag(cellStatusFlags_.constAt(cellIndex)));
+                         processOrGroup, cellStatusFlag(cellStatusFlags_.at(cellIndex)));
 
     // If the Cell is flagged as unused, return true
     if (status == RegionalDistributor::UnusedFlag)
@@ -243,12 +243,12 @@ bool RegionalDistributor::canLockCellForEditing(int processOrGroup, int cellInde
     // If the Cell is flagged as 'LockedForEditing', and not by this processOrGroup, return false. If we have locked it,
     // return true.
     if (status == RegionalDistributor::LockedForEditingFlag)
-        return (cellLockOwners_.constAt(cellIndex) == processOrGroup);
+        return (cellLockOwners_.at(cellIndex) == processOrGroup);
 
     // If the Cell is flagged as 'ReadByOne', but not by this processOrGroup, return false (if we are the sole reader, we
     // can lock it)
     if (status == RegionalDistributor::ReadByOneFlag)
-        return (cellLockOwners_.constAt(cellIndex) == processOrGroup);
+        return (cellLockOwners_.at(cellIndex) == processOrGroup);
 
     // If the Cell is flagged as 'ReadByMany', there is no chance of locking it, so return false.
     if (status == RegionalDistributor::ReadByManyFlag)

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -147,7 +147,7 @@ void ScatteringMatrix::print(double q) const
                 break;
             }
         }
-        Messenger::print("{}  {}\n", line, data_.constAt(row).name());
+        Messenger::print("{}  {}\n", line, data_.at(row).name());
 
         // Limit to sensible number of rows
         if (row >= std::max(nColsWritten, 10))
@@ -199,7 +199,7 @@ void ScatteringMatrix::printInverse(double q) const
                 break;
             }
         }
-        Messenger::print("{}  {}\n", line, data_.constAt(col).name());
+        Messenger::print("{}  {}\n", line, data_.at(col).name());
 
         // Limit to sensible number of rows
         if (col >= std::max(nColsWritten, 10))

--- a/src/classes/sitestack.cpp
+++ b/src/classes/sitestack.cpp
@@ -168,5 +168,5 @@ bool SiteStack::sitesHaveOrientation() const { return sitesHaveOrientation_; }
 // Return site with index specified
 const Site &SiteStack::site(int index) const
 {
-    return (sitesHaveOrientation_ ? orientedSites_.constAt(index) : sites_.constAt(index));
+    return (sitesHaveOrientation_ ? orientedSites_.at(index) : sites_.at(index));
 }

--- a/src/classes/sitestack.cpp
+++ b/src/classes/sitestack.cpp
@@ -166,7 +166,4 @@ bool SiteStack::sitesInMolecules() const { return sitesInMolecules_; }
 bool SiteStack::sitesHaveOrientation() const { return sitesHaveOrientation_; }
 
 // Return site with index specified
-const Site &SiteStack::site(int index) const
-{
-    return (sitesHaveOrientation_ ? orientedSites_.at(index) : sites_.at(index));
-}
+const Site &SiteStack::site(int index) const { return (sitesHaveOrientation_ ? orientedSites_.at(index) : sites_.at(index)); }

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -143,16 +143,14 @@ class Species : public ListItem<Species>, public ObjectStore<Species>
     int nBonds() const;
     // Return array of SpeciesBond
     std::vector<SpeciesBond> &bonds();
-    // Return array of SpeciesBonds (const)
-    const std::vector<SpeciesBond> &constBonds() const;
+    const std::vector<SpeciesBond> &bonds() const;
     // Return whether SpeciesBond between SpeciesAtoms exists
     bool hasBond(SpeciesAtom *i, SpeciesAtom *j) const;
     // Return the SpeciesBond between the specified SpeciesAtoms
     OptionalReferenceWrapper<SpeciesBond> getBond(SpeciesAtom *i, SpeciesAtom *j);
+    OptionalReferenceWrapper<const SpeciesBond> getBond(SpeciesAtom *i, SpeciesAtom *j) const;
     // Return the SpeciesBond between the specified SpeciesAtom indices
     OptionalReferenceWrapper<SpeciesBond> getBond(int i, int j);
-    // Return the SpeciesBond between the specified SpeciesAtoms (const)
-    OptionalReferenceWrapper<const SpeciesBond> getConstBond(SpeciesAtom *i, SpeciesAtom *j) const;
     // Add missing bonds
     void addMissingBonds(double tolerance = 1.1);
     // Add new SpeciesAngle definition
@@ -163,8 +161,7 @@ class Species : public ListItem<Species>, public ObjectStore<Species>
     int nAngles() const;
     // Return array of SpeciesAngle
     std::vector<SpeciesAngle> &angles();
-    // Return array of SpeciesAngle (const)
-    const std::vector<SpeciesAngle> &constAngles() const;
+    const std::vector<SpeciesAngle> &angles() const;
     // Return whether SpeciesAngle between SpeciesAtoms exists
     bool hasAngle(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k) const;
     // Return the SpeciesAngle between the specified SpeciesAtoms
@@ -179,8 +176,7 @@ class Species : public ListItem<Species>, public ObjectStore<Species>
     int nTorsions() const;
     // Return array of SpeciesTorsion
     std::vector<SpeciesTorsion> &torsions();
-    // Return array of SpeciesTorsion (const)
-    const std::vector<SpeciesTorsion> &constTorsions() const;
+    const std::vector<SpeciesTorsion> &torsions() const;
     // Return whether SpeciesTorsion between SpeciesAtoms exists
     bool hasTorsion(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l) const;
     // Return the SpeciesTorsion between the specified SpeciesAtoms
@@ -195,8 +191,7 @@ class Species : public ListItem<Species>, public ObjectStore<Species>
     int nImpropers() const;
     // Return array of SpeciesImproper
     std::vector<SpeciesImproper> &impropers();
-    // Return array of SpeciesImproper (const)
-    const std::vector<SpeciesImproper> &constImpropers() const;
+    const std::vector<SpeciesImproper> &impropers() const;
     // Return whether SpeciesImproper between SpeciesAtoms exists
     bool hasImproper(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l) const;
     // Return the SpeciesImproper between the specified SpeciesAtoms (if it exists)

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -123,8 +123,7 @@ int Species::nBonds() const { return bonds_.size(); }
 // Return array of SpeciesBond
 std::vector<SpeciesBond> &Species::bonds() { return bonds_; }
 
-// Return array of SpeciesBond (const)
-const std::vector<SpeciesBond> &Species::constBonds() const { return bonds_; }
+const std::vector<SpeciesBond> &Species::bonds() const { return bonds_; }
 
 // Return whether SpeciesBond between specified SpeciesAtoms exists
 bool Species::hasBond(SpeciesAtom *i, SpeciesAtom *j) const
@@ -138,6 +137,15 @@ bool Species::hasBond(SpeciesAtom *i, SpeciesAtom *j) const
 OptionalReferenceWrapper<SpeciesBond> Species::getBond(SpeciesAtom *i, SpeciesAtom *j)
 {
     auto it = std::find_if(bonds_.begin(), bonds_.end(), [i, j](auto &bond) { return bond.matches(i, j); });
+    if (it == bonds_.end())
+        return {};
+
+    return *it;
+}
+
+OptionalReferenceWrapper<const SpeciesBond> Species::getBond(SpeciesAtom *i, SpeciesAtom *j) const
+{
+    auto it = std::find_if(bonds_.cbegin(), bonds_.cend(), [i, j](const auto &bond) { return bond.matches(i, j); });
     if (it == bonds_.end())
         return {};
 
@@ -163,16 +171,6 @@ OptionalReferenceWrapper<SpeciesBond> Species::getBond(int i, int j)
     }
 
     return getBond(atoms_[i], atoms_[j]);
-}
-
-// Return the SpeciesBond between the specified SpeciesAtoms (const)
-OptionalReferenceWrapper<const SpeciesBond> Species::getConstBond(SpeciesAtom *i, SpeciesAtom *j) const
-{
-    auto it = std::find_if(bonds_.cbegin(), bonds_.cend(), [i, j](const auto &bond) { return bond.matches(i, j); });
-    if (it == bonds_.end())
-        return {};
-
-    return *it;
 }
 
 // Add missing bonds
@@ -243,8 +241,7 @@ int Species::nAngles() const { return angles_.size(); }
 // Return array of SpeciesAngle
 std::vector<SpeciesAngle> &Species::angles() { return angles_; }
 
-// Return array of SpeciesAngle (const)
-const std::vector<SpeciesAngle> &Species::constAngles() const { return angles_; }
+const std::vector<SpeciesAngle> &Species::angles() const { return angles_; }
 
 // Return whether SpeciesAngle between SpeciesAtoms exists
 bool Species::hasAngle(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k) const
@@ -303,8 +300,7 @@ int Species::nTorsions() const { return torsions_.size(); }
 // Return array of SpeciesTorsions
 std::vector<SpeciesTorsion> &Species::torsions() { return torsions_; }
 
-// Return array of SpeciesTorsions (const)
-const std::vector<SpeciesTorsion> &Species::constTorsions() const { return torsions_; }
+const std::vector<SpeciesTorsion> &Species::torsions() const { return torsions_; }
 
 // Return whether SpeciesTorsion between SpeciesAtoms exists
 bool Species::hasTorsion(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l) const
@@ -362,8 +358,7 @@ int Species::nImpropers() const { return impropers_.size(); }
 // Return array of SpeciesImproper
 std::vector<SpeciesImproper> &Species::impropers() { return impropers_; }
 
-// Return array of SpeciesImproper (const)
-const std::vector<SpeciesImproper> &Species::constImpropers() const { return impropers_; }
+const std::vector<SpeciesImproper> &Species::impropers() const { return impropers_; }
 
 // Return whether SpeciesImproper between SpeciesAtoms exists
 bool Species::hasImproper(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l) const

--- a/src/data/ff/uff.cpp
+++ b/src/data/ff/uff.cpp
@@ -443,10 +443,10 @@ bool Forcefield_UFF::generateAngleTerm(const Species *sp, SpeciesAngle &angle, c
 {
     // rBO : Bond-order correction = -0.1332 * (ri + rj) * ln(n)  (eq 3)
     // We need the bond orders of the involved bonds...
-    const auto &ijRef = sp->getConstBond(angle.i(), angle.j());
+    const auto &ijRef = sp->getBond(angle.i(), angle.j());
     if (!ijRef)
         return Messenger::error("Can't locate bond i-j for bond order retrieval.\n");
-    const auto &jkRef = sp->getConstBond(angle.j(), angle.k());
+    const auto &jkRef = sp->getBond(angle.j(), angle.k());
     if (!jkRef)
         return Messenger::error("Can't locate bond j-k for bond order retrieval.\n");
 
@@ -575,7 +575,7 @@ bool Forcefield_UFF::generateTorsionTerm(const Species *sp, SpeciesTorsion &tors
     {
         // Case e) j and k are both sp2 centres
         // Force constant is adjusted based on current bond order
-        auto jkRef = sp->getConstBond(torsionTerm.j(), torsionTerm.k());
+        auto jkRef = sp->getBond(torsionTerm.j(), torsionTerm.k());
         if (jkRef)
         {
             const SpeciesBond &jk = *jkRef;

--- a/src/genericitems/arraydouble.h
+++ b/src/genericitems/arraydouble.h
@@ -52,7 +52,7 @@ template <> class GenericItemContainer<Array<double>> : public GenericItem
         parser.writeLineF("{}\n", thisData.nItems());
         for (auto n = 0; n < thisData.nItems(); ++n)
         {
-            if (!parser.writeLineF("{:16.9e}\n", thisData.constAt(n)))
+            if (!parser.writeLineF("{:16.9e}\n", thisData.at(n)))
                 return false;
         }
         return true;

--- a/src/genericitems/arrayint.h
+++ b/src/genericitems/arrayint.h
@@ -48,7 +48,7 @@ template <> class GenericItemContainer<Array<int>> : public GenericItem
         parser.writeLineF("{}\n", data_.nItems());
         for (auto n = 0; n < data_.nItems(); ++n)
         {
-            if (!parser.writeLineF("{}\n", data_.constAt(n)))
+            if (!parser.writeLineF("{}\n", data_.at(n)))
                 return false;
         }
         return true;

--- a/src/genericitems/arrayvec3double.h
+++ b/src/genericitems/arrayvec3double.h
@@ -84,7 +84,7 @@ template <> class GenericItemContainer<Array<Vec3<double>>> : public GenericItem
             return false;
         // Keep it simple (and slow) and check/send one value at a time
         for (auto n = 0; n < data_.nItems(); ++n)
-            if (!procPool.equality(data_.constAt(n)))
+            if (!procPool.equality(data_.at(n)))
                 return false;
         return true;
     }

--- a/src/genericitems/arrayvec3int.h
+++ b/src/genericitems/arrayvec3int.h
@@ -84,7 +84,7 @@ template <> class GenericItemContainer<Array<Vec3<int>>> : public GenericItem
             return false;
         // Keep it simple (and slow) and check/send one value at a time
         for (auto n = 0; n < data_.nItems(); ++n)
-            if (!procPool.equality(data_.constAt(n)))
+            if (!procPool.equality(data_.at(n)))
                 return false;
         return true;
     }

--- a/src/gui/addconfigurationwizard_funcs.cpp
+++ b/src/gui/addconfigurationwizard_funcs.cpp
@@ -166,7 +166,7 @@ void AddConfigurationWizard::reset()
 
     // Set a new, unique name ready on the final page
     ui_.FinishNameEdit->setText(
-        QString::fromStdString(std::string(dissolveReference_->constCoreData().uniqueConfigurationName("NewConfiguration"))));
+        QString::fromStdString(std::string(dissolveReference_->coreData().uniqueConfigurationName("NewConfiguration"))));
 }
 
 /*

--- a/src/gui/addforcefieldtermswizard_funcs.cpp
+++ b/src/gui/addforcefieldtermswizard_funcs.cpp
@@ -137,7 +137,7 @@ bool AddForcefieldTermsWizard::applyForcefieldTerms(Dissolve &dissolve)
     // Copy intramolecular terms
     if (!ui_.IntramolecularTermsAssignNoneRadio->isChecked())
     {
-        auto modifiedBond = modifiedSpecies_->constBonds().cbegin();
+        auto modifiedBond = modifiedSpecies_->bonds().cbegin();
         for (auto &originalBond : targetSpecies_->bonds())
         {
             // Selection only?
@@ -149,7 +149,7 @@ bool AddForcefieldTermsWizard::applyForcefieldTerms(Dissolve &dissolve)
             ++modifiedBond;
         }
 
-        auto modifiedAngle = modifiedSpecies_->constAngles().cbegin();
+        auto modifiedAngle = modifiedSpecies_->angles().cbegin();
         for (auto &originalAngle : targetSpecies_->angles())
         {
             // Selection only?
@@ -161,7 +161,7 @@ bool AddForcefieldTermsWizard::applyForcefieldTerms(Dissolve &dissolve)
             ++modifiedAngle;
         }
 
-        auto modifiedTorsion = modifiedSpecies_->constTorsions().cbegin();
+        auto modifiedTorsion = modifiedSpecies_->torsions().cbegin();
         for (auto &originalTorsion : targetSpecies_->torsions())
         {
 
@@ -174,7 +174,7 @@ bool AddForcefieldTermsWizard::applyForcefieldTerms(Dissolve &dissolve)
             ++modifiedTorsion;
         }
 
-        for (auto &modifiedImproper : modifiedSpecies_->constImpropers())
+        for (auto &modifiedImproper : modifiedSpecies_->impropers())
         {
             // Selection only?
             if (intraSelectionOnly && (!modifiedImproper.isSelected()))

--- a/src/gui/addforcefieldtermswizard_funcs.cpp
+++ b/src/gui/addforcefieldtermswizard_funcs.cpp
@@ -631,7 +631,7 @@ void AddForcefieldTermsWizard::updateMasterTermsTreeChild(QTreeWidgetItem *paren
 
     // Set item data
     item->setText(0, QString::fromStdString(std::string(masterIntra->name())));
-    item->setIcon(0, QIcon(dissolveReference_->constCoreData().findMasterTerm(masterIntra->name())
+    item->setIcon(0, QIcon(dissolveReference_->coreData().findMasterTerm(masterIntra->name())
                                ? ":/general/icons/general_warn.svg"
                                : ":/general/icons/general_true.svg"));
 }
@@ -655,28 +655,28 @@ void AddForcefieldTermsWizard::updateMasterTermsPage()
     auto conflicts = false;
     ListIterator<MasterIntra> bondIterator(temporaryCoreData_.masterBonds());
     while (MasterIntra *intra = bondIterator.iterate())
-        if (dissolveReference_->constCoreData().findMasterTerm(intra->name()))
+        if (dissolveReference_->coreData().findMasterTerm(intra->name()))
         {
             conflicts = true;
             break;
         }
     ListIterator<MasterIntra> angleIterator(temporaryCoreData_.masterAngles());
     while (MasterIntra *intra = angleIterator.iterate())
-        if (dissolveReference_->constCoreData().findMasterTerm(intra->name()))
+        if (dissolveReference_->coreData().findMasterTerm(intra->name()))
         {
             conflicts = true;
             break;
         }
     ListIterator<MasterIntra> torsionIterator(temporaryCoreData_.masterTorsions());
     while (MasterIntra *intra = torsionIterator.iterate())
-        if (dissolveReference_->constCoreData().findMasterTerm(intra->name()))
+        if (dissolveReference_->coreData().findMasterTerm(intra->name()))
         {
             conflicts = true;
             break;
         }
     ListIterator<MasterIntra> improperIterator(temporaryCoreData_.masterTorsions());
     while (MasterIntra *intra = improperIterator.iterate())
-        if (dissolveReference_->constCoreData().findMasterTerm(intra->name()))
+        if (dissolveReference_->coreData().findMasterTerm(intra->name()))
         {
             conflicts = true;
             break;

--- a/src/gui/dataviewer_interaction.cpp
+++ b/src/gui/dataviewer_interaction.cpp
@@ -112,7 +112,7 @@ const QString DataViewer::interactionModeText() const
     switch (interactionMode())
     {
         case (DataViewer::DefaultInteraction):
-            if (constView().isFlatView())
+            if (view().isFlatView())
                 return "2D View: <b>Left</b> Zoom to area; <b>Middle</b> Translate view";
             else
                 return "3D View: <b>Right</b> Rotate view; <b>Middle</b> Translate view; <b>Wheel</b> Zoom "

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -69,8 +69,7 @@ class DissolveWindow : public QMainWindow
     public:
     // Return reference to Dissolve
     Dissolve &dissolve();
-    // Return const reference to Dissolve
-    const Dissolve &constDissolve() const;
+    const Dissolve &dissolve() const;
     // Link the Messenger in to the GUI output device
     void addOutputHandler();
 

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -134,8 +134,7 @@ void DissolveWindow::setModified()
 // Return reference to Dissolve
 Dissolve &DissolveWindow::dissolve() { return dissolve_; }
 
-// Return const reference to Dissolve
-const Dissolve &DissolveWindow::constDissolve() const { return dissolve_; }
+const Dissolve &DissolveWindow::dissolve() const { return dissolve_; }
 
 // Link output handler in to the Messenger
 void DissolveWindow::addOutputHandler()

--- a/src/gui/importspecieswizard_funcs.cpp
+++ b/src/gui/importspecieswizard_funcs.cpp
@@ -208,7 +208,7 @@ void ImportSpeciesWizard::reset()
 
     // Set a new, unique name ready on the final page
     ui_.SpeciesNameEdit->setText(
-        QString::fromStdString(std::string(dissolveReference_->constCoreData().uniqueSpeciesName("NewSpecies"))));
+        QString::fromStdString(std::string(dissolveReference_->coreData().uniqueSpeciesName("NewSpecies"))));
 }
 
 /*
@@ -373,7 +373,7 @@ void ImportSpeciesWizard::updateMasterTermsTreeChild(QTreeWidgetItem *parent, in
 
     // Set item data
     item->setText(0, QString::fromStdString(std::string(masterIntra->name())));
-    item->setIcon(0, QIcon(dissolveReference_->constCoreData().findMasterTerm(masterIntra->name())
+    item->setIcon(0, QIcon(dissolveReference_->coreData().findMasterTerm(masterIntra->name())
                                ? ":/general/icons/general_warn.svg"
                                : ":/general/icons/general_true.svg"));
 }
@@ -393,21 +393,21 @@ void ImportSpeciesWizard::updateMasterTermsPage()
     auto conflicts = false;
     ListIterator<MasterIntra> bondIterator(temporaryCoreData_.masterBonds());
     while (MasterIntra *intra = bondIterator.iterate())
-        if (dissolveReference_->constCoreData().findMasterTerm(intra->name()))
+        if (dissolveReference_->coreData().findMasterTerm(intra->name()))
         {
             conflicts = true;
             break;
         }
     ListIterator<MasterIntra> angleIterator(temporaryCoreData_.masterAngles());
     while (MasterIntra *intra = angleIterator.iterate())
-        if (dissolveReference_->constCoreData().findMasterTerm(intra->name()))
+        if (dissolveReference_->coreData().findMasterTerm(intra->name()))
         {
             conflicts = true;
             break;
         }
     ListIterator<MasterIntra> torsionIterator(temporaryCoreData_.masterTorsions());
     while (MasterIntra *intra = torsionIterator.iterate())
-        if (dissolveReference_->constCoreData().findMasterTerm(intra->name()))
+        if (dissolveReference_->coreData().findMasterTerm(intra->name()))
         {
             conflicts = true;
             break;

--- a/src/gui/modulecontrolwidget_funcs.cpp
+++ b/src/gui/modulecontrolwidget_funcs.cpp
@@ -52,7 +52,7 @@ void ModuleControlWidget::setModule(Module *module, Dissolve *dissolve)
     ui_.ModuleIconLabel->setPixmap(ModuleBlock::modulePixmap(module_));
 
     // Set up our control widgets
-    ui_.ModuleKeywordsWidget->setUp(module_->keywords(), dissolve_->constCoreData());
+    ui_.ModuleKeywordsWidget->setUp(module_->keywords(), dissolve_->coreData());
 
     // Create any additional controls offered by the Module
     moduleWidget_ = module->createWidget(nullptr, *dissolve_);

--- a/src/gui/render/colourscale.cpp
+++ b/src/gui/render/colourscale.cpp
@@ -68,13 +68,13 @@ int ColourScale::nPoints() const { return points_.nItems(); }
 const Array<ColourScalePoint> &ColourScale::points() const { return points_; }
 
 // Return first point in ColourScale
-const ColourScalePoint &ColourScale::firstPoint() const { return points_.constAt(0); }
+const ColourScalePoint &ColourScale::firstPoint() const { return points_.at(0); }
 
 // Return last point in ColourScale
-const ColourScalePoint &ColourScale::lastPoint() const { return points_.constAt(points_.nItems() - 1); }
+const ColourScalePoint &ColourScale::lastPoint() const { return points_.at(points_.nItems() - 1); }
 
 // Return specific point in ColourScale
-const ColourScalePoint &ColourScale::point(int id) const { return points_.constAt(id); }
+const ColourScalePoint &ColourScale::point(int id) const { return points_.at(id); }
 
 // Set colour and value data for point
 void ColourScale::setPoint(int position, double value, QColor colour)
@@ -150,20 +150,20 @@ QColor ColourScale::colour(double value) const
         return QColor(0, 0, 0);
 
     // Is supplied value less than the value at the first point?
-    if (value < points_.constAt(0).value())
-        return points_.constAt(0).colour();
-    else if (value > points_.constAt(nPoints() - 1).value())
-        return points_.constAt(nPoints() - 1).colour();
+    if (value < points_.at(0).value())
+        return points_.at(0).colour();
+    else if (value > points_.at(nPoints() - 1).value())
+        return points_.at(nPoints() - 1).colour();
 
     // Find the correct delta to use
     for (auto n = 0; n < deltas_.nItems(); ++n)
     {
-        if (deltas_.constAt(n).containsValue(value))
+        if (deltas_.at(n).containsValue(value))
         {
             if (interpolated_)
-                return deltas_.constAt(n).colour(value);
+                return deltas_.at(n).colour(value);
             else
-                return deltas_.constAt(n).startColour();
+                return deltas_.at(n).startColour();
         }
     }
 
@@ -185,26 +185,26 @@ void ColourScale::colour(double value, GLfloat *rgba) const
     }
 
     // Is supplied value less than the value at the first point?
-    if (value < points_.constAt(0).value())
+    if (value < points_.at(0).value())
     {
-        points_.constAt(0).colour(rgba);
+        points_.at(0).colour(rgba);
         return;
     }
-    else if (value > points_.constAt(nPoints() - 1).value())
+    else if (value > points_.at(nPoints() - 1).value())
     {
-        points_.constAt(nPoints() - 1).colour(rgba);
+        points_.at(nPoints() - 1).colour(rgba);
         return;
     }
 
     // Find the correct delta to use
     for (auto n = 0; n < deltas_.nItems(); ++n)
     {
-        if (deltas_.constAt(n).containsValue(value))
+        if (deltas_.at(n).containsValue(value))
         {
             if (interpolated_)
-                return deltas_.constAt(n).colour(value, rgba);
+                return deltas_.at(n).colour(value, rgba);
             else
-                return deltas_.constAt(n).startColour(rgba);
+                return deltas_.at(n).startColour(rgba);
             return;
         }
     }

--- a/src/gui/render/renderable.cpp
+++ b/src/gui/render/renderable.cpp
@@ -264,8 +264,7 @@ void Renderable::setColour(StockColours::StockColour stockColour)
 // Return local colour definition for display
 ColourDefinition &Renderable::colour() { return colour_; }
 
-// Return local colour definition for display (const)
-const ColourDefinition &Renderable::constColour() const { return colour_; }
+const ColourDefinition &Renderable::colour() const { return colour_; }
 
 // Return line style
 LineStyle &Renderable::lineStyle() { return lineStyle_; }
@@ -304,7 +303,7 @@ void Renderable::updateAndSendPrimitives(const View &view, bool forceUpdate, boo
         return;
 
     // Grab axes for the View
-    const Axes &axes = view.constAxes();
+    const Axes &axes = view.axes();
 
     // Grab copy of the relevant colour definition for this Renderable
     const ColourDefinition &colourDefinition = colour();

--- a/src/gui/render/renderable.h
+++ b/src/gui/render/renderable.h
@@ -170,8 +170,7 @@ class Renderable : public ListItem<Renderable>
     void setColour(StockColours::StockColour stockColour);
     // Return local colour definition for display
     ColourDefinition &colour();
-    // Return local colour definition for display (const)
-    const ColourDefinition &constColour() const;
+    const ColourDefinition &colour() const;
     // Return line style
     LineStyle &lineStyle();
     // Return style version

--- a/src/gui/render/renderabledata1d.cpp
+++ b/src/gui/render/renderabledata1d.cpp
@@ -83,27 +83,27 @@ void RenderableData1D::transformValues()
     for (auto n = 0; n < transformedData_.nValues(); ++n)
     {
         // X
-        if (transformedData_.constXAxis(n) > 0.0)
+        if (transformedData_.xAxis(n) > 0.0)
         {
             if (positiveLimitsMin_.x < 0.0)
-                positiveLimitsMin_.x = transformedData_.constXAxis(n);
-            else if (transformedData_.constXAxis(n) < positiveLimitsMin_.x)
-                positiveLimitsMin_.x = transformedData_.constXAxis(n);
+                positiveLimitsMin_.x = transformedData_.xAxis(n);
+            else if (transformedData_.xAxis(n) < positiveLimitsMin_.x)
+                positiveLimitsMin_.x = transformedData_.xAxis(n);
 
-            if (transformedData_.constXAxis(n) > positiveLimitsMax_.x)
-                positiveLimitsMax_.x = transformedData_.constXAxis(n);
+            if (transformedData_.xAxis(n) > positiveLimitsMax_.x)
+                positiveLimitsMax_.x = transformedData_.xAxis(n);
         }
 
         // Value
-        if (transformedData_.constValue(n) > 0.0)
+        if (transformedData_.value(n) > 0.0)
         {
             if (positiveValuesMin_ < 0.0)
-                positiveValuesMin_ = transformedData_.constValue(n);
-            else if (transformedData_.constValue(n) < positiveValuesMin_)
-                positiveValuesMin_ = transformedData_.constValue(n);
+                positiveValuesMin_ = transformedData_.value(n);
+            else if (transformedData_.value(n) < positiveValuesMin_)
+                positiveValuesMin_ = transformedData_.value(n);
 
-            if (transformedData_.constValue(n) > positiveValuesMax_)
-                positiveValuesMax_ = transformedData_.constValue(n);
+            if (transformedData_.value(n) > positiveValuesMax_)
+                positiveValuesMax_ = transformedData_.value(n);
         }
     }
 
@@ -153,23 +153,23 @@ bool RenderableData1D::yRangeOverX(double xMin, double xMax, double &yMin, doubl
     auto first = true;
     for (auto n = 0; n < data.nValues(); ++n)
     {
-        if (data.constXAxis(n) < xMin)
+        if (data.xAxis(n) < xMin)
             continue;
-        else if (data.constXAxis(n) > xMax)
+        else if (data.xAxis(n) > xMax)
             break;
 
         if (first)
         {
-            yMin = data.constValue(n);
+            yMin = data.value(n);
             yMax = yMin;
             first = false;
         }
         else
         {
-            if (data.constValue(n) < yMin)
-                yMin = data.constValue(n);
-            else if (data.constValue(n) > yMax)
-                yMax = data.constValue(n);
+            if (data.value(n) < yMin)
+                yMin = data.value(n);
+            else if (data.value(n) > yMax)
+                yMax = data.value(n);
         }
     }
 

--- a/src/gui/render/renderabledata1d.cpp
+++ b/src/gui/render/renderabledata1d.cpp
@@ -185,7 +185,7 @@ void RenderableData1D::recreatePrimitives(const View &view, const ColourDefiniti
 {
     dataPrimitive_->initialise(GL_LINE_STRIP, true, 4096);
 
-    constructLineXY(transformedData().xAxis(), transformedData().values(), dataPrimitive_, view.constAxes(), colourDefinition);
+    constructLineXY(transformedData().xAxis(), transformedData().values(), dataPrimitive_, view.axes(), colourDefinition);
 }
 
 // Send primitives for rendering

--- a/src/gui/render/renderabledata2d.cpp
+++ b/src/gui/render/renderabledata2d.cpp
@@ -166,7 +166,7 @@ void RenderableData2D::recreatePrimitives(const View &view, const ColourDefiniti
     }
 
     reinitialisePrimitives(source_->yAxis().size(), GL_LINE_STRIP, true);
-    constructLine(transformedData().xAxis(), transformedData().yAxis(), transformedData().constValues2D(), view.constAxes(),
+    constructLine(transformedData().xAxis(), transformedData().yAxis(), transformedData().constValues2D(), view.axes(),
                   colourDefinition);
 }
 

--- a/src/gui/render/renderabledata2d.cpp
+++ b/src/gui/render/renderabledata2d.cpp
@@ -166,7 +166,7 @@ void RenderableData2D::recreatePrimitives(const View &view, const ColourDefiniti
     }
 
     reinitialisePrimitives(source_->yAxis().size(), GL_LINE_STRIP, true);
-    constructLine(transformedData().xAxis(), transformedData().yAxis(), transformedData().constValues2D(), view.axes(),
+    constructLine(transformedData().xAxis(), transformedData().yAxis(), transformedData().values2D(), view.axes(),
                   colourDefinition);
 }
 

--- a/src/gui/render/renderabledata3d.cpp
+++ b/src/gui/render/renderabledata3d.cpp
@@ -182,7 +182,7 @@ void RenderableData3D::recreatePrimitives(const View &view, const ColourDefiniti
         return;
 
     marchingCubesOriginal(transformedData_.xAxis(), transformedData_.yAxis(), transformedData_.zAxis(),
-                          transformedData_.constValues3D(), lowerCutoff_, upperCutoff_, colourDefinition, view.axes(),
+                          transformedData_.values3D(), lowerCutoff_, upperCutoff_, colourDefinition, view.axes(),
                           dataPrimitive_);
 }
 

--- a/src/gui/render/renderabledata3d.cpp
+++ b/src/gui/render/renderabledata3d.cpp
@@ -135,7 +135,7 @@ void RenderableData3D::transformValues()
     // Values
     for (auto n = 0; n < transformedData_.nValues(); ++n)
     {
-        double val = transformedData_.values().linearValue(n);
+        auto val = transformedData_.values3D().linearValue(n);
         if (val > 0.0)
         {
             if (positiveValuesMin_ < 0.0)

--- a/src/gui/render/renderabledata3d.cpp
+++ b/src/gui/render/renderabledata3d.cpp
@@ -182,7 +182,7 @@ void RenderableData3D::recreatePrimitives(const View &view, const ColourDefiniti
         return;
 
     marchingCubesOriginal(transformedData_.xAxis(), transformedData_.yAxis(), transformedData_.zAxis(),
-                          transformedData_.constValues3D(), lowerCutoff_, upperCutoff_, colourDefinition, view.constAxes(),
+                          transformedData_.constValues3D(), lowerCutoff_, upperCutoff_, colourDefinition, view.axes(),
                           dataPrimitive_);
 }
 

--- a/src/gui/render/renderablespecies.cpp
+++ b/src/gui/render/renderablespecies.cpp
@@ -190,7 +190,7 @@ void RenderableSpecies::recreatePrimitives(const View &view, const ColourDefinit
         }
 
         // Draw bonds
-        for (const auto &bond : source_->constBonds())
+        for (const auto &bond : source_->bonds())
         {
             // Determine half delta i-j for bond
             const auto ri = bond.i()->r();
@@ -231,7 +231,7 @@ void RenderableSpecies::recreatePrimitives(const View &view, const ColourDefinit
         }
 
         // Draw bonds
-        for (const auto &bond : source_->constBonds())
+        for (const auto &bond : source_->bonds())
             createCylinderBond(speciesAssembly_, bond.i(), bond.j(), spheresBondRadius_);
     }
 }

--- a/src/gui/render/view.cpp
+++ b/src/gui/render/view.cpp
@@ -1257,8 +1257,7 @@ void View::shiftFlatAxisLimitsFractional(double fracH, double fracV)
 // Return axes for the view
 Axes &View::axes() { return axes_; }
 
-// Return axes for the view (const)
-const Axes &View::constAxes() const { return axes_; }
+const Axes &View::axes() const { return axes_; }
 
 /*
  * Style

--- a/src/gui/render/view.h
+++ b/src/gui/render/view.h
@@ -225,8 +225,7 @@ class View
     void shiftFlatAxisLimitsFractional(double fracH, double fracV);
     // Return axes for the view
     Axes &axes();
-    // Return axes for the view (const)
-    const Axes &constAxes() const;
+    const Axes &axes() const;
 
     /*
      * Style

--- a/src/gui/speciestab_sites.cpp
+++ b/src/gui/speciestab_sites.cpp
@@ -157,24 +157,24 @@ void SpeciesTab::updateSitesTab()
 
     // Set origin atom indices
     Array<int> originAtoms = site->originAtomIndices();
-    QString originText = originAtoms.nItems() == 0 ? QString() : QString::number(originAtoms.constAt(0) + 1);
+    QString originText = originAtoms.nItems() == 0 ? QString() : QString::number(originAtoms.at(0) + 1);
     for (auto n = 1; n < originAtoms.nItems(); ++n)
-        originText += QString(" %1").arg(originAtoms.constAt(n) + 1);
+        originText += QString(" %1").arg(originAtoms.at(n) + 1);
     ui_.SiteOriginAtomsEdit->setText(originText);
     ui_.SiteOriginMassWeightedCheck->setCheckState(site->originMassWeighted() ? Qt::Checked : Qt::Unchecked);
 
     // Set x axis atom indices
     Array<int> xAxisAtoms = site->xAxisAtomIndices();
-    QString xAxisText = xAxisAtoms.nItems() == 0 ? QString() : QString::number(xAxisAtoms.constAt(0) + 1);
+    QString xAxisText = xAxisAtoms.nItems() == 0 ? QString() : QString::number(xAxisAtoms.at(0) + 1);
     for (auto n = 1; n < xAxisAtoms.nItems(); ++n)
-        xAxisText += QString(" %1").arg(xAxisAtoms.constAt(n) + 1);
+        xAxisText += QString(" %1").arg(xAxisAtoms.at(n) + 1);
     ui_.SiteXAxisAtomsEdit->setText(xAxisText);
 
     // Set y axis atom indices
     Array<int> yAxisAtoms = site->yAxisAtomIndices();
-    QString yAxisText = yAxisAtoms.nItems() == 0 ? QString() : QString::number(yAxisAtoms.constAt(0) + 1);
+    QString yAxisText = yAxisAtoms.nItems() == 0 ? QString() : QString::number(yAxisAtoms.at(0) + 1);
     for (auto n = 1; n < yAxisAtoms.nItems(); ++n)
-        yAxisText += QString(" %1").arg(yAxisAtoms.constAt(n) + 1);
+        yAxisText += QString(" %1").arg(yAxisAtoms.at(n) + 1);
     ui_.SiteYAxisAtomsEdit->setText(yAxisText);
 
     // If the current site has changed, also regenerate the SpeciesSite renderable

--- a/src/gui/viewer.hui
+++ b/src/gui/viewer.hui
@@ -53,8 +53,7 @@ class BaseViewer : public QOpenGLWidget, protected QOpenGLFunctions
     public:
     // Return the View definition
     View &view();
-    // Return the View definition (const)
-    const View &constView() const;
+    const View &view() const;
     // Link this viewer to the one specified
     void linkView(BaseViewer *viewToLinkTo);
     // Unlink this viewer from the one specified

--- a/src/gui/viewer_io.cpp
+++ b/src/gui/viewer_io.cpp
@@ -646,7 +646,7 @@ bool BaseViewer::writeRenderableBlock(LineParser &parser, Renderable *renderable
     const Array<ColourScalePoint> customGradient = colourDef.customGradientPoints();
     for (auto n = 0; n < customGradient.nItems(); ++n)
     {
-        const ColourScalePoint &point = customGradient.constAt(n);
+        const ColourScalePoint &point = customGradient.at(n);
         if (!parser.writeLineF("{}  {}  {} {} {} {} {}\n", indent,
                                BaseViewer::renderableKeywords().keyword(BaseViewer::ColourCustomGradientKeyword), point.value(),
                                point.colour().red(), point.colour().green(), point.colour().blue(), point.colour().alpha()))

--- a/src/gui/viewer_io.cpp
+++ b/src/gui/viewer_io.cpp
@@ -969,10 +969,10 @@ bool BaseViewer::writeViewBlock(LineParser &parser) const
                            View::autoFollowTypes().keyword(view_.autoFollowType())))
         return false;
     if (!parser.writeLineF("  {}  {}\n", BaseViewer::viewKeywords().keyword(BaseViewer::AutoPositionTitlesKeyword),
-                           DissolveSys::btoa(view_.constAxes().autoPositionTitles())))
+                           DissolveSys::btoa(view_.axes().autoPositionTitles())))
         return false;
     for (auto axis = 0; axis < 3; ++axis)
-        writeAxisBlock(parser, view_.constAxes(), axis);
+        writeAxisBlock(parser, view_.axes(), axis);
     if (!parser.writeLineF("  {}  {}\n", BaseViewer::viewKeywords().keyword(BaseViewer::FlatLabelsKeyword),
                            DissolveSys::btoa(view_.flatLabelsIn3D())))
         return false;
@@ -1000,7 +1000,7 @@ bool BaseViewer::writeViewBlock(LineParser &parser) const
                            DissolveSys::btoa(view_.hasPerspective())))
         return false;
     if (!parser.writeLineF("  {}  {}\n", BaseViewer::viewKeywords().keyword(BaseViewer::UseBestFlatViewKeyword),
-                           DissolveSys::btoa(view_.constAxes().useBestFlatView())))
+                           DissolveSys::btoa(view_.axes().useBestFlatView())))
         return false;
     if (!parser.writeLineF("  {}  {}\n", BaseViewer::viewKeywords().keyword(BaseViewer::VerticalShiftKeyword),
                            groupManager_.verticalShiftAmount()))

--- a/src/gui/viewer_view.cpp
+++ b/src/gui/viewer_view.cpp
@@ -15,8 +15,7 @@ View &BaseViewer::view()
     return view_;
 }
 
-// Return the View definition (const)
-const View &BaseViewer::constView() const
+const View &BaseViewer::view() const
 {
     if (view_.linkedView())
         return (*view_.linkedView());

--- a/src/io/export/data2d.cpp
+++ b/src/io/export/data2d.cpp
@@ -57,7 +57,7 @@ bool Data2DExportFileFormat::exportBlock(LineParser &parser, const Data2D &data)
         return false;
 
     // Export datapoints, separating each block of a specific x value with a single blank line
-    const Array2D<double> &values = data.constValues2D();
+    const Array2D<double> &values = data.values2D();
     for (auto x = 0; x < values.nRows(); ++x)
     {
         for (auto y = 0; y < values.nColumns(); ++y)
@@ -74,7 +74,7 @@ bool Data2DExportFileFormat::exportBlock(LineParser &parser, const Data2D &data)
 bool Data2DExportFileFormat::exportCartesian(LineParser &parser, const Data2D &data)
 {
     // Three-column format (x  y  value) in blocks of similar y value, separated by blank lines
-    const Array2D<double> &values = data.constValues2D();
+    const Array2D<double> &values = data.values2D();
     const auto &xAxis = data.xAxis();
     const auto &yAxis = data.yAxis();
     for (auto x = 0; x < values.nRows(); ++x)

--- a/src/io/export/data3d.cpp
+++ b/src/io/export/data3d.cpp
@@ -59,7 +59,7 @@ bool Data3DExportFileFormat::exportBlock(LineParser &parser, const Data3D &data)
         return false;
 
     // Export datapoints, separating each block of a specific x value with a single blank line
-    const Array3D<double> &values = data.constValues3D();
+    const Array3D<double> &values = data.values3D();
     for (auto x = 0; x < values.nX(); ++x)
     {
         for (auto y = 0; y < values.nY(); ++y)
@@ -81,7 +81,7 @@ bool Data3DExportFileFormat::exportBlock(LineParser &parser, const Data3D &data)
 bool Data3DExportFileFormat::exportCartesian(LineParser &parser, const Data3D &data)
 {
     // Four-column format (x  y  z  value) in blocks of similar x and y value, separated by blank lines
-    const Array3D<double> &values = data.constValues3D();
+    const Array3D<double> &values = data.values3D();
     const auto &xAxis = data.xAxis();
     const auto &yAxis = data.yAxis();
     const auto &zAxis = data.zAxis();
@@ -108,7 +108,7 @@ bool Data3DExportFileFormat::exportCartesian(LineParser &parser, const Data3D &d
 bool Data3DExportFileFormat::exportPDens(LineParser &parser, const Data3D &data)
 {
     // Line 1 (Integer Extents): nx, ny, nz, xmin, ymin, zmin, xmax, ymax, zmax
-    const Array3D<double> &values = data.constValues3D();
+    const Array3D<double> &values = data.values3D();
     if (!parser.writeLineF("{:5d}{:5d}{:5d}{:5d}{:5d}{:5d}{:5d}{:5d}{:5d}\n", values.nX(), values.nY(), values.nZ(), 0, 0, 0,
                            values.nX(), values.nY(), values.nZ()))
         return false;

--- a/src/io/export/forces.cpp
+++ b/src/io/export/forces.cpp
@@ -60,7 +60,7 @@ bool ForceExportFileFormat::exportSimple(LineParser &parser, const Array<double>
         return false;
 
     for (auto n = 0; n < fx.nItems(); ++n)
-        if (!parser.writeLineF("  {:10d}  {:15.8e}  {:15.8e}  {:15.8e}\n", n + 1, fx.constAt(n), fy.constAt(n), fz.constAt(n)))
+        if (!parser.writeLineF("  {:10d}  {:15.8e}  {:15.8e}  {:15.8e}\n", n + 1, fx.at(n), fy.at(n), fz.at(n)))
             return false;
 
     return true;

--- a/src/io/export/pairpotential.cpp
+++ b/src/io/export/pairpotential.cpp
@@ -74,10 +74,9 @@ bool PairPotentialExportFileFormat::exportBlock(LineParser &parser, PairPotentia
         return false;
 
     for (auto n = 0; n < nPoints; ++n)
-        if (!parser.writeLineF("{:10.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}\n",
-                               uOriginal.constXAxis(n), uFull.constValue(n), dUFull.constValue(n), uOriginal.constValue(n),
-                               uAdditional.constValue(n), pp->analyticEnergy(uOriginal.constXAxis(n)),
-                               pp->analyticForce(uOriginal.constXAxis(n))))
+        if (!parser.writeLineF("{:10.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}\n", uOriginal.xAxis(n),
+                               uFull.value(n), dUFull.value(n), uOriginal.value(n), uAdditional.value(n),
+                               pp->analyticEnergy(uOriginal.xAxis(n)), pp->analyticForce(uOriginal.xAxis(n))))
             return false;
 
     return true;
@@ -106,7 +105,7 @@ bool PairPotentialExportFileFormat::exportDLPOLY(LineParser &parser, PairPotenti
     // Write energy data
     for (auto n = 0; n < nPoints; ++n)
     {
-        if (!parser.writeLineF("{:17.12e} ", uFull.constValue(n)))
+        if (!parser.writeLineF("{:17.12e} ", uFull.value(n)))
             return false;
         if (((n + 1) % 4 == 0) || (n == (nPoints - 1)))
         {
@@ -118,7 +117,7 @@ bool PairPotentialExportFileFormat::exportDLPOLY(LineParser &parser, PairPotenti
     // Write force data
     for (auto n = 0; n < nPoints; ++n)
     {
-        if (!parser.writeLineF("{:17.12e} ", dUFull.constValue(n)))
+        if (!parser.writeLineF("{:17.12e} ", dUFull.value(n)))
             return false;
         if (((n + 1) % 4 == 0) || (n == (nPoints - 1)))
         {

--- a/src/keywords/nodearray.h
+++ b/src/keywords/nodearray.h
@@ -234,7 +234,7 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
     int indexOfNode(ProcedureNode *node) const
     {
         for (auto n = 0; n < KeywordData<Array<N *> &>::data_.nItems(); ++n)
-            if (KeywordData<Array<N *> &>::data_.constAt(n) == node)
+            if (KeywordData<Array<N *> &>::data_.at(n) == node)
                 return n;
 
         return -1;
@@ -245,7 +245,7 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
         Array<ProcedureNode *> nodes(KeywordData<Array<N *> &>::data_.nItems());
 
         for (auto n = 0; n < KeywordData<Array<N *> &>::data_.nItems(); ++n)
-            nodes[n] = KeywordData<Array<N *> &>::data_.constAt(n);
+            nodes[n] = KeywordData<Array<N *> &>::data_.at(n);
 
         return nodes;
     }

--- a/src/main/configurations.cpp
+++ b/src/main/configurations.cpp
@@ -51,8 +51,7 @@ int Dissolve::nConfigurations() const { return coreData_.nConfigurations(); }
 // Return Configuration list
 List<Configuration> &Dissolve::configurations() { return coreData_.configurations(); }
 
-// Return Configuration list (const)
-const List<Configuration> &Dissolve::constConfigurations() const { return coreData_.configurations(); }
+const List<Configuration> &Dissolve::configurations() const { return coreData_.configurations(); }
 
 // Find configuration by name
 Configuration *Dissolve::findConfiguration(std::string_view name) const { return coreData_.findConfiguration(name); }
@@ -60,7 +59,7 @@ Configuration *Dissolve::findConfiguration(std::string_view name) const { return
 // Find configuration by 'nice' name
 Configuration *Dissolve::findConfigurationByNiceName(std::string_view name) const
 {
-    for (auto *cfg = constConfigurations().first(); cfg != nullptr; cfg = cfg->next())
+    for (auto *cfg = configurations().first(); cfg != nullptr; cfg = cfg->next())
         if (DissolveSys::sameString(name, cfg->niceName()))
             return cfg;
 

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -55,8 +55,7 @@ Dissolve::~Dissolve()
 // Return reference to CoreData
 CoreData &Dissolve::coreData() { return coreData_; }
 
-// Return const reference to CoreData
-const CoreData &Dissolve::constCoreData() const { return coreData_; }
+const CoreData &Dissolve::coreData() const { return coreData_; }
 
 // Clear all data
 void Dissolve::clear()

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -35,8 +35,7 @@ class Dissolve
     public:
     // Return reference to CoreData
     CoreData &coreData();
-    // Return const reference to CoreData
-    const CoreData &constCoreData() const;
+    const CoreData &coreData() const;
     // Clear all data
     void clear();
     // Register GenericItems
@@ -170,8 +169,7 @@ class Dissolve
     int nConfigurations() const;
     // Return Configuration list
     List<Configuration> &configurations();
-    // Return Configuration list (const)
-    const List<Configuration> &constConfigurations() const;
+    const List<Configuration> &configurations() const;
     // Find configuration by name
     Configuration *findConfiguration(std::string_view name) const;
     // Find configuration by 'nice' name

--- a/src/main/species.cpp
+++ b/src/main/species.cpp
@@ -151,7 +151,7 @@ Species *Dissolve::copySpecies(const Species *species)
     }
 
     // Duplicate bonds
-    for (const auto &bond : species->constBonds())
+    for (const auto &bond : species->bonds())
     {
         // Create the bond in the new Species
         auto &newBond = newSpecies->addBond(bond.indexI(), bond.indexJ());
@@ -161,7 +161,7 @@ Species *Dissolve::copySpecies(const Species *species)
     }
 
     // Duplicate angles
-    for (const auto &angle : species->constAngles())
+    for (const auto &angle : species->angles())
     {
         // Create the angle in the new Species
         auto &newAngle = newSpecies->addAngle(angle.indexI(), angle.indexJ(), angle.indexK());
@@ -171,7 +171,7 @@ Species *Dissolve::copySpecies(const Species *species)
     }
 
     // Duplicate torsions
-    for (const auto &torsion : species->constTorsions())
+    for (const auto &torsion : species->torsions())
     {
         // Create the torsion in the new Species
         SpeciesTorsion &newTorsion =
@@ -182,7 +182,7 @@ Species *Dissolve::copySpecies(const Species *species)
     }
 
     // Duplicate impropers
-    for (auto &t : species->constImpropers())
+    for (auto &t : species->impropers())
     {
         // Create the improper in the new Species
         auto &newImproper = newSpecies->addImproper(t.indexI(), t.indexJ(), t.indexK(), t.indexL());

--- a/src/math/data1d.cpp
+++ b/src/math/data1d.cpp
@@ -312,7 +312,6 @@ std::vector<double> &Data1D::errors()
     return errors_;
 }
 
-// Return error Array (const)
 const std::vector<double> &Data1D::errors() const
 {
     if (!hasError_)

--- a/src/math/data1d.cpp
+++ b/src/math/data1d.cpp
@@ -174,13 +174,12 @@ double &Data1D::xAxis(int index)
     return x_[index];
 }
 
-// Return x value specified (const)
-double Data1D::constXAxis(int index) const
+const double &Data1D::xAxis(int index) const
 {
 #ifdef CHECKS
     if ((index < 0) || (index >= x_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data1D::constXAxis().\n", index);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data1D::xAxis().\n", index);
         return 0.0;
     }
 #endif
@@ -195,7 +194,6 @@ std::vector<double> &Data1D::xAxis()
     return x_;
 }
 
-// Return x axis Array (const)
 const std::vector<double> &Data1D::xAxis() const { return x_; }
 
 // Return y value specified
@@ -214,20 +212,19 @@ double &Data1D::value(int index)
     return values_[index];
 }
 
-// Return y value specified (const)
-double Data1D::constValue(int index) const
+const double &Data1D::value(int index) const
 {
 #ifdef CHECKS
     if ((index < 0) || (index >= values_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for values_ array in Data1D::constValue().\n", index);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for values_ array in Data1D::value().\n", index);
         return 0.0;
     }
 #endif
     return values_[index];
 }
 
-// Return y Array
+// Return values Array
 std::vector<double> &Data1D::values()
 {
     ++version_;
@@ -235,7 +232,6 @@ std::vector<double> &Data1D::values()
     return values_;
 }
 
-// Return y Array (const)
 const std::vector<double> &Data1D::values() const { return values_; }
 
 // Return number of values present in whole dataset
@@ -291,14 +287,14 @@ double &Data1D::error(int index)
     return errors_.at(index);
 }
 
-// Return error value specified (const)
-double Data1D::error(int index) const
+const double &Data1D::error(int index) const
 {
     if (!hasError_)
     {
-        Messenger::warn("This Data1D (name='{}', tag='{}') has no errors to return, but constError(int) was requested.\n",
-                        name(), objectTag());
-        return 0.0;
+        static double dummy;
+        Messenger::warn("This Data1D (name='{}', tag='{}') has no errors to return, but error(int) was requested.\n", name(),
+                        objectTag());
+        return dummy;
     }
 
     return errors_[index];
@@ -320,7 +316,7 @@ std::vector<double> &Data1D::errors()
 const std::vector<double> &Data1D::errors() const
 {
     if (!hasError_)
-        Messenger::warn("This Data1D (name='{}', tag='{}') has no errors to return, but constErrors() was requested.\n", name(),
+        Messenger::warn("This Data1D (name='{}', tag='{}') has no errors to return, but errors() was requested.\n", name(),
                         objectTag());
 
     return errors_;
@@ -367,7 +363,7 @@ void Data1D::operator+=(const Data1D &source)
         {
             Messenger::error("Failed to += these Data1D together since the x arrays are different (at point {}, x "
                              "are {:e} and {:e}).\n",
-                             n, x_[n], source.constXAxis(n));
+                             n, x_[n], source.xAxis(n));
             return;
         }
     }
@@ -410,7 +406,7 @@ void Data1D::operator-=(const Data1D &source)
         {
             Messenger::error("Failed to -= these Data1D together since the x arrays are different (at point {}, x "
                              "are {:e} and {:e}).\n",
-                             n, x_[n], source.constXAxis(n));
+                             n, x_[n], source.xAxis(n));
             return;
         }
     }

--- a/src/math/data1d.h
+++ b/src/math/data1d.h
@@ -53,19 +53,15 @@ class Data1D : public PlottableData, public ListItem<Data1D>, public ObjectStore
     void removeLastPoint();
     // Return x axis value specified
     double &xAxis(int index);
-    // Return x axis value specified (const)
-    double constXAxis(int index) const;
+    const double &xAxis(int index) const;
     // Return x axis Array
     std::vector<double> &xAxis();
-    // Return x axis Array (const)
     const std::vector<double> &xAxis() const;
     // Return value specified
     double &value(int index);
-    // Return value value specified (const)
-    double constValue(int index) const;
+    const double &value(int index) const;
     // Return value Array
     std::vector<double> &values();
-    // Return values Array
     const std::vector<double> &values() const;
     // Return number of values present in whole dataset
     int nValues() const;
@@ -79,8 +75,7 @@ class Data1D : public PlottableData, public ListItem<Data1D>, public ObjectStore
     bool valuesHaveErrors() const;
     // Return error value specified
     double &error(int index);
-    // Return error value specified (const)
-    double error(int index) const;
+    const double &error(int index) const;
     // Return error Array
     std::vector<double> &errors();
     // Return errors Array

--- a/src/math/data2d.cpp
+++ b/src/math/data2d.cpp
@@ -158,13 +158,12 @@ double &Data2D::xAxis(int index)
     return x_[index];
 }
 
-// Return x value specified (const)
-double Data2D::constXAxis(int index) const
+const double &Data2D::xAxis(int index) const
 {
 #ifdef CHECKS
     if ((index < 0) || (index >= x_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data2D::constXAxis().\n", index);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data2D::xAxis().\n", index);
         return 0.0;
     }
 #endif
@@ -179,7 +178,6 @@ std::vector<double> &Data2D::xAxis()
     return x_;
 }
 
-// Return x axis Array (const)
 const std::vector<double> &Data2D::xAxis() const { return x_; }
 
 // Return y value specified
@@ -198,13 +196,12 @@ double &Data2D::yAxis(int index)
     return y_[index];
 }
 
-// Return y value specified (const)
-double Data2D::constYAxis(int index) const
+const double &Data2D::yAxis(int index) const
 {
 #ifdef CHECKS
     if ((index < 0) || (index >= y_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y_ array in Data2D::constYAxis().\n", index);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y_ array in Data2D::yAxis().\n", index);
         return 0.0;
     }
 #endif
@@ -219,7 +216,6 @@ std::vector<double> &Data2D::yAxis()
     return y_;
 }
 
-// Return y axis Array (const)
 const std::vector<double> &Data2D::yAxis() const { return y_; }
 
 // Return value specified
@@ -244,18 +240,17 @@ double &Data2D::value(int xIndex, int yIndex)
     return values_[{xIndex, yIndex}];
 }
 
-// Return value specified (const)
-double Data2D::constValue(int xIndex, int yIndex) const
+const double &Data2D::value(int xIndex, int yIndex) const
 {
 #ifdef CHECKS
     if ((xIndex < 0) || (xIndex >= x_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data2D::constValue().\n", xIndex);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data2D::value().\n", xIndex);
         return 0.0;
     }
     if ((yIndex < 0) || (yIndex >= y_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data2D::constValue().\n", yIndex);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data2D::value().\n", yIndex);
         return 0.0;
     }
 #endif
@@ -271,7 +266,7 @@ Array2D<double> &Data2D::values()
 }
 
 // Return values Array (const)
-const Array2D<double> &Data2D::constValues2D() const { return values_; }
+const Array2D<double> &Data2D::values2D() const { return values_; }
 
 // Return value specified from linear array
 double Data2D::value(int index) { return values_[index]; }
@@ -343,25 +338,27 @@ double &Data2D::error(int xIndex, int yIndex)
     return errors_[{xIndex, yIndex}];
 }
 
-// Return error value specified (const)
-double Data2D::constError(int xIndex, int yIndex) const
+const double &Data2D::error(int xIndex, int yIndex) const
 {
     if (!hasError_)
     {
-        Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but constError(int,int) was requested.\n",
+        static double dummy;
+        Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but error(int,int) was requested.\n",
                         name(), objectTag());
-        return 0.0;
+        return dummy;
     }
 #ifdef CHECKS
     if ((xIndex < 0) || (xIndex >= x_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data2D::constError().\n", xIndex);
-        return 0.0;
+        static double dummy;
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data2D::error().\n", xIndex);
+        return dummy;
     }
     if ((yIndex < 0) || (yIndex >= y_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data2D::constError().\n", yIndex);
-        return 0.0;
+        static double dummy;
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data2D::error().\n", yIndex);
+        return dummy;
     }
 #endif
 
@@ -381,11 +378,11 @@ Array2D<double> &Data2D::errors()
 }
 
 // Return error Array (const)
-const Array2D<double> &Data2D::constErrors2D() const
+const Array2D<double> &Data2D::errors2D() const
 {
     if (!hasError_)
-        Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but constErrors2D() was requested.\n",
-                        name(), objectTag());
+        Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but errors2D() was requested.\n", name(),
+                        objectTag());
 
     return errors_;
 }

--- a/src/math/data2d.cpp
+++ b/src/math/data2d.cpp
@@ -257,15 +257,14 @@ const double &Data2D::value(int xIndex, int yIndex) const
     return values_[{xIndex, yIndex}];
 }
 
-// Return values Array
-Array2D<double> &Data2D::values()
+// Return two-dimensional values Array
+Array2D<double> &Data2D::values2D()
 {
     ++version_;
 
     return values_;
 }
 
-// Return values Array (const)
 const Array2D<double> &Data2D::values2D() const { return values_; }
 
 // Return value specified from linear array
@@ -365,8 +364,8 @@ const double &Data2D::error(int xIndex, int yIndex) const
     return errors_[{xIndex, yIndex}];
 }
 
-// Return error Array
-Array2D<double> &Data2D::errors()
+// Return two-dimensional errors Array
+Array2D<double> &Data2D::errors2D()
 {
     if (!hasError_)
         Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but errors() was requested.\n", name(),
@@ -377,7 +376,6 @@ Array2D<double> &Data2D::errors()
     return errors_;
 }
 
-// Return error Array (const)
 const Array2D<double> &Data2D::errors2D() const
 {
     if (!hasError_)

--- a/src/math/data2d.h
+++ b/src/math/data2d.h
@@ -54,28 +54,23 @@ class Data2D : public PlottableData, public ListItem<Data2D>, public ObjectStore
     int version() const;
     // Return x axis value specified
     double &xAxis(int index);
-    // Return x axis value specified (const)
-    double constXAxis(int index) const;
+    const double &xAxis(int index) const;
     // Return x axis Array
     std::vector<double> &xAxis();
-    // Return x axis Array (const)
     const std::vector<double> &xAxis() const;
     // Return y axis value specified
     double &yAxis(int index);
-    // Return y axis value specified (const)
-    double constYAxis(int index) const;
+    const double &yAxis(int index) const;
     // Return y axis Array
     std::vector<double> &yAxis();
-    // Return y axis Array (const)
     const std::vector<double> &yAxis() const;
     // Return value specified
     double &value(int xIndex, int yIndex);
-    // Return value value specified (const)
-    double constValue(int xIndex, int yIndex) const;
+    const double &value(int xIndex, int yIndex) const;
     // Return value Array
     Array2D<double> &values();
     // Return values Array
-    const Array2D<double> &constValues2D() const;
+    const Array2D<double> &values2D() const;
     // Return value specified from linear array
     double value(int index);
     // Return number of values present in whole dataset
@@ -90,12 +85,11 @@ class Data2D : public PlottableData, public ListItem<Data2D>, public ObjectStore
     bool valuesHaveErrors() const;
     // Return error value specified
     double &error(int xIndex, int yIndex);
-    // Return error value specified (const)
-    double constError(int xIndex, int yIndex) const;
+    const double &error(int xIndex, int yIndex) const;
     // Return error Array
     Array2D<double> &errors();
     // Return errors Array
-    const Array2D<double> &constErrors2D() const;
+    const Array2D<double> &errors2D() const;
 
     /*
      * Operators

--- a/src/math/data2d.h
+++ b/src/math/data2d.h
@@ -67,9 +67,8 @@ class Data2D : public PlottableData, public ListItem<Data2D>, public ObjectStore
     // Return value specified
     double &value(int xIndex, int yIndex);
     const double &value(int xIndex, int yIndex) const;
-    // Return value Array
-    Array2D<double> &values();
-    // Return values Array
+    // Return two-dimensional values Array
+    Array2D<double> &values2D();
     const Array2D<double> &values2D() const;
     // Return value specified from linear array
     double value(int index);
@@ -86,9 +85,8 @@ class Data2D : public PlottableData, public ListItem<Data2D>, public ObjectStore
     // Return error value specified
     double &error(int xIndex, int yIndex);
     const double &error(int xIndex, int yIndex) const;
-    // Return error Array
-    Array2D<double> &errors();
-    // Return errors Array
+    // Return two-dimensional errors Array
+    Array2D<double> &errors2D();
     const Array2D<double> &errors2D() const;
 
     /*

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -135,9 +135,9 @@ const double &Data3D::xAxis(int index) const
 // Return x axis Array
 std::vector<double> &Data3D::xAxis()
 {
-    return x_;
-
     ++version_;
+
+    return x_;
 }
 
 const std::vector<double> &Data3D::xAxis() const { return x_; }

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -268,15 +268,14 @@ const double &Data3D::value(int xIndex, int yIndex, int zIndex) const
     return values_[{xIndex, yIndex, zIndex}];
 }
 
-// Return values Array
-Array3D<double> &Data3D::values()
+// Return three-dimensional values Array
+Array3D<double> &Data3D::values3D()
 {
     ++version_;
 
     return values_;
 }
 
-// Return values Array (const)
 const Array3D<double> &Data3D::values3D() const { return values_; }
 
 // Return number of values present in whole dataset
@@ -384,8 +383,8 @@ const double &Data3D::error(int xIndex, int yIndex, int zIndex) const
     return errors_[{xIndex, yIndex, zIndex}];
 }
 
-// Return error Array
-Array3D<double> &Data3D::errors()
+// Return three-dimensional errors Array
+Array3D<double> &Data3D::errors3D()
 {
     if (!hasError_)
         Messenger::warn("This Data3D (name='{}', tag='{}') has no errors to return, but errors() was requested.\n", name(),
@@ -396,7 +395,6 @@ Array3D<double> &Data3D::errors()
     return errors_;
 }
 
-// Return error Array (const)
 const Array3D<double> &Data3D::errors3D() const
 {
     if (!hasError_)

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -120,13 +120,12 @@ double &Data3D::xAxis(int index)
     return x_[index];
 }
 
-// Return x value specified (const)
-double Data3D::constXAxis(int index) const
+const double &Data3D::xAxis(int index) const
 {
 #ifdef CHECKS
     if ((index < 0) || (index >= x_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data3D::constXAxis().\n", index);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data3D::xAxis().\n", index);
         return 0.0;
     }
 #endif
@@ -141,7 +140,6 @@ std::vector<double> &Data3D::xAxis()
     ++version_;
 }
 
-// Return x axis Array (const)
 const std::vector<double> &Data3D::xAxis() const { return x_; }
 
 // Return y value specified
@@ -160,13 +158,12 @@ double &Data3D::yAxis(int index)
     return y_[index];
 }
 
-// Return y value specified (const)
-double Data3D::constYAxis(int index) const
+const double &Data3D::yAxis(int index) const
 {
 #ifdef CHECKS
     if ((index < 0) || (index >= y_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data3D::constYAxis().\n", index);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data3D::yAxis().\n", index);
         return 0.0;
     }
 #endif
@@ -181,7 +178,6 @@ std::vector<double> &Data3D::yAxis()
     return y_;
 }
 
-// Return y axis Array (const)
 const std::vector<double> &Data3D::yAxis() const { return y_; }
 
 // Return z value specified
@@ -200,13 +196,12 @@ double &Data3D::zAxis(int index)
     return z_[index];
 }
 
-// Return z value specified (const)
-double Data3D::constZAxis(int index) const
+const double &Data3D::zAxis(int index) const
 {
 #ifdef CHECKS
     if ((index < 0) || (index >= z_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z_ array in Data3D::constZAxis().\n", index);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z_ array in Data3D::zAxis().\n", index);
         return 0.0;
     }
 #endif
@@ -221,7 +216,6 @@ std::vector<double> &Data3D::zAxis()
     return z_;
 }
 
-// Return z axis Array (const)
 const std::vector<double> &Data3D::zAxis() const { return z_; }
 
 // Return value specified
@@ -252,23 +246,22 @@ double &Data3D::value(int xIndex, int yIndex, int zIndex)
     return values_[{xIndex, yIndex, zIndex}];
 }
 
-// Return value specified (const)
-double Data3D::constValue(int xIndex, int yIndex, int zIndex) const
+const double &Data3D::value(int xIndex, int yIndex, int zIndex) const
 {
 #ifdef CHECKS
     if ((xIndex < 0) || (xIndex >= x_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data3D::constValue().\n", xIndex);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data3D::value().\n", xIndex);
         return 0.0;
     }
     if ((yIndex < 0) || (yIndex >= y_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data3D::constValue().\n", yIndex);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data3D::value().\n", yIndex);
         return 0.0;
     }
     if ((zIndex < 0) || (zIndex >= z_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z axis in Data3D::constValue().\n", zIndex);
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z axis in Data3D::value().\n", zIndex);
         return 0.0;
     }
 #endif
@@ -284,7 +277,7 @@ Array3D<double> &Data3D::values()
 }
 
 // Return values Array (const)
-const Array3D<double> &Data3D::constValues3D() const { return values_; }
+const Array3D<double> &Data3D::values3D() const { return values_; }
 
 // Return number of values present in whole dataset
 int Data3D::nValues() const { return values_.linearArraySize(); }
@@ -358,30 +351,33 @@ double &Data3D::error(int xIndex, int yIndex, int zIndex)
     return errors_[{xIndex, yIndex, zIndex}];
 }
 
-// Return error value specified (const)
-double Data3D::constError(int xIndex, int yIndex, int zIndex) const
+const double &Data3D::error(int xIndex, int yIndex, int zIndex) const
 {
     if (!hasError_)
     {
-        Messenger::warn("This Data3D (name='{}', tag='{}') has no errors to return, but constError(int,int) was requested.\n",
+        static double dummy;
+        Messenger::warn("This Data3D (name='{}', tag='{}') has no errors to return, but error(int,int) was requested.\n",
                         name(), objectTag());
-        return 0.0;
+        return dummy;
     }
 #ifdef CHECKS
     if ((xIndex < 0) || (xIndex >= x_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data3D::constError().\n", xIndex);
-        return 0.0;
+        static double dummy;
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data3D::error().\n", xIndex);
+        return dummy;
     }
     if ((yIndex < 0) || (yIndex >= y_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data3D::constError().\n", yIndex);
-        return 0.0;
+        static double dummy;
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data3D::error().\n", yIndex);
+        return dummy;
     }
     if ((zIndex < 0) || (zIndex >= z_.size()))
     {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z axis in Data3D::constError().\n", zIndex);
-        return 0.0;
+        static double dummy;
+        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z axis in Data3D::error().\n", zIndex);
+        return dummy;
     }
 #endif
 
@@ -401,10 +397,10 @@ Array3D<double> &Data3D::errors()
 }
 
 // Return error Array (const)
-const Array3D<double> &Data3D::constErrors3D() const
+const Array3D<double> &Data3D::errors3D() const
 {
     if (!hasError_)
-        Messenger::warn("This Data3D (name='{}', tag='{}') has no errors to return, but constErrors() was requested.\n", name(),
+        Messenger::warn("This Data3D (name='{}', tag='{}') has no errors to return, but errors() was requested.\n", name(),
                         objectTag());
 
     return errors_;

--- a/src/math/data3d.h
+++ b/src/math/data3d.h
@@ -53,36 +53,29 @@ class Data3D : public PlottableData, public ListItem<Data3D>, public ObjectStore
     int version() const;
     // Return x axis value specified
     double &xAxis(int index);
-    // Return x axis value specified (const)
-    double constXAxis(int index) const;
+    const double &xAxis(int index) const;
     // Return x axis Array
     std::vector<double> &xAxis();
-    // Return x axis Array (const)
     const std::vector<double> &xAxis() const;
     // Return y axis value specified
     double &yAxis(int index);
-    // Return y axis value specified (const)
-    double constYAxis(int index) const;
+    const double &yAxis(int index) const;
     // Return y axis Array
     std::vector<double> &yAxis();
-    // Return y axis Array (const)
     const std::vector<double> &yAxis() const;
     // Return z axis value specified
     double &zAxis(int index);
-    // Return z axis value specified (const)
-    double constZAxis(int index) const;
+    const double &zAxis(int index) const;
     // Return z axis Array
     std::vector<double> &zAxis();
-    // Return z axis Array (const)
     const std::vector<double> &zAxis() const;
     // Return value specified
     double &value(int xIndex, int yIndex, int zIndex);
-    // Return value value specified (const)
-    double constValue(int xIndex, int yIndex, int zIndex) const;
+    const double &value(int xIndex, int yIndex, int zIndex) const;
     // Return value Array
     Array3D<double> &values();
     // Return values Array
-    const Array3D<double> &constValues3D() const;
+    const Array3D<double> &values3D() const;
     // Return number of values present in whole dataset
     int nValues() const;
     // Return minimum value over all data points
@@ -95,12 +88,11 @@ class Data3D : public PlottableData, public ListItem<Data3D>, public ObjectStore
     bool valuesHaveErrors() const;
     // Return error value specified
     double &error(int xIndex, int yIndex, int zIndex);
-    // Return error value specified (const)
-    double constError(int xIndex, int yIndex, int zIndex) const;
+    const double &error(int xIndex, int yIndex, int zIndex) const;
     // Return error Array
     Array3D<double> &errors();
     // Return errors Array
-    const Array3D<double> &constErrors3D() const;
+    const Array3D<double> &errors3D() const;
 
     /*
      * Operators

--- a/src/math/data3d.h
+++ b/src/math/data3d.h
@@ -72,9 +72,8 @@ class Data3D : public PlottableData, public ListItem<Data3D>, public ObjectStore
     // Return value specified
     double &value(int xIndex, int yIndex, int zIndex);
     const double &value(int xIndex, int yIndex, int zIndex) const;
-    // Return value Array
-    Array3D<double> &values();
-    // Return values Array
+    // Return three-dimensional values Array
+    Array3D<double> &values3D();
     const Array3D<double> &values3D() const;
     // Return number of values present in whole dataset
     int nValues() const;
@@ -89,9 +88,8 @@ class Data3D : public PlottableData, public ListItem<Data3D>, public ObjectStore
     // Return error value specified
     double &error(int xIndex, int yIndex, int zIndex);
     const double &error(int xIndex, int yIndex, int zIndex) const;
-    // Return error Array
-    Array3D<double> &errors();
-    // Return errors Array
+    // Return three-dimensional errors Array
+    Array3D<double> &errors3D();
     const Array3D<double> &errors3D() const;
 
     /*

--- a/src/math/extrema.cpp
+++ b/src/math/extrema.cpp
@@ -10,11 +10,11 @@ double Extrema::min(const Array<double> &A)
 {
     if (A.nItems() > 0)
     {
-        double min = A.constAt(0);
+        double min = A.at(0);
         for (auto i = 0; i < A.nItems(); ++i)
         {
-            if (A.constAt(i) < min)
-                min = A.constAt(i);
+            if (A.at(i) < min)
+                min = A.at(i);
         }
         return min;
     }
@@ -27,11 +27,11 @@ double Extrema::max(const Array<double> &A)
 {
     if (A.nItems() > 0)
     {
-        double max = A.constAt(0);
+        double max = A.at(0);
         for (auto i = 0; i < A.nItems(); ++i)
         {
-            if (A.constAt(i) > max)
-                max = A.constAt(i);
+            if (A.at(i) > max)
+                max = A.at(i);
         }
         return max;
     }
@@ -60,11 +60,11 @@ double Extrema::absMin(const Array<double> &A)
 {
     if (A.nItems() > 0)
     {
-        auto absMin = fabs(A.constAt(0));
+        auto absMin = fabs(A.at(0));
         for (auto i = 0; i < A.nItems(); ++i)
         {
-            if (fabs(A.constAt(i)) < absMin)
-                absMin = fabs(A.constAt(i));
+            if (fabs(A.at(i)) < absMin)
+                absMin = fabs(A.at(i));
         }
         return absMin;
     }
@@ -77,11 +77,11 @@ double Extrema::absMax(const Array<double> &A)
 {
     if (A.nItems() > 0)
     {
-        auto absMax = fabs(A.constAt(0));
+        auto absMax = fabs(A.at(0));
         for (auto i = 0; i < A.nItems(); ++i)
         {
-            if (fabs(A.constAt(i)) > absMax)
-                absMax = fabs(A.constAt(i));
+            if (fabs(A.at(i)) > absMax)
+                absMax = fabs(A.at(i));
         }
         return absMax;
     }

--- a/src/math/gaussfit.cpp
+++ b/src/math/gaussfit.cpp
@@ -128,7 +128,7 @@ void GaussFit::printCoefficients() const
 // Save Fourier-transformed Gaussians to individual files
 bool GaussFit::saveFTGaussians(std::string_view filenamePrefix, double xStep) const
 {
-    double xDelta = (xStep < 0.0 ? referenceData_.constXAxis(1) - referenceData_.constXAxis(0) : xStep);
+    double xDelta = (xStep < 0.0 ? referenceData_.xAxis(1) - referenceData_.xAxis(0) : xStep);
     for (auto n = 0; n < nGaussians_; ++n)
     {
         LineParser parser;

--- a/src/math/integrator.cpp
+++ b/src/math/integrator.cpp
@@ -222,15 +222,12 @@ double Integrator::sumOfSquares(const Data1D &data, const Range range)
 }
 
 // Return sum of all values in supplied data
-double Integrator::sum(const Data2D &data)
-{
-    return std::accumulate(data.constValues2D().begin(), data.constValues2D().end(), 0.0);
-}
+double Integrator::sum(const Data2D &data) { return std::accumulate(data.values2D().begin(), data.values2D().end(), 0.0); }
 
 // Return sum of all absolute values in supplied data
 double Integrator::absSum(const Data2D &data)
 {
-    return std::accumulate(data.constValues2D().begin(), data.constValues2D().end(), 0.0,
+    return std::accumulate(data.values2D().begin(), data.values2D().end(), 0.0,
                            [](auto a, auto b) { return fabs(a) + fabs(b); });
 }
 
@@ -238,7 +235,7 @@ double Integrator::absSum(const Data2D &data)
 double Integrator::sum(const Data3D &data)
 {
     // Grab data array
-    const Array3D<double> &values = data.constValues3D();
+    const Array3D<double> &values = data.values3D();
 
     return std::accumulate(values.linearArray().begin(), values.linearArray().end(), 0.0);
 }
@@ -247,7 +244,7 @@ double Integrator::sum(const Data3D &data)
 double Integrator::absSum(const Data3D &data)
 {
     // Grab data array
-    const Array3D<double> &values = data.constValues3D();
+    const Array3D<double> &values = data.values3D();
 
     return std::accumulate(values.linearArray().begin(), values.linearArray().end(), 0.0,
                            [](auto acc, auto n) { return acc + fabs(n); });

--- a/src/math/plottable.cpp
+++ b/src/math/plottable.cpp
@@ -51,7 +51,7 @@ const std::vector<double> &PlottableData::values() const
 }
 
 // Return values Array
-const Array2D<double> &PlottableData::constValues2D() const
+const Array2D<double> &PlottableData::values2D() const
 {
     Messenger::error(
         "Tried to retrieve a two-dimensional value array from a PlottableData that doesn't know how to return one.\n");
@@ -60,7 +60,7 @@ const Array2D<double> &PlottableData::constValues2D() const
 }
 
 // Return three-dimensional values Array
-const Array3D<double> &PlottableData::constValues3D() const
+const Array3D<double> &PlottableData::values3D() const
 {
     Messenger::error("Tried to retrieve a three-dimensional value array from a PlottableData that doesn't know how to "
                      "return one.\n");
@@ -81,7 +81,7 @@ const std::vector<double> &PlottableData::errors() const
 }
 
 // Return errors Array
-const Array2D<double> &PlottableData::constErrors2D() const
+const Array2D<double> &PlottableData::errors2D() const
 {
     Messenger::error(
         "Tried to retrieve a two-dimensional error array from a PlottableData that doesn't know how to return one.\n");
@@ -90,7 +90,7 @@ const Array2D<double> &PlottableData::constErrors2D() const
 }
 
 // Return three-dimensional errors Array
-const Array3D<double> &PlottableData::constErrors3D() const
+const Array3D<double> &PlottableData::errors3D() const
 {
     Messenger::error("Tried to retrieve a three-dimensional error array from a PlottableData that doesn't know how to "
                      "return one.\n");

--- a/src/math/plottable.cpp
+++ b/src/math/plottable.cpp
@@ -50,7 +50,7 @@ const std::vector<double> &PlottableData::values() const
     return dummy;
 }
 
-// Return values Array
+// Return two-dimensional values Array
 const Array2D<double> &PlottableData::values2D() const
 {
     Messenger::error(
@@ -80,7 +80,7 @@ const std::vector<double> &PlottableData::errors() const
     return dummy;
 }
 
-// Return errors Array
+// Return two-dimensional errors Array
 const Array2D<double> &PlottableData::errors2D() const
 {
     Messenger::error(

--- a/src/math/plottable.h
+++ b/src/math/plottable.h
@@ -59,7 +59,7 @@ class PlottableData
     virtual int version() const = 0;
     // Return values Array
     virtual const std::vector<double> &values() const;
-    // Return values Array
+    // Return two-dimensional values Array
     virtual const Array2D<double> &values2D() const;
     // Return three-dimensional values Array
     virtual const Array3D<double> &values3D() const;
@@ -73,7 +73,7 @@ class PlottableData
     virtual bool valuesHaveErrors() const;
     // Return errors Array
     virtual const std::vector<double> &errors() const;
-    // Return errors Array
+    // Return two-dimensional errors Array
     virtual const Array2D<double> &errors2D() const;
     // Return three-dimensional errors Array
     virtual const Array3D<double> &errors3D() const;

--- a/src/math/plottable.h
+++ b/src/math/plottable.h
@@ -60,9 +60,9 @@ class PlottableData
     // Return values Array
     virtual const std::vector<double> &values() const;
     // Return values Array
-    virtual const Array2D<double> &constValues2D() const;
+    virtual const Array2D<double> &values2D() const;
     // Return three-dimensional values Array
-    virtual const Array3D<double> &constValues3D() const;
+    virtual const Array3D<double> &values3D() const;
     // Return number of values present in the whole dataset
     virtual int nValues() const = 0;
     // Return minimum value over all data points
@@ -74,7 +74,7 @@ class PlottableData
     // Return errors Array
     virtual const std::vector<double> &errors() const;
     // Return errors Array
-    virtual const Array2D<double> &constErrors2D() const;
+    virtual const Array2D<double> &errors2D() const;
     // Return three-dimensional errors Array
-    virtual const Array3D<double> &constErrors3D() const;
+    virtual const Array3D<double> &errors3D() const;
 };

--- a/src/math/poissonfit.cpp
+++ b/src/math/poissonfit.cpp
@@ -102,7 +102,7 @@ double PoissonFit::poissonFT(const int qIndex, const int nIndex) const
 
     double factor = 1.0 / ((n + 2) * pow(sqrtOnePlusQSqSigmaSq_[qIndex], n + 4));
 
-    double value = 2.0 * cos(na) + (oneMinusQSqSigmaSq_[qIndex] / (referenceData_.constXAxis(qIndex) * sigmaQ_)) * sin(na);
+    double value = 2.0 * cos(na) + (oneMinusQSqSigmaSq_[qIndex] / (referenceData_.xAxis(qIndex) * sigmaQ_)) * sin(na);
 
     return factor * value;
 }

--- a/src/math/transformer.cpp
+++ b/src/math/transformer.cpp
@@ -96,7 +96,7 @@ void Transformer::transformValues(Data2D &data)
     // Get references to x and value arrays, and take copies of each
     const auto &xAxis = data.xAxis();
     const auto &yAxis = data.yAxis();
-    Array2D<double> &values = data.values();
+    auto &values = data.values2D();
 
     // Data2D x and y arrays may be of different sizes
     for (auto i = 0; i < xAxis.size(); ++i)
@@ -129,7 +129,7 @@ void Transformer::transformValues(Data3D &data)
     const auto &xAxis = data.xAxis();
     const auto &yAxis = data.yAxis();
     const auto &zAxis = data.zAxis();
-    Array3D<double> &values = data.values();
+    auto &values = data.values3D();
 
     // Data3D x, y and z arrays may be of different sizes
     for (auto i = 0; i < xAxis.size(); ++i)

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -382,10 +382,10 @@ bool BraggModule::formReflectionFunctions(ProcessPool &procPool, Configuration *
         for (auto n = 0; n < nReflections; ++n)
         {
             // Get q value and intensity of reflection
-            qCentre = braggReflections.constAt(n).q();
+            qCentre = braggReflections.at(n).q();
             bin = qCentre / qDelta;
 
-            partial.value(bin) += braggReflections.constAt(n).intensity(typeI, typeJ);
+            partial.value(bin) += braggReflections.at(n).intensity(typeI, typeJ);
         }
 
         // Add this partial into the total function, accounting for doubling of partials between unlike atom
@@ -424,11 +424,11 @@ bool BraggModule::reBinReflections(ProcessPool &procPool, Configuration *cfg, Ar
     for (auto n = 0; n < nReflections; ++n)
     {
         // Get Q bin (in the braggPartials) of the reflection
-        bin = braggReflections.constAt(n).q() / qDelta;
+        bin = braggReflections.at(n).q() / qDelta;
         if ((bin < 0) || (bin >= nBins))
         {
             Messenger::warn("Reflection {} is at Q = {} Angstroms**-1, which is outside of the current Q range.\n", n,
-                            braggReflections.constAt(n).q());
+                            braggReflections.at(n).q());
             continue;
         }
 
@@ -442,7 +442,7 @@ bool BraggModule::reBinReflections(ProcessPool &procPool, Configuration *cfg, Ar
             int typeJ = typeI;
             for (auto atd2 = atd1; atd2 != types.end(); typeJ++, atd2++)
             {
-                braggPartials[{typeI, typeJ}].value(bin) += braggReflections.constAt(n).intensity(typeI, typeJ);
+                braggPartials[{typeI, typeJ}].value(bin) += braggReflections.at(n).intensity(typeI, typeJ);
             }
         }
     }

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -100,8 +100,7 @@ bool BraggModule::process(Dissolve &dissolve, ProcessPool &procPool)
             for (auto n = 0; n < braggReflections.nItems(); ++n)
             {
                 if (!braggParser.writeLineF("{:6d}  {:10.6f}  {:8d}  {:10.6e}\n", n, braggReflections.at(n).q(),
-                                            braggReflections.at(n).nKVectors(),
-                                            braggReflections.at(n).intensity(0, 0)))
+                                            braggReflections.at(n).nKVectors(), braggReflections.at(n).intensity(0, 0)))
                     return false;
             }
             braggParser.closeFiles();

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -99,9 +99,9 @@ bool BraggModule::process(Dissolve &dissolve, ProcessPool &procPool)
             braggParser.writeLineF("#   ID      Q       nKVecs    Intensity(0,0)\n");
             for (auto n = 0; n < braggReflections.nItems(); ++n)
             {
-                if (!braggParser.writeLineF("{:6d}  {:10.6f}  {:8d}  {:10.6e}\n", n, braggReflections.constAt(n).q(),
-                                            braggReflections.constAt(n).nKVectors(),
-                                            braggReflections.constAt(n).intensity(0, 0)))
+                if (!braggParser.writeLineF("{:6d}  {:10.6f}  {:8d}  {:10.6e}\n", n, braggReflections.at(n).q(),
+                                            braggReflections.at(n).nKVectors(),
+                                            braggReflections.at(n).intensity(0, 0)))
                     return false;
             }
             braggParser.closeFiles();
@@ -118,8 +118,8 @@ bool BraggModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     intensityParser.writeLineF("#     Q      Intensity({},{})\n", atd1.atomTypeName(), atd2.atomTypeName());
                     for (auto n = 0; n < braggReflections.nItems(); ++n)
                     {
-                        if (!intensityParser.writeLineF("{:10.6f}  {:10.6e}\n", braggReflections.constAt(n).q(),
-                                                        braggReflections.constAt(n).intensity(i, j)))
+                        if (!intensityParser.writeLineF("{:10.6f}  {:10.6e}\n", braggReflections.at(n).q(),
+                                                        braggReflections.at(n).intensity(i, j)))
                             return false;
                         intensityParser.writeLineF("#     Q      Intensity({},{})\n", atd1.atomTypeName(), atd2.atomTypeName());
                     }

--- a/src/modules/calculate_avgmol/functions.cpp
+++ b/src/modules/calculate_avgmol/functions.cpp
@@ -48,7 +48,7 @@ void CalculateAvgMolModule::updateSpecies(const Array<SampledDouble> &x, const A
 {
     // Loop over atoms in our species
     for (auto n = 0; n < averageSpecies_.nAtoms(); ++n)
-        averageSpecies_.setAtomCoordinates(n, x.constAt(n).value(), y.constAt(n).value(), z.constAt(n).value());
+        averageSpecies_.setAtomCoordinates(n, x.at(n).value(), y.at(n).value(), z.at(n).value());
 }
 
 /*

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -151,27 +151,27 @@ double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Configuration *
         mol = molecules[m];
 
         // Loop over Bond
-        bondEnergy += std::accumulate(mol->species()->constBonds().cbegin(), mol->species()->constBonds().cend(), 0.0,
+        bondEnergy += std::accumulate(mol->species()->bonds().cbegin(), mol->species()->bonds().cend(), 0.0,
                                       [&mol, &kernel](auto const acc, const auto &t) {
                                           return acc + kernel.energy(t, mol->atom(t.indexI()), mol->atom(t.indexJ()));
                                       });
 
         // Loop over Angle
-        angleEnergy += std::accumulate(mol->species()->constAngles().cbegin(), mol->species()->constAngles().cend(), 0.0,
+        angleEnergy += std::accumulate(mol->species()->angles().cbegin(), mol->species()->angles().cend(), 0.0,
                                        [&mol, &kernel](auto const acc, const auto &t) {
                                            return acc + kernel.energy(t, mol->atom(t.indexI()), mol->atom(t.indexJ()),
                                                                       mol->atom(t.indexK()));
                                        });
 
         // Loop over Torsions
-        torsionEnergy += std::accumulate(mol->species()->constTorsions().cbegin(), mol->species()->constTorsions().cend(), 0.0,
+        torsionEnergy += std::accumulate(mol->species()->torsions().cbegin(), mol->species()->torsions().cend(), 0.0,
                                          [&mol, &kernel](auto const acc, const auto &t) {
                                              return acc + kernel.energy(t, mol->atom(t.indexI()), mol->atom(t.indexJ()),
                                                                         mol->atom(t.indexK()), mol->atom(t.indexL()));
                                          });
 
-        improperEnergy += std::accumulate(mol->species()->constImpropers().cbegin(), mol->species()->constImpropers().cend(),
-                                          0.0, [&mol, &kernel](auto const acc, const auto &imp) {
+        improperEnergy += std::accumulate(mol->species()->impropers().cbegin(), mol->species()->impropers().cend(), 0.0,
+                                          [&mol, &kernel](auto const acc, const auto &imp) {
                                               return acc + kernel.energy(imp, mol->atom(imp.indexI()), mol->atom(imp.indexJ()),
                                                                          mol->atom(imp.indexK()), mol->atom(imp.indexL()));
                                           });
@@ -210,16 +210,20 @@ double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Species *sp)
     auto energy = 0.0;
 
     // Loop over bonds
-    for (const auto &bond : sp->constBonds())
+    for (const auto &bond : sp->bonds())
         energy += EnergyKernel::energy(bond);
 
     // Loop over angles
-    for (const auto &angle : sp->constAngles())
+    for (const auto &angle : sp->angles())
         energy += EnergyKernel::energy(angle);
 
     // Loop over torsions
-    for (const auto &torsion : sp->constTorsions())
+    for (const auto &torsion : sp->torsions())
         energy += EnergyKernel::energy(torsion);
+
+    // Loop over impropers
+    for (const auto &improper : sp->impropers())
+        energy += EnergyKernel::energy(improper);
 
     return energy;
 }

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -157,14 +157,14 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 }
 
                 // Bond energy
-                for (const auto &bond : molN->species()->constBonds())
+                for (const auto &bond : molN->species()->bonds())
                 {
                     r = cfg->box()->minimumDistance(molN->atom(bond.indexI()), molN->atom(bond.indexJ()));
                     correctIntraEnergy += bond.energy(r);
                 }
 
                 // Angle energy
-                for (const auto &angle : molN->species()->constAngles())
+                for (const auto &angle : molN->species()->angles())
                 {
                     // Get vectors 'j-i' and 'j-k'
                     vecji = cfg->box()->minimumVector(molN->atom(angle.indexJ()), molN->atom(angle.indexI()));
@@ -177,7 +177,7 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 }
 
                 // Torsion energy
-                for (const auto &torsion : molN->species()->constTorsions())
+                for (const auto &torsion : molN->species()->torsions())
                 {
                     // Get vectors 'j-i', 'j-k' and 'k-l'
                     vecji = cfg->box()->minimumVector(molN->atom(torsion.indexJ()), molN->atom(torsion.indexI()));
@@ -191,7 +191,7 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 }
 
                 // Improper energy
-                for (const auto &imp : molN->species()->constImpropers())
+                for (const auto &imp : molN->species()->impropers())
                 {
                     // Get vectors 'j-i', 'j-k' and 'k-l'
                     vecji = cfg->box()->minimumVector(molN->atom(imp.indexJ()), molN->atom(imp.indexI()));

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -75,7 +75,7 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, 
 
     // Loop over supplied atom indices
     for (auto n = start; n < targetIndices.nItems(); n += stride)
-        kernel.forces(cfg->atoms()[targetIndices.constAt(n)], ProcessPool::subDivisionStrategy(strategy));
+        kernel.forces(cfg->atoms()[targetIndices.at(n)], ProcessPool::subDivisionStrategy(strategy));
 }
 
 // Calculate interatomic forces within the specified Species
@@ -145,7 +145,7 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
     const auto &atoms = cfg->atoms();
     for (auto n = start; n < targetIndices.nItems(); n += stride)
     {
-        const auto i = atoms[targetIndices.constAt(n)];
+        const auto i = atoms[targetIndices.at(n)];
         const SpeciesAtom *spAtom = i->speciesAtom();
         std::shared_ptr<const Molecule> mol = i->molecule();
 
@@ -336,7 +336,7 @@ void ForcesModule::totalForces(ProcessPool &procPool, Configuration *cfg,
     Array<int> indices;
     for (auto n = 0; n < targetMolecules.nItems(); ++n)
     {
-        std::shared_ptr<Molecule> mol = targetMolecules.constAt(n);
+        std::shared_ptr<Molecule> mol = targetMolecules.at(n);
 
         for (auto i = 0; i < mol->nAtoms(); ++i)
         {

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -199,20 +199,20 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
         mol = molecules[m];
 
         // Loop over bonds
-        for (const auto &bond : mol->species()->constBonds())
+        for (const auto &bond : mol->species()->bonds())
             kernel.forces(bond, mol->atom(bond.indexI()), mol->atom(bond.indexJ()));
 
         // Loop over angles
-        for (const auto &angle : mol->species()->constAngles())
+        for (const auto &angle : mol->species()->angles())
             kernel.forces(angle, mol->atom(angle.indexI()), mol->atom(angle.indexJ()), mol->atom(angle.indexK()));
 
         // Loop over torsions
-        for (const auto &torsion : mol->species()->constTorsions())
+        for (const auto &torsion : mol->species()->torsions())
             kernel.forces(torsion, mol->atom(torsion.indexI()), mol->atom(torsion.indexJ()), mol->atom(torsion.indexK()),
                           mol->atom(torsion.indexL()));
 
         // Loop over impropers
-        for (const auto &imp : mol->species()->constImpropers())
+        for (const auto &imp : mol->species()->impropers())
             kernel.forces(imp, mol->atom(imp.indexI()), mol->atom(imp.indexJ()), mol->atom(imp.indexK()),
                           mol->atom(imp.indexL()));
     }
@@ -226,19 +226,19 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Species *sp, cons
     ForceKernel kernel(procPool, &box, potentialMap, fx, fy, fz);
 
     // Loop over bonds
-    for (const auto &b : sp->constBonds())
+    for (const auto &b : sp->bonds())
         kernel.forces(b);
 
     // Loop over angles
-    for (const auto &a : sp->constAngles())
+    for (const auto &a : sp->angles())
         kernel.forces(a);
 
     // Loop over torsions
-    for (const auto &t : sp->constTorsions())
+    for (const auto &t : sp->torsions())
         kernel.forces(t);
 
     // Loop over impropers
-    for (const auto &imp : sp->constImpropers())
+    for (const auto &imp : sp->impropers())
         kernel.forces(imp);
 }
 

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -506,9 +506,9 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 sumError = 0.0;
                 for (auto n = 0; n < cfg->nAtoms(); ++n)
                 {
-                    totalRatio.x = referenceFx.constAt(n) - (interFx[n] + intraFx[n]);
-                    totalRatio.y = referenceFy.constAt(n) - (interFy[n] + intraFy[n]);
-                    totalRatio.z = referenceFz.constAt(n) - (interFz[n] + intraFz[n]);
+                    totalRatio.x = referenceFx.at(n) - (interFx[n] + intraFx[n]);
+                    totalRatio.y = referenceFy.at(n) - (interFy[n] + intraFy[n]);
+                    totalRatio.z = referenceFz.at(n) - (interFz[n] + intraFz[n]);
                     if (fabs(interFx[n] + intraFx[n]) > 1.0e-6)
                         totalRatio.x *= 100.0 / (interFx[n] + intraFx[n]);
                     if (fabs(interFy[n] + intraFy[n]) > 1.0e-6)
@@ -532,9 +532,9 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     {
                         Messenger::print("Check atom {:10d} - errors are {:15.8e} ({:5.2f}%) {:15.8e} "
                                          "({:5.2f}%) {:15.8e} ({:5.2f}%) (x y z) 10J/mol\n",
-                                         n + 1, referenceFx.constAt(n) - (interFx[n] + intraFx[n]), totalRatio.x,
-                                         referenceFy.constAt(n) - (interFy[n] + intraFy[n]), totalRatio.y,
-                                         referenceFz.constAt(n) - (interFz[n] + intraFz[n]), totalRatio.z);
+                                         n + 1, referenceFx.at(n) - (interFx[n] + intraFx[n]), totalRatio.x,
+                                         referenceFy.at(n) - (interFy[n] + intraFy[n]), totalRatio.y,
+                                         referenceFz.at(n) - (interFz[n] + intraFz[n]), totalRatio.z);
                         ++nFailed2;
                     }
                 }
@@ -548,9 +548,9 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 sumError = 0.0;
                 for (auto n = 0; n < cfg->nAtoms(); ++n)
                 {
-                    totalRatio.x = referenceFx.constAt(n) - (checkInterFx[n] + checkIntraFx[n]);
-                    totalRatio.y = referenceFy.constAt(n) - (checkInterFy[n] + checkIntraFy[n]);
-                    totalRatio.z = referenceFz.constAt(n) - (checkInterFz[n] + checkIntraFz[n]);
+                    totalRatio.x = referenceFx.at(n) - (checkInterFx[n] + checkIntraFx[n]);
+                    totalRatio.y = referenceFy.at(n) - (checkInterFy[n] + checkIntraFy[n]);
+                    totalRatio.z = referenceFz.at(n) - (checkInterFz[n] + checkIntraFz[n]);
                     if (fabs(checkInterFx[n] + checkIntraFx[n]) > 1.0e-6)
                         totalRatio.x *= 100.0 / (checkInterFx[n] + checkIntraFx[n]);
                     if (fabs(checkInterFy[n] + checkIntraFy[n]) > 1.0e-6)
@@ -574,9 +574,9 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     {
                         Messenger::print("Check atom {:10d} - errors are {:15.8e} ({:5.2f}%) {:15.8e} "
                                          "({:5.2f}%) {:15.8e} ({:5.2f}%) (x y z) 10J/mol\n",
-                                         n + 1, referenceFx.constAt(n) - (checkInterFx[n] + checkIntraFx[n]), totalRatio.x,
-                                         referenceFy.constAt(n) - (checkInterFy[n] + checkIntraFy[n]), totalRatio.y,
-                                         referenceFz.constAt(n) - (checkInterFz[n] + checkIntraFz[n]), totalRatio.z);
+                                         n + 1, referenceFx.at(n) - (checkInterFx[n] + checkIntraFx[n]), totalRatio.x,
+                                         referenceFy.at(n) - (checkInterFy[n] + checkIntraFy[n]), totalRatio.y,
+                                         referenceFz.at(n) - (checkInterFz[n] + checkIntraFz[n]), totalRatio.z);
                         ++nFailed3;
                     }
                 }

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -197,7 +197,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 if (testIntra)
                 {
                     // Bond forces
-                    for (const auto &bond : molN->species()->constBonds())
+                    for (const auto &bond : molN->species()->bonds())
                     {
                         // Grab pointers to atoms involved in bond
                         i = molN->atom(bond.indexI());
@@ -216,7 +216,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     }
 
                     // Angle forces
-                    for (const auto &angle : molN->species()->constAngles())
+                    for (const auto &angle : molN->species()->angles())
                     {
                         // Grab pointers to atoms involved in angle
                         i = molN->atom(angle.indexI());
@@ -249,7 +249,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     }
 
                     // Torsion forces
-                    for (const auto &torsion : molN->species()->constTorsions())
+                    for (const auto &torsion : molN->species()->torsions())
                     {
                         // Grab pointers to atoms involved in angle
                         i = molN->atom(torsion.indexI());
@@ -296,7 +296,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     }
 
                     // Improper forces
-                    for (const auto &imp : molN->species()->constImpropers())
+                    for (const auto &imp : molN->species()->impropers())
                     {
                         // Grab pointers to atoms involved in angle
                         i = molN->atom(imp.indexI());

--- a/src/modules/geomopt/functions.cpp
+++ b/src/modules/geomopt/functions.cpp
@@ -50,8 +50,8 @@ double GeometryOptimisationModule::rmsForce() const
 {
     double rmsf = 0.0;
     for (auto n = 0; n < xForce_.nItems(); ++n)
-        rmsf += xForce_.constAt(n) * xForce_.constAt(n) + yForce_.constAt(n) * yForce_.constAt(n) +
-                zForce_.constAt(n) * zForce_.constAt(n);
+        rmsf += xForce_.at(n) * xForce_.at(n) + yForce_.at(n) * yForce_.at(n) +
+                zForce_.at(n) * zForce_.at(n);
     rmsf /= xForce_.nItems();
 
     return sqrt(rmsf);

--- a/src/modules/geomopt/functions.cpp
+++ b/src/modules/geomopt/functions.cpp
@@ -50,8 +50,7 @@ double GeometryOptimisationModule::rmsForce() const
 {
     double rmsf = 0.0;
     for (auto n = 0; n < xForce_.nItems(); ++n)
-        rmsf += xForce_.at(n) * xForce_.at(n) + yForce_.at(n) * yForce_.at(n) +
-                zForce_.at(n) * zForce_.at(n);
+        rmsf += xForce_.at(n) * xForce_.at(n) + yForce_.at(n) * yForce_.at(n) + zForce_.at(n) * zForce_.at(n);
     rmsf /= xForce_.nItems();
 
     return sqrt(rmsf);

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -155,7 +155,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
                 // Loop over defined bonds
                 if (adjustBonds)
-                    for (const auto &bond : mol->species()->constBonds())
+                    for (const auto &bond : mol->species()->bonds())
                     {
                         // Get Atom pointers
                         i = mol->atom(bond.indexI());
@@ -209,7 +209,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
                 // Loop over defined angles
                 if (adjustAngles)
-                    for (const auto &angle : mol->species()->constAngles())
+                    for (const auto &angle : mol->species()->angles())
                     {
                         // Get Atom pointers
                         i = mol->atom(angle.indexI());
@@ -266,7 +266,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
                 // Loop over defined torsions
                 if (adjustTorsions)
-                    for (const auto &torsion : mol->species()->constTorsions())
+                    for (const auto &torsion : mol->species()->torsions())
                     {
                         // Get Atom pointers
                         i = mol->atom(torsion.indexI());

--- a/src/modules/neutronsq/functions.cpp
+++ b/src/modules/neutronsq/functions.cpp
@@ -96,7 +96,7 @@ void NeutronSQModule::calculateWeights(const RDFModule *rdfModule, NeutronWeight
         if (isoRef)
         {
             const Isotopologues &topes = *isoRef;
-            for (const auto &isoWeight : topes.constMix())
+            for (const auto &isoWeight : topes.mix())
                 weights.addIsotopologue(speciesPop.first, speciesPop.second, isoWeight.isotopologue(), isoWeight.weight());
         }
         else

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -118,7 +118,7 @@ bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
         const auto &braggReflections = GenericListHelper<Array<BraggReflection>>::value(
             dissolve.processingModuleData(), "BraggReflections", braggModule->uniqueName(), Array<BraggReflection>());
         const auto nReflections = braggReflections.nItems();
-        const auto braggQMax = braggReflections.constAt(nReflections - 1).q();
+        const auto braggQMax = braggReflections.at(nReflections - 1).q();
         Messenger::print("Found BraggReflections data for module '{}' (nReflections = {}, QMax = {} "
                          "Angstroms**-1).\n",
                          braggModule->uniqueName(), nReflections, braggQMax);

--- a/src/procedure/nodes/operateexpression.cpp
+++ b/src/procedure/nodes/operateexpression.cpp
@@ -61,7 +61,7 @@ bool OperateExpressionProcedureNode::operateData2D(ProcessPool &procPool, Config
 {
     const auto &x = targetData2D_->xAxis();
     const auto &y = targetData2D_->yAxis();
-    Array2D<double> &values = targetData2D_->values();
+    auto &values = targetData2D_->values2D();
 
     z_->setValue(0.0);
 
@@ -91,7 +91,7 @@ bool OperateExpressionProcedureNode::operateData3D(ProcessPool &procPool, Config
     const auto &x = targetData3D_->xAxis();
     const auto &y = targetData3D_->yAxis();
     const auto &z = targetData3D_->zAxis();
-    Array3D<double> &values = targetData3D_->values();
+    auto &values = targetData3D_->values3D();
 
     z_->setValue(0.0);
 

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -118,7 +118,7 @@ int SelectProcedureNode::nCumulativeSites() const { return nCumulativeSites_; }
 // Return current site
 const Site *SelectProcedureNode::currentSite() const
 {
-    return (currentSiteIndex_ == -1 ? nullptr : sites_.constAt(currentSiteIndex_));
+    return (currentSiteIndex_ == -1 ? nullptr : sites_.at(currentSiteIndex_));
 }
 
 /*
@@ -247,7 +247,7 @@ ProcedureNode::NodeExecutionResult SelectProcedureNode::execute(ProcessPool &pro
 
         const Array<Site> &generatedSites = dynamicNode->generatedSites();
         for (auto n = 0; n < generatedSites.nItems(); ++n)
-            sites_.add(&generatedSites.constAt(n));
+            sites_.add(&generatedSites.at(n));
     }
 
     // Set first site index and increase selections counter

--- a/src/templates/array.h
+++ b/src/templates/array.h
@@ -274,13 +274,13 @@ template <class A> class Array : public ListItem<Array<A>>
         return array_[n];
     }
     // Return nth item as const reference
-    A &constAt(int n) const
+    const A &at(int n) const
     {
 #ifdef CHECKS
         if ((n < 0) || (n >= nItems_))
         {
             static A dummy;
-            Messenger::print("OUT_OF_RANGE - Array index {} is out of range in Array::constAt() (nItems = {}).\n", n, nItems_);
+            Messenger::print("OUT_OF_RANGE - Array index {} is out of range in Array::at() (nItems = {}).\n", n, nItems_);
             return dummy;
         }
 #endif
@@ -391,7 +391,7 @@ template <class A> class Array : public ListItem<Array<A>>
     void operator+=(const Array<A> array)
     {
         for (auto n = 0; n < nItems_; ++n)
-            array_[n] += array.constAt(n);
+            array_[n] += array.at(n);
     }
     // Operator-= (subtract from all)
     void operator-=(const A value)
@@ -422,7 +422,7 @@ template <class A> class Array : public ListItem<Array<A>>
     {
         Array<A> result(nItems_);
         for (auto n = 0; n < nItems_; ++n)
-            result[n] = array_[n] - array.constAt(n);
+            result[n] = array_[n] - array.at(n);
         return result;
     }
     // Operator+ (addition)
@@ -436,7 +436,7 @@ template <class A> class Array : public ListItem<Array<A>>
     {
         Array<A> result(nItems_);
         for (auto n = 0; n < nItems_; ++n)
-            result[n] = array_[n] + array.constAt(n);
+            result[n] = array_[n] + array.at(n);
         return result;
     }
     // Operator* (multiply all and return new)

--- a/src/templates/array2d.h
+++ b/src/templates/array2d.h
@@ -174,13 +174,13 @@ template <class A> class Array2D
         static A dummy;
         if ((row < 0) || (row >= nRows_))
         {
-            Messenger::print("OUT_OF_RANGE - Row number ({}) is out of range in Array2D::constAt() (nRows = {}).\n", row,
+            Messenger::print("OUT_OF_RANGE - Row number ({}) is out of range in Array2D::at() (nRows = {}).\n", row,
                              nRows_);
             return dummy;
         }
         if ((column < 0) || (column >= nColumns_))
         {
-            Messenger::print("OUT_OF_RANGE - Column number ({}) is out of range in Array2D::constAt() (nColumns = {}).\n",
+            Messenger::print("OUT_OF_RANGE - Column number ({}) is out of range in Array2D::at() (nColumns = {}).\n",
                              column, nColumns_);
             return dummy;
         }

--- a/src/templates/array2d.h
+++ b/src/templates/array2d.h
@@ -174,14 +174,13 @@ template <class A> class Array2D
         static A dummy;
         if ((row < 0) || (row >= nRows_))
         {
-            Messenger::print("OUT_OF_RANGE - Row number ({}) is out of range in Array2D::at() (nRows = {}).\n", row,
-                             nRows_);
+            Messenger::print("OUT_OF_RANGE - Row number ({}) is out of range in Array2D::at() (nRows = {}).\n", row, nRows_);
             return dummy;
         }
         if ((column < 0) || (column >= nColumns_))
         {
-            Messenger::print("OUT_OF_RANGE - Column number ({}) is out of range in Array2D::at() (nColumns = {}).\n",
-                             column, nColumns_);
+            Messenger::print("OUT_OF_RANGE - Column number ({}) is out of range in Array2D::at() (nColumns = {}).\n", column,
+                             nColumns_);
             return dummy;
         }
 #endif

--- a/src/templates/array3d.h
+++ b/src/templates/array3d.h
@@ -196,8 +196,8 @@ template <class A> class Array3D
         static A dummy;
         if ((index < 0) || (index >= array_.size()))
         {
-            Messenger::print("OUT_OF_RANGE - Index ({}) is out of range in Array3D::linearValue() (linearSize = {}).\n",
-                             index, array_.size());
+            Messenger::print("OUT_OF_RANGE - Index ({}) is out of range in Array3D::linearValue() (linearSize = {}).\n", index,
+                             array_.size());
             return dummy;
         }
 #endif

--- a/src/templates/array3d.h
+++ b/src/templates/array3d.h
@@ -116,17 +116,17 @@ template <class A> class Array3D
         static A dummy;
         if ((x < 0) || (x >= nX_))
         {
-            Messenger::print("OUT_OF_RANGE - X index ({}) is out of range in Array3D::constAt() (nX_ = {}).\n", x, nX_);
+            Messenger::print("OUT_OF_RANGE - X index ({}) is out of range in Array3D::at() (nX_ = {}).\n", x, nX_);
             return dummy;
         }
         if ((y < 0) || (y >= nY_))
         {
-            Messenger::print("OUT_OF_RANGE - Y index ({}) is out of range in Array3D::constAt() (nY_ = {}).\n", y, nY_);
+            Messenger::print("OUT_OF_RANGE - Y index ({}) is out of range in Array3D::at() (nY_ = {}).\n", y, nY_);
             return dummy;
         }
         if ((z < 0) || (z >= nZ_))
         {
-            Messenger::print("OUT_OF_RANGE - Z index ({}) is out of range in Array3D::constAt() (nZ_ = {}).\n", z, nZ_);
+            Messenger::print("OUT_OF_RANGE - Z index ({}) is out of range in Array3D::at() (nZ_ = {}).\n", z, nZ_);
             return dummy;
         }
 #endif
@@ -190,14 +190,13 @@ template <class A> class Array3D
 #endif
         return array_[index];
     }
-    // Return linear value (const)
     const A &linearValue(int index) const
     {
 #ifdef CHECKS
         static A dummy;
         if ((index < 0) || (index >= array_.size()))
         {
-            Messenger::print("OUT_OF_RANGE - Index ({}) is out of range in Array3D::constLinearValue() (linearSize = {}).\n",
+            Messenger::print("OUT_OF_RANGE - Index ({}) is out of range in Array3D::linearValue() (linearSize = {}).\n",
                              index, array_.size());
             return dummy;
         }
@@ -440,14 +439,13 @@ template <class A> class OffsetArray3D
 #endif
         return array_[index];
     }
-    // Return linear value (const)
-    const A &constLinearValue(int index) const
+    const A &linearValue(int index) const
     {
 #ifdef CHECKS
         static A dummy;
         if ((index < 0) || (index >= array_.size()))
         {
-            Messenger::print("OUT_OF_RANGE - Index ({}) is out of range in OffsetArray3D::constLinearValue() "
+            Messenger::print("OUT_OF_RANGE - Index ({}) is out of range in OffsetArray3D::linearValue() "
                              "(linearSize = {}).\n",
                              index, array_.size());
             return dummy;

--- a/src/templates/venum.h
+++ b/src/templates/venum.h
@@ -32,8 +32,7 @@ template <class V, class E> class Venum
     public:
     // Return value
     V &value() { return value_; }
-    // Return value (const)
-    const V &constValue() const { return value_; }
+    const V &value() const { return value_; }
     // Set value
     void setValue(V value) { value_ = value; }
 


### PR DESCRIPTION
This PR addresses renames many custom functions that are const-equivalents to other functions, but have distinct names.

### Summary

- Rename const equivalent functions to have the same name as their non-const equivalent, and let the compiler work it out.
- Fix / update some function comments.
- Fix some instances in the `DataND` classes where virtual functions were overloaded with functions having the wrong return type.
- Fix bug where the improper energy was not calculated for a species (in `EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Species *sp)`.
- Fixed an instance in `Data3D` where `version_` was not updated on access to a member variable.

Closes #408.
